### PR TITLE
make the nether portal delays better

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -50,11 +50,30 @@ public class CarpetSettings
     public static boolean superSecretSetting = false;
 
     @Rule(
-            desc = "Portals won't let a creative player go through instantly",
-            extra = "Holding obsidian in either hand won't let you through at all",
-            category = CREATIVE
+            desc = "Modify the amount of ticks for entering a Nether portal in creative",
+            options = {"1", "40", "80", "72000"},
+            category = CREATIVE,
+            strict = false,
+            validate = NetherPortalDelayLimit.class
     )
-    public static boolean portalCreativeDelay = false;
+    public static int portalCreativeDelay = 1;
+
+    @Rule(
+            desc = "Modify the amount of ticks for entering a Nether portal in survival",
+            options = {"1", "40", "80", "72000"},
+            category = SURVIVAL,
+            strict = false,
+            validate = NetherPortalDelayLimit.class
+    )
+    public static int portalSurvivalDelay = 80;
+
+    private static class NetherPortalDelayLimit extends Validator<Integer> {
+        @Override public Integer validate(ServerCommandSource source, ParsedRule<Integer> currentRule, Integer newValue, String string) {
+            return (newValue > 0 && newValue <= 72000) ? newValue : null;
+        }
+        @Override
+        public String description() { return "You must choose a value from 1 to 72000";}
+    }
 
     @Rule(desc = "Dropping entire stacks works also from on the crafting UI result slot", category = {BUGFIX, SURVIVAL})
     public static boolean ctrlQCraftingFix = false;

--- a/src/main/java/carpet/mixins/PlayerEntityMixin.java
+++ b/src/main/java/carpet/mixins/PlayerEntityMixin.java
@@ -5,13 +5,22 @@ import net.minecraft.entity.player.PlayerAbilities;
 import net.minecraft.entity.player.PlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(PlayerEntity.class)
 public abstract class PlayerEntityMixin {
     @Shadow
     public PlayerAbilities abilities;
 
-    public int getMaxNetherPortalTime() {
-        return this.abilities.invulnerable ? CarpetSettings.portalCreativeDelay : CarpetSettings.portalSurvivalDelay;
+    @Inject(
+        method = "getMaxNetherPortalTime()I",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    public void onMaxNetherPortalTime(CallbackInfoReturnable<Integer> cir) {
+        if(CarpetSettings.portalCreativeDelay != 1) cir.setReturnValue(CarpetSettings.portalCreativeDelay);
+        else if(CarpetSettings.portalSurvivalDelay != 80) cir.setReturnValue(CarpetSettings.portalSurvivalDelay);
     }
 }

--- a/src/main/java/carpet/mixins/PlayerEntityMixin.java
+++ b/src/main/java/carpet/mixins/PlayerEntityMixin.java
@@ -1,23 +1,17 @@
 package carpet.mixins;
 
 import carpet.CarpetSettings;
-import carpet.helpers.PortalHelper;
+import net.minecraft.entity.player.PlayerAbilities;
 import net.minecraft.entity.player.PlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.Constant;
-import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(PlayerEntity.class)
-public abstract class PlayerEntityMixin
-{
-    @ModifyConstant(method = "getMaxNetherPortalTime",
-            constant = @Constant(intValue = 1))
-    private int addFillUpdatesInt(int original) {
-        if (CarpetSettings.portalCreativeDelay)
-            if (PortalHelper.player_holds_obsidian((PlayerEntity) (Object)this))
-                return 72000;
-            else
-                return 80;
-        return original;
+public abstract class PlayerEntityMixin {
+    @Shadow
+    public PlayerAbilities abilities;
+
+    public int getMaxNetherPortalTime() {
+        return this.abilities.invulnerable ? CarpetSettings.portalCreativeDelay : CarpetSettings.portalSurvivalDelay;
     }
 }

--- a/src/main/java/carpet/mixins/PlayerEntityMixin.java
+++ b/src/main/java/carpet/mixins/PlayerEntityMixin.java
@@ -20,7 +20,7 @@ public abstract class PlayerEntityMixin {
         cancellable = true
     )
     public void onMaxNetherPortalTime(CallbackInfoReturnable<Integer> cir) {
-        if(CarpetSettings.portalCreativeDelay != 1) cir.setReturnValue(CarpetSettings.portalCreativeDelay);
+        if(CarpetSettings.portalCreativeDelay != 1 && this.abilities.invulnerable) cir.setReturnValue(CarpetSettings.portalCreativeDelay);
         else if(CarpetSettings.portalSurvivalDelay != 80) cir.setReturnValue(CarpetSettings.portalSurvivalDelay);
     }
 }

--- a/src/main/java/carpet/mixins/PlayerEntityMixin.java
+++ b/src/main/java/carpet/mixins/PlayerEntityMixin.java
@@ -21,6 +21,6 @@ public abstract class PlayerEntityMixin {
     )
     public void onMaxNetherPortalTime(CallbackInfoReturnable<Integer> cir) {
         if(CarpetSettings.portalCreativeDelay != 1 && this.abilities.invulnerable) cir.setReturnValue(CarpetSettings.portalCreativeDelay);
-        else if(CarpetSettings.portalSurvivalDelay != 80) cir.setReturnValue(CarpetSettings.portalSurvivalDelay);
+        else if(CarpetSettings.portalSurvivalDelay != 80 && !this.abilities.invulnerable) cir.setReturnValue(CarpetSettings.portalSurvivalDelay);
     }
 }


### PR DESCRIPTION
Fixes #139 and overwrites the default method of getMaxNetherPortalTime to something similar of the vanilla one but instead of returning constant numbers, it returns carpet rules.