### PR TITLE
Fix for shulker dispenser behaviour

### DIFF
--- a/src/main/java/carpet/mixins/BlockPlacementDispenserBehaviourMixin.java
+++ b/src/main/java/carpet/mixins/BlockPlacementDispenserBehaviourMixin.java
@@ -1,0 +1,21 @@
+package carpet.mixins;
+
+import carpet.CarpetSettings;
+import net.minecraft.block.dispenser.BlockPlacementDispenserBehavior;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(BlockPlacementDispenserBehavior.class)
+public class BlockPlacementDispenserBehaviourMixin
+{
+    @Redirect(method = "dispenseSilently", at = @At(value="INVOKE", target="Lnet/minecraft/item/ItemStack;decrement(I)V"))
+    private void cancleDoubleDecrement(ItemStack stack, int amount)
+    {
+        if (!CarpetSettings.b_stackableShulkerBoxes)
+        {
+            stack.decrement(amount);
+        }
+    }
+}

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -79,7 +79,9 @@
     "PistonBlock_movableTEMixin",
     "PistonBlockEntity_movableTEMixin",
     "World_movableTEMixin",
-    "WorldChunk_movableTEMixin"
+    "WorldChunk_movableTEMixin",
+
+    "BlockPlacementDispenserBehaviourMixin",
   ],
   "client": [
     "MinecraftClientMixin",


### PR DESCRIPTION
Fixes the behaviour of dispensers to remove 2 shulker boxes from a stack instead of 1

Basically the same as in 1.13.2