### PR TITLE
Add '/info chunk' that displays chunk loading info

### DIFF
--- a/src/main/java/carpet/commands/InfoCommand.java
+++ b/src/main/java/carpet/commands/InfoCommand.java
@@ -2,16 +2,19 @@ package carpet.commands;
 
 import carpet.settings.CarpetSettings;
 import carpet.utils.BlockInfo;
+import carpet.utils.ChunkInfo;
 import carpet.utils.EntityInfo;
 import carpet.utils.Messenger;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.command.arguments.ColumnPosArgumentType;
 import net.minecraft.text.BaseText;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.command.arguments.BlockPosArgumentType;
 import net.minecraft.command.arguments.EntityArgumentType;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ColumnPos;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -50,7 +53,12 @@ public class InfoCommand
                                                 executes( (c) -> infoEntities(
                                                         c.getSource(),
                                                         EntityArgumentType.getEntities(c,"entity selector"),
-                                                        getString(c, "regexp")))))));
+                                                        getString(c, "regexp"))))))).
+                then(literal("chunk").
+                        then(argument("column position", ColumnPosArgumentType.columnPos()).
+                        executes( (c) -> infoChunk(
+                                c.getSource(),
+                                ColumnPosArgumentType.getColumnPos(c, "column position")))));
 
         dispatcher.register(command);
     }
@@ -109,6 +117,11 @@ public class InfoCommand
         }
     }
 
+    public static void printChunk(List<BaseText> messages, ServerCommandSource source)
+    {
+        Messenger.send(source, messages);
+    }
+
 
 
     private static int infoEntities(ServerCommandSource source, Collection<? extends Entity> entities, String grep)
@@ -123,6 +136,11 @@ public class InfoCommand
     private static int infoBlock(ServerCommandSource source, BlockPos pos, String grep)
     {
         printBlock(BlockInfo.blockInfo(pos, source.getWorld()),source, grep);
+        return 1;
+    }
+    private static int infoChunk(ServerCommandSource source, ColumnPos pos)
+    {
+        printChunk(ChunkInfo.chunkInfo(pos, source.getWorld()), source);
         return 1;
     }
 

--- a/src/main/java/carpet/mixins/ChunkTicketManagerMixin.java
+++ b/src/main/java/carpet/mixins/ChunkTicketManagerMixin.java
@@ -1,0 +1,18 @@
+package carpet.mixins;
+
+import it.unimi.dsi.fastutil.objects.ObjectSortedSet;
+import net.minecraft.server.world.ChunkHolder;
+import net.minecraft.server.world.ChunkTicket;
+import net.minecraft.server.world.ChunkTicketManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(ChunkTicketManager.class)
+public interface ChunkTicketManagerMixin
+{
+    @Invoker("getTicketSet")
+    ObjectSortedSet<ChunkTicket<?>> invokeGetTicketSet(long pos);
+
+    @Invoker("getChunkHolder")
+    ChunkHolder invokeGetChunkHolder(long pos);
+}

--- a/src/main/java/carpet/mixins/ServerChunkManager_ticketManagerMixin.java
+++ b/src/main/java/carpet/mixins/ServerChunkManager_ticketManagerMixin.java
@@ -1,0 +1,13 @@
+package carpet.mixins;
+
+import net.minecraft.server.world.ChunkTicketManager;
+import net.minecraft.server.world.ServerChunkManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ServerChunkManager.class)
+public interface ServerChunkManager_ticketManagerMixin
+{
+    @Accessor("ticketManager")
+    ChunkTicketManager getTicketManager();
+}

--- a/src/main/java/carpet/utils/ChunkInfo.java
+++ b/src/main/java/carpet/utils/ChunkInfo.java
@@ -50,7 +50,7 @@ public class ChunkInfo
         {
             lst.add(Messenger.s(
                     String.format("- Chunk holder: level: %d, type: %s",
-                            chunkHolder.getLevel(), chunkHolder.getLevelType())));
+                            chunkHolder.getLevel(), ChunkHolder.getLevelType(chunkHolder.getLevel()))));
         }
 
         ObjectSortedSet<ChunkTicket<?>> ticketSet =

--- a/src/main/java/carpet/utils/ChunkInfo.java
+++ b/src/main/java/carpet/utils/ChunkInfo.java
@@ -1,0 +1,75 @@
+package carpet.utils;
+
+import carpet.mixins.ChunkTicketManagerMixin;
+import carpet.mixins.ServerChunkManager_ticketManagerMixin;
+import it.unimi.dsi.fastutil.objects.ObjectSortedSet;
+import net.minecraft.server.world.*;
+import net.minecraft.text.BaseText;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.ColumnPos;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.ChunkStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChunkInfo
+{
+    public static List<BaseText> chunkInfo(ColumnPos columnPos, ServerWorld world)
+    {
+        List<BaseText> lst = new ArrayList<>();
+
+        ChunkPos chunkPos = new ChunkPos(columnPos.x >> 4, columnPos.z >> 4);
+
+        lst.add(Messenger.s(""));
+        lst.add(Messenger.s("==============================="));
+        lst.add(Messenger.s(String.format("Input x=%d z=%d ==> chunk x=%d z=%d",
+                    columnPos.x, columnPos.z, chunkPos.x, chunkPos.z)));
+        lst.add(Messenger.s(String.format("Chunk info for chunk x=%d z=%d:", chunkPos.x, chunkPos.z)));
+
+        // Get chunk from the manager. Last parameter seems to be "throw exception if chunk is unloaded".
+        ServerChunkManager chunkManager = (ServerChunkManager) world.getChunkManager();
+        Chunk chunk = chunkManager.getChunk(chunkPos.x, chunkPos.z, ChunkStatus.FULL, false);
+
+        if (chunk == null)
+        {
+            lst.add(Messenger.s("- Chunk is not loaded"));
+            return lst;
+        }
+
+        lst.add(Messenger.s("- Chunk is loaded"));
+
+        ChunkTicketManager ticketManager = ((ServerChunkManager_ticketManagerMixin) chunkManager).getTicketManager();
+        ChunkHolder chunkHolder = ((ChunkTicketManagerMixin) ticketManager).invokeGetChunkHolder(chunkPos.toLong());
+
+        if (chunkHolder == null)
+        {
+            lst.add(Messenger.s("- Err: unexpected missing chunk holder"));
+        }
+        else
+        {
+            lst.add(Messenger.s(
+                    String.format("- Chunk holder: level: %d, type: %s",
+                            chunkHolder.getLevel(), chunkHolder.getLevelType())));
+        }
+
+        ObjectSortedSet<ChunkTicket<?>> ticketSet =
+                ((ChunkTicketManagerMixin) ticketManager).invokeGetTicketSet(chunkPos.toLong());
+
+        lst.add(Messenger.s("- Chunk tickets:"));
+        for (ChunkTicket<?> ticket : ticketSet)
+        {
+            // "Distance" is speculative - this is only used for teleport/random tickets anyway, so omit it if not set
+            long distance = ticket.getType().method_20629();
+            String distanceDescription = distance == 0L ? "" : String.format(", distance: '%d'", distance);
+
+            lst.add(Messenger.s(
+                    String.format("  * level: %d, type: '%s'%s",
+                            ticket.getLevel(),
+                            ticket.getType(),
+                            distanceDescription)));
+        }
+
+        return lst;
+    }
+}

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -21,7 +21,9 @@
     "World_tickMixin",
     "ServerWorld_tickMixin",
     "ServerChunkManager_tickMixin",
+    "ServerChunkManager_ticketManagerMixin",
     "ThreadedAnvilChunkStorage_tickMixin",
+    "ChunkTicketManagerMixin",
 
     "MobEntityMixin",
     "ServerWorld_unloadedEntityMixin",


### PR DESCRIPTION
The new command accepts a column position (like /forceload), displays
the associated x/z chunk coordinates, whether or not the chunk is
loaded, what level it's loaded at (and what 'type' of level that is),
and any chunk loading tickets attached to that chunk.

I've attached some screenshots showing example output. My test conditions
were:

- I was at (position) -5000 -5000
- There was a `/forceload` done on 1000 1000

Showing the 0,0 chunk and its special 'start' ticket (`/info chunk 0 0`):

![java_2019-07-27_13-15-10](https://user-images.githubusercontent.com/25137514/61998226-9e4b3500-b072-11e9-8d44-3519c16d8ea2.png)

One of the border chunks of spawn (`/info chunk 176 176`):

![java_2019-07-27_13-15-34](https://user-images.githubusercontent.com/25137514/61998233-adca7e00-b072-11e9-8469-781975cc9156.png)

The area near me, the player:

![java_2019-07-27_13-14-51](https://user-images.githubusercontent.com/25137514/61998245-caff4c80-b072-11e9-9b68-f4d579ce767d.png)

My forceloaded area:

![java_2019-07-27_13-15-49](https://user-images.githubusercontent.com/25137514/61998235-b6bb4f80-b072-11e9-95e0-cb91e91b2c18.png)

![java_2019-07-27_13-16-12](https://user-images.githubusercontent.com/25137514/61998238-bd49c700-b072-11e9-9a1a-e01064616a92.png)