### PR TITLE
Fix: typos in first half of ..\docs\scarpet\api

### DIFF
--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -28,7 +28,7 @@ apart you would want particles to appear, so `0.1` means one every 10cm.
 
 ### `particle_rect(name, pos, pos2, density?)`
 
-Renders a cuboid of particles between point `pos` to `pos2` with supplied density.
+Renders a cuboid of particles between points `pos` and `pos2` with supplied density.
 
 ## Markers
 
@@ -36,7 +36,7 @@ Renders a cuboid of particles between point `pos` to `pos2` with supplied densit
 
 Spawns a (permanent) marker entity with text or block at position. Returns that entity for further manipulations. 
 Unloading the app that spawned them will cause all the markers from the loaded portion of the world to be removed. 
-Also - if the game loads that marker in the future and the app is not loaded, it will be removed as well.
+Also, if the game loads that marker in the future and the app is not loaded, it will be removed as well.
 
 ### `remove_all_markers()`
 
@@ -124,7 +124,7 @@ Prints the message to system logs, and not to chat.
 Runs a vanilla command from the string result of the `expr` and returns its success count
 
 <pre>
-run('fill 1 1 1 10 10 10 air') -> 123 // 123 block were filled, this operation was successful 123 times out of a possible 1000 blocks volume
+run('fill 1 1 1 10 10 10 air') -> 123 // 123 block were filled, this operation was successful 123 times out of a possible 1000 block volume
 run('give @s stone 4') -> 1 // this operation was successful once
 </pre>
 
@@ -136,7 +136,7 @@ performance reasons and saves the world only on demand.
 ### `load_app_data(), load_app_data(file), load_app_data(file, shared?)`
 
 Loads the app data associated with the app from the world /scripts folder. Without argument returns the memory 
-managed and buffered / throttled NBT tag. With a file name - reads explicitly a file with that name from the 
+managed and buffered / throttled NBT tag. With a file name, reads explicitly a file with that name from the 
 scripts folder that belongs exclusively to the app. if `shared` is true, the file location is not exclusive
 to the app anymore, but located in a shared app space. 
 
@@ -235,7 +235,7 @@ Queries in-game statistics for certain values. Categories include:
 
 For the options of `entry`, consult your statistics page, or give it a guess.
 
-The call will return `null` if the statistics options are incorrect, or player didn't get these in their history. 
+The call will return `null` if the statistics options are incorrect, or player doesn't have them in their history. 
 If the player encountered the statistic, or game created for him empty one, it will return a number. 
 Scarpet will not affect the entries of the statistics, even if it is just creating empty ones. With `null` response 
-it could either mean your input is wrong, or statistic has effectively a value of `0`.
+it could either mean your input is wrong, or statistic effectively has a value of `0`.

--- a/docs/scarpet/api/BlockIterations.md
+++ b/docs/scarpet/api/BlockIterations.md
@@ -7,7 +7,7 @@ These functions help scan larger areas of blocks without using generic loop func
 Evaluates expression over area of blocks defined by its center `center = (cx, cy, cz)`, expanded in all directions 
 by `range = (dx, dy, dz)` blocks, or optionally in negative with `range` coords, and `upper_range` coords in 
 positive values.
-`center` can be defined either as a three coordinates, list of three coords, or block value.
+`center` can be defined either as three coordinates, a list of three coords, or a block value.
 `range` and `lower_range` can have the same representations, just if its a block, it computes the distance to the center
 as range instead of taking the values as is.
 `expr` receives `_x, _y, _z` as coords of current analyzed block and `_`, which represents the block itself.
@@ -20,7 +20,7 @@ return value. `break` return value has no effect.
 
 ### `volume(x1, y1, z1, x2, y2, z2, expr)`
 
-Evaluates expression for each block in the area, the same as the `scan`function, but using two opposite corners of 
+Evaluates expression for each block in the area, the same as the `scan` function, but using two opposite corners of 
 the rectangular cuboid. Any corners can be specified, its like you would do with `/fill` command.
 
 For return value and handling `break` and `continue` statements, see `scan` function above.
@@ -36,7 +36,7 @@ for(neighbours(x,y,z),air(_)) => 4 // number of air blocks around a block
 ### `rect(cx, cy, cz, dx?, dy?, dz?, px?, py?, pz?)`
 
 returns an iterator, just like `range` function that iterates over rectangular cubarea of blocks. If only center 
-point is specified, it iterates over 27 blocks. If `d` arguments are specified, expands selection of respective 
+point is specified, it iterates over 27 blocks. If `d` arguments are specified, expands selection by the  respective 
 number of blocks in each direction. If `p` arguments are specified, it uses `d` for negative offset, and `p` for positive.
 
 ### `diamond(cx, cy, cz, radius?, height?)`

--- a/docs/scarpet/api/BlocksAndWorldAccess.md
+++ b/docs/scarpet/api/BlocksAndWorldAccess.md
@@ -275,7 +275,7 @@ Boolean function, true if the block is solid.
 
 ### `air(pos)`
 
-Boolean function, true if a block is air, cave air, or void air, or any other air they come up with.
+Boolean function, true if a block is air... or cave air... or void air... or any other air they come up with.
 
 ### `liquid(pos)`
 

--- a/docs/scarpet/api/BlocksAndWorldAccess.md
+++ b/docs/scarpet/api/BlocksAndWorldAccess.md
@@ -70,8 +70,8 @@ set(x,y,z,'hopper[facing=north]{Items:[{Slot:1b,id:"minecraft:slime_ball",Count:
 
 Evaluates subexpression without causing updates when blocks change in the world
 
-Consider following scenario: We would like to generate a bunch of terrain in a flat world following a perling noise 
-generator. The following code causes cascading effect as blocks placed on chunk borders will cause other chunks to get 
+Consider following scenario: We would like to generate a bunch of terrain in a flat world following a perlin noise 
+generator. The following code causes a cascading effect as blocks placed on chunk borders will cause other chunks to get 
 loaded to full, thus generated:
 
 <pre>
@@ -85,7 +85,7 @@ __on_chunk_generated(x, z) -> (
 )
 </pre>
 
-The following addition resolves this issue, by not allowing block updates pass chunk borders:
+The following addition resolves this issue, by not allowing block updates past chunk borders:
 
 <pre>
 __config() -> m(l('scope', 'global'));
@@ -110,7 +110,7 @@ block, or 'up-north', which means a block placed facing up (player looking down)
 center towards north. Optional sneak is a boolean indicating if a player would be sneaking while placing the 
 block - this option only affects placement of chests and scaffolding at the moment. 
 
-Works with items that have the right-click effect on the block placed, `'like bone_meal`` on grass or axes on logs,
+Works with items that have the right-click effect on the block placed, like `bone_meal` on grass or axes on logs,
 but doesn't open chests / containers, so have no effect on interactive blocks, like TNT, comparators, etc.
 
 Returns true if placement/use was 
@@ -136,7 +136,7 @@ markers for scarpet apps. `meeting` is the only one with increased max occupancy
 
 ### `set_biome(pos, biome_name)`
 
-changes biome at that block position.
+Changes the biome at that block position.
 
 ### `update(pos)`
 
@@ -152,7 +152,7 @@ Causes a random tick at position.
 
 ### `destroy(pos), destroy(pos, -1), destroy(pos, <N>), destroy(pos, tool, nbt?)`
 
-Destroys the block like it was mined by a player. Add -1 for silk touch, and positive number for fortune level. 
+Destroys the block like it was mined by a player. Add -1 for silk touch, and a positive number for fortune level. 
 If tool is specified, and optionally its nbt, it will use that tool and will attempt to mine the block with this tool. 
 If called without item context, this function, unlike harvest, will affect all kinds of blocks. If called with item 
 in context, it will fail to break blocks that cannot be broken by a survival player.
@@ -168,28 +168,28 @@ for mining. Obviously, in this case the use of `harvest` would be much more appl
 <pre>
 mine(x,y,z) ->
 (
-   p = player();
-   slot = p~'selected_slot';
-   item_tuple = inventory_get(p, slot);
-   if (!item_tuple, destroy(x,y,z,'air'); return()); // empty hand, just break with 'air'
-   l(item, count, tag) = item_tuple;
-   tag_back = destroy(x,y,z, item, tag);
-   if (tag_back == false, // failed to break the item
-	     return(tag_back)
-   );
-   if (tag_back == true, // block broke, tool has no tag
-	     return(tag_back)
-   );
-   if (tag_back == null, //item broke
-	     delete(tag:'Damage');
-	     inventory_set(p, slot, count-1, item, tag);
-	     return(tag_back)
-   );
-   if (type(tag_back) == 'nbt', // item didn't break, here is the effective nbt
-	     inventory_set(p, slot, count, item, tag_back);
-	     return(tag_back)
-   );
-   print('How did we get here?');
+  p = player();
+  slot = p~'selected_slot';
+  item_tuple = inventory_get(p, slot);
+  if (!item_tuple, destroy(x,y,z,'air'); return()); // empty hand, just break with 'air'
+  l(item, count, tag) = item_tuple;
+  tag_back = destroy(x,y,z, item, tag);
+  if (tag_back == false, // failed to break the item
+    return(tag_back)
+  );
+  if (tag_back == true, // block broke, tool has no tag
+    return(tag_back)
+  );
+  if (tag_back == null, //item broke
+    delete(tag:'Damage');
+    inventory_set(p, slot, count-1, item, tag);
+    return(tag_back)
+  );
+  if (type(tag_back) == 'nbt', // item didn't break, here is the effective nbt
+    inventory_set(p, slot, count, item, tag_back);
+    return(tag_back)
+  );
+  print('How did we get here?');
 )
 </pre>
 
@@ -207,9 +207,9 @@ Returns a triple of coordinates of a specified block or entity. Technically enti
 and the same can be achieved with `query(entity,'pos')`, but for simplicity `pos` allows to pass all positional objects.
 
 <pre>
-pos(block(0,5,0))  => l(0,5,0)
+pos(block(0,5,0)) => l(0,5,0)
 pos(players()) => l(12.3, 45.6, 32.05)
-pos(block('stone'))  => Error: Cannot fetch position of an unrealized block
+pos(block('stone')) => Error: Cannot fetch position of an unrealized block
 </pre>
 
 ### `pos_offset(pos, direction, amount?)`
@@ -267,51 +267,51 @@ poi(x,y,z,5) => [['nether_portal',0,[7,8,9]],['nether_portal',0,[7,9,9]]] // two
 
 ### `biome(pos)`
 
-returns biome at that block position.
+Returns the biome at that block position.
 
 ### `solid(pos)`
 
-Boolean function, true if the block is solid
+Boolean function, true if the block is solid.
 
 ### `air(pos)`
 
-Boolean function, true if a block is air.... or cave air... or void air.... or any other air they come up with.
+Boolean function, true if a block is air, cave air, or void air, or any other air they come up with.
 
 ### `liquid(pos)`
 
-Boolean function, true if the block is liquid, or liquidlogged
+Boolean function, true if the block is liquid, or waterlogged (with any liquid).
 
 ### `flammable(pos)`
 
-Boolean function, true if the block is flammable
+Boolean function, true if the block is flammable.
 
 ### `transparent(pos)`
 
-Boolean function, true if the block is transparent
+Boolean function, true if the block is transparent.
 
 ### `opacity(pos)`
 
-Numeric, returning opacity level of a block
+Numeric function, returning the opacity level of a block.
 
 ### `blocks_daylight(pos)`
 
-Boolean function, true if the block blocks daylight
+Boolean function, true if the block blocks daylight.
 
 ### `emitted_light(pos)`
 
-Numeric, returning light level emitted from block
+Numeric function, returning the light level emitted from the block.
 
 ### `light(pos)`
 
-Integer function, returning total light level at position
+Numeric function, returning the total light level at position.
 
 ### `block_light(pos)`
 
-Integer function, returning block light at position. From torches and other light sources.
+Numeric function, returning the block light at position (from torches and other light sources).
 
 ### `sky_light(pos)`
 
-Numeric function, returning sky light at position. From the sky access.
+Numeric function, returning the sky light at position (from sky access).
 
 ### `see_sky(pos)`
 
@@ -359,7 +359,7 @@ Boolean function, true if the block ticks randomly.
 
 ### `blocks_movement(pos)`
 
-Boolean function, true if block at position blocks movement.
+Boolean function, true if the block at position blocks movement.
 
 ### `block_sound(pos)`
 
@@ -485,11 +485,11 @@ Returns the map colour of a block at position. One of:
 ### `loaded(pos)`
 
 Boolean function, true if the block is accessible for the game mechanics. Normally `scarpet` doesn't check if operates 
-on loaded area - the game will automatically load missing blocks. We see this as advantage. Vanilla `fill/clone` 
+on loaded area - the game will automatically load missing blocks. We see this as an advantage. Vanilla `fill/clone` 
 commands only check the specified corners for loadness.
 
-To check if block is truly loaded, I mean in memory, use `generation_status(x) != null`, as chunks can still be loaded 
-outside of the playable area, just are not used any of the game mechanics processes.
+To check if a block is truly loaded, I mean in memory, use `generation_status(x) != null`, as chunks can still be loaded 
+outside of the playable area, just are not used by any of the game mechanic processes.
 
 <pre>
 loaded(pos(players()))  => 1
@@ -504,7 +504,7 @@ Deprecated as of scarpet 1.6, use `loaded_status(x) > 0`, or just `loaded(x)` wi
 
 ### `loaded_status(pos)`
 
-Returns loaded status as per new 1.14 chunk ticket system, 0 for inaccessible, 1 for border chunk, 2 for ticking, 
+Returns loaded status as per new 1.14 chunk ticket system, 0 for inaccessible, 1 for border chunk, 2 for (non-entity) ticking, 
 3 for entity ticking
 
 ### `is_chunk_generated(pos)`, `is_chunk_generated(pos, force)`
@@ -539,10 +539,10 @@ Returns spawn potential at a location (1.16+ only)
 Checks wordgen eligibility for a structure in a given chunk. If no structure is given, or `null`, then it will check
  for all structures. If bounding box of the structures is also requested, it will compute size of potential
   structures. This function, unlike other in the `structure*` category is not using world data nor accesses chunks
-  making it preferred for scoping ungenerated terrain, but it takes some compute money to calculate the structure.
+  making it preferred for scoping ungenerated terrain, but it takes some compute power to calculate the structure.
   
   Unlike `'structure'` this will return a tentative structure location. Random factors in world generation may prevent
-  actual structure from forming.
+  the actual structure from forming.
   
 If structure is specified, it will return `null` if a chunk is not eligible, `true` if the structure should appear, or 
 a map with two values: `'box'` for a pair of coordinates indicating bounding box of the structure, and `'pieces'` for 
@@ -575,7 +575,7 @@ then to get its bounding boxes.
 
 Creates or removes structure information of a structure associated with a chunk of `pos`. Unlike `plop`, blocks are 
 not placed in the world, only structure information is set. For the game this is a fully functional structure even 
-if blocks are not set. To remove structure a given point is in, use `structure_references` to find where current 
+if blocks are not set. To remove the structure a given point is in, use `structure_references` to find where current 
 structure starts.
 
 ### `plop(pos, what)`

--- a/docs/scarpet/api/BlocksAndWorldAccess.md
+++ b/docs/scarpet/api/BlocksAndWorldAccess.md
@@ -539,7 +539,7 @@ Returns spawn potential at a location (1.16+ only)
 Checks wordgen eligibility for a structure in a given chunk. If no structure is given, or `null`, then it will check
  for all structures. If bounding box of the structures is also requested, it will compute size of potential
   structures. This function, unlike other in the `structure*` category is not using world data nor accesses chunks
-  making it preferred for scoping ungenerated terrain, but it takes some compute power to calculate the structure.
+  making it preferred for scoping ungenerated terrain, but it takes some compute resources to calculate the structure.
   
   Unlike `'structure'` this will return a tentative structure location. Random factors in world generation may prevent
   the actual structure from forming.

--- a/docs/scarpet/api/BlocksAndWorldAccess.md
+++ b/docs/scarpet/api/BlocksAndWorldAccess.md
@@ -504,7 +504,7 @@ Deprecated as of scarpet 1.6, use `loaded_status(x) > 0`, or just `loaded(x)` wi
 
 ### `loaded_status(pos)`
 
-Returns loaded status as per new 1.14 chunk ticket system, 0 for inaccessible, 1 for border chunk, 2 for (non-entity) ticking, 
+Returns loaded status as per new 1.14 chunk ticket system, 0 for inaccessible, 1 for border chunk, 2 for redstone ticking, 
 3 for entity ticking
 
 ### `is_chunk_generated(pos)`, `is_chunk_generated(pos, force)`

--- a/docs/scarpet/api/Entities.md
+++ b/docs/scarpet/api/Entities.md
@@ -3,23 +3,23 @@
 ## Entity Selection
 
 Entities have to be fetched before using them. Entities can also change their state between calls to the script if 
-game happens either in between separate calls to the programs, or if the program calls `game_tick` on its own. 
-In this case - entities would need to be re-fetched, or the code should account for entities getting dead.
+game ticks occur either in between separate calls to the programs, or if the program calls `game_tick` on its own. 
+In this case - entities would need to be re-fetched, or the code should account for entities dying.
 
 ### `player(), player(type), player(name)`
 
 With no arguments, it returns the calling player or the player closest to the caller. Note that the main context 
-will receive `p` variable pointing to this player. With `type` or `name` specified it will try first to match a type, 
+will receive `p` variable pointing to this player. With `type` or `name` specified, it will try first to match a type, 
 returning a list of players matching a type, and if this fails, will assume its player name query retuning player with 
 that name, or `null` if no player was found. With `'all'`, list of all players in the game, in all dimensions, so end 
 user needs to be cautious, that you might be referring to wrong blocks and entities around the player in question. 
 With `type = '*'` it returns all players in caller dimension, `'survival'` returns all survival and adventure players,
 `'creative'` returns all creative players, `'spectating'` returns all spectating players, and `'!spectating'`, 
-all not-spectating players. If all fails, with `name`, the player in question, if is logged in.
+all not-spectating players. If all fails, with `name`, the player in question, if he/she is logged in.
 
 ### `entity_id(uuid), entity_id(id)`
 
-Fetching entities wither by their ID obtained via `entity ~ 'id'`, which is unique for a dimension and current world 
+Fetching entities either by their ID obtained via `entity ~ 'id'`, which is unique for a dimension and current world 
 run, or by UUID, obtained via `entity ~ 'uuid'`. It returns null if no such entity is found. Safer way to 'store' 
 entities between calls, as missing entities will be returning `null`. Both calls using UUID or numerical ID are `O(1)`, 
 but obviously using UUIDs takes more memory and compute.
@@ -38,12 +38,12 @@ selectors are available:
 ### `entity_area(type, cx, cy, cz, dx, dy, dz)`
 
 Returns entities of a specified type in an area centered on `cx, cy, cz` and at most `dx, dy, dz` blocks away from 
-the center point. Uses same selectors as `entities_list`
+the center point. Uses the same selectors as `entities_list`.
 
 ### `entity_selector(selector)`
 
-Returns entities satisfying given vanilla entity selector. Most complex among all the methods of selecting entities, 
-but the most capable. Selectors are cached so should be as fast as other methods of selecting entities.
+Returns entities satisifying given vanilla entity selector. Most complex among all the methods of selecting entities, 
+but the most capable. Selectors are cached so it should be as fast as other methods of selecting entities.
 
 ### `spawn(name, pos, nbt?)`
 
@@ -53,12 +53,12 @@ you get the entity back as a return value, which is swell.
 
 ## Entity Manipulation
 
-Unlike with blocks, that use plethora of vastly different querying functions, entities are queried with `query` 
-function and altered via `modify` function. Type of information needed or values to be modified are different for 
+Unlike with blocks, that use a plethora of vastly different querying functions, entities are queried with the `query` 
+function and altered via the `modify` function. Type of information needed or values to be modified are different for 
 each call.
 
 Using `~` (in) operator is an alias for `query`. Especially useful if a statement has no arguments, 
-which in this case can be radically simplified
+which in this case can be radically simplified:
 
 <pre>
 query(p, 'name') <=> p ~ 'name'     // much shorter and cleaner
@@ -67,19 +67,19 @@ query(p, 'holds', 'offhand') <=> p ~ l('holds', 'offhand')    // not really but 
 
 ### `query(e,'removed')`
 
-Boolean. True if the entity is removed
+Boolean. True if the entity is removed.
 
 ### `query(e,'id')`
 
 Returns numerical id of the entity. Most efficient way to keep track of entites in a script. 
 Ids are only unique within current game session (ids are not preserved between restarts), 
-and dimension (each dimension has its own ids which can overlap.
+and dimension (each dimension has its own ids which can overlap).
 
 ### `query(e,'uuid')`
 
-Returns UUID (unique id) of the entity. Can be used to access entities with the other vanilla commands and 
+Returns the UUID (unique id) of the entity. Can be used to access entities with the other vanilla commands and 
 remains unique regardless of the dimension, and is preserved between game restarts. Apparently players cannot be 
-accessed via UUID, but name instead.
+accessed via UUID, but should be accessed with their name instead.
 
 <pre>
 map(entities_area('*',x,y,z,30,30,30),run('kill '+query(_,'id'))) // doesn't kill the player
@@ -87,15 +87,15 @@ map(entities_area('*',x,y,z,30,30,30),run('kill '+query(_,'id'))) // doesn't kil
 
 ### `query(e,'pos')`
 
-Triple of entity position
+Triple of the entity's position
 
 ### `query(e,'location')`
 
-Quin-tuple of entity position (x, y, and z coords), and rotation (yaw, pitch)
+Quin-tuple of the entity's position (x, y, and z coords), and rotation (yaw, pitch)
 
 ### `query(e,'x'), query(e,'y'), query(e,'z')`
 
-Respective entity coordinate
+Respective component of entity's coordinates
 
 ### `query(e,'pitch'), query(e,'yaw')`
 
@@ -107,11 +107,11 @@ Returns a 3d vector where the entity is looking.
 
 ### `query(e,'motion')`
 
-Triple of entity motion vector, `l(motion_x, motion_y, motion_z)`
+Triple of entity's motion vector, `l(motion_x, motion_y, motion_z)`
 
 ### `query(e,'motion_x'), query(e,'motion_y'), query(e,'motion_z')`
 
-Respective component of the motion vector
+Respective component of the entity's motion vector
 
 ### `query(e,'name'), query(e,'display_name'), query(e,'custom_name'), query(e,'type')`
 
@@ -134,11 +134,11 @@ run('/kill ' + e~'command_name');
 
 ### `query(e,'is_riding')`
 
-Boolean. True if riding another entity.
+Boolean, true if the entity is riding another entity.
 
 ### `query(e,'is_ridden')`
 
-Boolean. True if another entity is riding it.
+Boolean, true if another entity is riding it.
 
 ### `query(e,'passengers')`
 
@@ -150,15 +150,15 @@ Entity that `e` rides.
 
 ### `query(e,'tags')`
 
-List of entity tags.
+List of entity's tags.
 
 ### `query(e,'has_tag',tag)`
 
-Boolean, True if the entity is marked with `tag`.
+Boolean, true if the entity is marked with `tag`.
 
 ### `query(e,'is_burning')`
 
-Boolean, True if the entity is burning.
+Boolean, true if the entity is burning.
 
 ### `query(e,'fire')`
 
@@ -166,43 +166,43 @@ Number of remaining ticks of being on fire.
 
 ### `query(e,'silent')`
 
-Boolean, True if the entity is silent.
+Boolean, true if the entity is silent.
 
 ### `query(e,'gravity')`
 
-Boolean, True if the entity is affected by gravity, like most entities do.
+Boolean, true if the entity is affected by gravity, like most entities are.
 
 ### `query(e,'immune_to_fire')`
 
-Boolean, True if the entity is immune to fire.
+Boolean, true if the entity is immune to fire.
 
 ### `query(e,'dimension')`
 
-Name of the dimension entity is in.
+Name of the dimension the entity is in.
 
 ### `query(e,'height')`
 
-Height of the entity.
+Height of the entity in blocks.
 
 ### `query(e,'width')`
 
-Width of the entity.
+Width of the entity in blocks.
 
 ### `query(e,'eye_height')`
 
-Eye height of the entity.
+Eye height of the entity in blocks.
 
 ### `query(e,'age')`
 
-Age, in ticks, of the entity, i.e. how long it existed.
+Age of the entity in ticks, i.e. how long it existed.
 
 ### `query(e,'breeding_age')`
 
-Breeding age of passive entity, in ticks. If negative it it time to adulthood, if positive, breeding cooldown
+Breeding age of passive entity, in ticks. If negative, time to adulthood, if positive, breeding cooldown
 
 ### `query(e,'despawn_timer')`
 
-For living entities - the number of ticks they fall outside of immediate player presence.
+For living entities, the number of ticks they fall outside of immediate player presence.
 
 ### `query(e,'item')`
 
@@ -241,19 +241,19 @@ Returns a pose of an entity, one of the following options
 
 ### `query(e,'sneaking')`
 
-Boolean, true if entity is sneaking.
+Boolean, true if the entity is sneaking.
 
 ### `query(e,'sprinting')`
 
-Boolean, true if entity is sprinting.
+Boolean, true if the entity is sprinting.
 
 ### `query(e,'swimming')`
 
-Boolean, true if entity is swimming.
+Boolean, true if the entity is swimming.
 
 ### `query(e,'jumping')`
 
-Boolean, true if entity is jumping.
+Boolean, true if the entity is jumping.
 
 ### `query(e,'gamemode')`
 
@@ -293,7 +293,7 @@ Player's permission level, or `null` if not applicable for this entity.
 ### `query(e,'effect',name?)`
 
 Without extra arguments, it returns list of effect active on a living entity. Each entry is a triple of short 
-effect name, amplifier, and remaining duration. With an argument, if the living entity has not that potion active, 
+effect name, amplifier, and remaining duration in ticks. With an argument, if the living entity has not that potion active, 
 returns `null`, otherwise return a tuple of amplifier and remaining duration.
 
 <pre>
@@ -308,7 +308,7 @@ Number indicating remaining entity health, or `null` if not applicable.
 
 ### `query(e,'holds',slot?)`
 
-Returns triple of short name, stack count, and NBT of item held in `slot`. Available options for `slot` are:
+Returns triple of short name, stack count, and NBT of item held in `slot`, or `null` if nothing or not applicable. Available options for `slot` are:
 
 *   `mainhand`
 *   `offhand`
@@ -321,7 +321,7 @@ If `slot` is not specified, it defaults to the main hand.
 
 ### `query(e,'selected_slot')`
 
-Number indicating the selected slot of entity inventory. Currently only applicable to players.
+Number indicating the selected slot of entity's inventory. Currently only applicable to players.
 
 ### `query(e,'facing', order?)`
 
@@ -342,7 +342,7 @@ entity, and block value if block is in reach.
 
 ### `query(e,'nbt',path?)`
 
-Returns full NBT of the entity. If path is specified, it fetches only that portion of the NBT, that corresponds to the 
+Returns full NBT of the entity. If path is specified, it fetches only the portion of the NBT that corresponds to the 
 path. For specification of `path` attribute, consult vanilla `/data get entity` command.
 
 Note that calls to `nbt` are considerably more expensive comparing to other calls in Minecraft API, and should only 
@@ -354,7 +354,7 @@ type objects via `get, put, has, delete`, so try to use API calls first for that
 Like with entity querying, entity modifications happen through one function. Most position and movements modifications 
 don't work currently on players as their position is controlled by clients.
 
-Currently there is no ability to modify NBT directly, but you could always use `run('data modify entity`
+Currently there is no ability to modify NBT directly, but you could always use `run('data modify entity ...')`
 
 ### `modify(e,'remove')`
 
@@ -374,7 +374,7 @@ Changes full location vector all at once.
 
 ### `modify(e, 'x', x), modify(e, 'y', y), modify(e, 'z', z)`
 
-Moves the entity in.... one direction.
+Moves the entity in one direction.
 
 ### `modify(e, 'pitch', pitch), modify(e, 'yaw', yaw)`
 
@@ -429,11 +429,11 @@ Mounts on all listed entities on `e`.
 
 ### `modify(e, 'tag', tag, ? ...), modify(e, 'tag', l(tags) )`
 
-Adds tag / tags to the entity.
+Adds tag(s) to the entity.
 
 ### `modify(e, 'clear_tag', tag, ? ...), modify(e, 'clear_tag', l(tags) )`
 
-Removes tag from entity.
+Removes tag(s) from the entity.
 
 ### `modify(e, 'talk')`
 
@@ -446,12 +446,12 @@ If called with `false` value, it will disable AI in the mob. `true` will enable 
 ### `modify(e, 'no_clip', boolean)`
 
 Sets if the entity obeys any collisions, including collisions with the terrain and basic physics. Not affecting 
-players, since they are controlled client side
+players, since they are controlled client side.
 
 ### `modify(e, 'effect', name, duration?, amplifier?, show_particles?, show_icon?)`
 
 Applies status effect to the living entity. Takes several optional parameters, which default to `0`, `true` 
-and `true`. If no duration is specified, or it is null or 0, the effect is removed.
+and `true`. If no duration is specified, or if it's null or 0, the effect is removed.
 
 ### `modify(e, 'home', null), modify(e, 'home', block, distance?), modify(e, 'home', x, y, z, distance?)`
 
@@ -481,11 +481,15 @@ Will make the entity jump once.
 
 ### `modify(e, 'silent', true/false)`
 
+Silences or unsilences the entity.
+
 ### `modify(e, 'gravity', true/false)`
+
+Toggles gravity for the entity.
 
 ### `modify(e, 'fire', ticks)`
 
-Will set mob on fire for `ticks` ticks. Set to 0 to extinguish.
+Will set entity on fire for `ticks` ticks. Set to 0 to extinguish.
 
 ## Entity Events
 
@@ -497,19 +501,19 @@ defining the callback with `entity_event`
 
 The following events can be handled by entities.
 
-*   `'on_tick'`: executes every tick right before entity is ticked in the game. Required arguments: `entity`
+*   `'on_tick'`: executes every tick right before the entity is ticked in the game. Required arguments: `entity`
 *   `'on_death'`: executes once when a living entity dies. Required arguments: `entity, reason`
 *   `'on_removed'`: execute once when an entity is removed. Required arguments: `entity`
 *   `'on_damaged'`: executed every time a living entity is about to receive damage. 
 Required arguments: `entity, amount, source, attacking_entity`
 
 It doesn't mean that all entity types will have a chance to execute a given event, but entities will not error 
-when you will attach inapplicable event to it.
+when you attach inapplicable event to it.
 
 ### `entity_event(e, event, call_name, args...)`
 
-Attaches specific function from the current package to be called upon the `event`, with extra `args` curried to the 
-original required arguments for the event handler
+Attaches specific function from the current package to be called upon the `event`, with extra `args` carried to the 
+original required arguments for the event handler.
 
 <pre>
 protect_villager(entity, amount, source, source_entity, healing_player) ->

--- a/docs/scarpet/api/Entities.md
+++ b/docs/scarpet/api/Entities.md
@@ -65,17 +65,17 @@ query(p, 'name') <=> p ~ 'name'     // much shorter and cleaner
 query(p, 'holds', 'offhand') <=> p ~ l('holds', 'offhand')    // not really but can be done
 </pre>
 
-### `query(e,'removed')`
+### `query(e, 'removed')`
 
 Boolean. True if the entity is removed.
 
-### `query(e,'id')`
+### `query(e, 'id')`
 
 Returns numerical id of the entity. Most efficient way to keep track of entites in a script. 
 Ids are only unique within current game session (ids are not preserved between restarts), 
 and dimension (each dimension has its own ids which can overlap).
 
-### `query(e,'uuid')`
+### `query(e, 'uuid')`
 
 Returns the UUID (unique id) of the entity. Can be used to access entities with the other vanilla commands and 
 remains unique regardless of the dimension, and is preserved between game restarts. Apparently players cannot be 
@@ -85,35 +85,35 @@ accessed via UUID, but should be accessed with their name instead.
 map(entities_area('*',x,y,z,30,30,30),run('kill '+query(_,'id'))) // doesn't kill the player
 </pre>
 
-### `query(e,'pos')`
+### `query(e, 'pos')`
 
 Triple of the entity's position
 
-### `query(e,'location')`
+### `query(e, 'location')`
 
 Quin-tuple of the entity's position (x, y, and z coords), and rotation (yaw, pitch)
 
-### `query(e,'x'), query(e,'y'), query(e,'z')`
+### `query(e, 'x'), query(e, 'y'), query(e, 'z')`
 
 Respective component of entity's coordinates
 
-### `query(e,'pitch'), query(e,'yaw')`
+### `query(e, 'pitch'), query(e, 'yaw')`
 
 Pitch and Yaw or where entity is looking.
 
-### `query(e,'look')`
+### `query(e, 'look')`
 
 Returns a 3d vector where the entity is looking.
 
-### `query(e,'motion')`
+### `query(e, 'motion')`
 
 Triple of entity's motion vector, `l(motion_x, motion_y, motion_z)`
 
-### `query(e,'motion_x'), query(e,'motion_y'), query(e,'motion_z')`
+### `query(e, 'motion_x'), query(e, 'motion_y'), query(e, 'motion_z')`
 
 Respective component of the entity's motion vector
 
-### `query(e,'name'), query(e,'display_name'), query(e,'custom_name'), query(e,'type')`
+### `query(e, 'name'), query(e, 'display_name'), query(e, 'custom_name'), query(e, 'type')`
 
 String of entity name
 
@@ -132,99 +132,99 @@ player, where its their name.
 run('/kill ' + e~'command_name');
 </pre>
 
-### `query(e,'is_riding')`
+### `query(e, 'is_riding')`
 
 Boolean, true if the entity is riding another entity.
 
-### `query(e,'is_ridden')`
+### `query(e, 'is_ridden')`
 
 Boolean, true if another entity is riding it.
 
-### `query(e,'passengers')`
+### `query(e, 'passengers')`
 
 List of entities riding the entity.
 
-### `query(e,'mount')`
+### `query(e, 'mount')`
 
 Entity that `e` rides.
 
-### `query(e,'tags')`
+### `query(e, 'tags')`
 
 List of entity's tags.
 
-### `query(e,'has_tag',tag)`
+### `query(e, 'has_tag',tag)`
 
 Boolean, true if the entity is marked with `tag`.
 
-### `query(e,'is_burning')`
+### `query(e, 'is_burning')`
 
 Boolean, true if the entity is burning.
 
-### `query(e,'fire')`
+### `query(e, 'fire')`
 
 Number of remaining ticks of being on fire.
 
-### `query(e,'silent')`
+### `query(e, 'silent')`
 
 Boolean, true if the entity is silent.
 
-### `query(e,'gravity')`
+### `query(e, 'gravity')`
 
 Boolean, true if the entity is affected by gravity, like most entities are.
 
-### `query(e,'immune_to_fire')`
+### `query(e, 'immune_to_fire')`
 
 Boolean, true if the entity is immune to fire.
 
-### `query(e,'dimension')`
+### `query(e, 'dimension')`
 
 Name of the dimension the entity is in.
 
-### `query(e,'height')`
+### `query(e, 'height')`
 
 Height of the entity in blocks.
 
-### `query(e,'width')`
+### `query(e, 'width')`
 
 Width of the entity in blocks.
 
-### `query(e,'eye_height')`
+### `query(e, 'eye_height')`
 
 Eye height of the entity in blocks.
 
-### `query(e,'age')`
+### `query(e, 'age')`
 
 Age of the entity in ticks, i.e. how long it existed.
 
-### `query(e,'breeding_age')`
+### `query(e, 'breeding_age')`
 
 Breeding age of passive entity, in ticks. If negative, time to adulthood, if positive, breeding cooldown
 
-### `query(e,'despawn_timer')`
+### `query(e, 'despawn_timer')`
 
 For living entities, the number of ticks they fall outside of immediate player presence.
 
-### `query(e,'item')`
+### `query(e, 'item')`
 
 The item triple (name, count, nbt) if its an item entity, `null` otherwise
 
-### `query(e,'count')`
+### `query(e, 'count')`
 
 Number of items in a stack from item entity, `null` otherwise
 
-### `query(e,'pickup_delay')`
+### `query(e, 'pickup_delay')`
 
 Retrieves pickup delay timeout for an item entity, `null` otherwise
 
-### `query(e,'is_baby')`
+### `query(e, 'is_baby')`
 
 Boolean, true if its a baby.
 
-### `query(e,'target')`
+### `query(e, 'target')`
 
 Returns mob's attack target or null if none or not applicable.
 
-### `query(e,'home')`
+### `query(e, 'home')`
 
 Returns creature's home position or null if none or not applicable.
 
@@ -239,31 +239,31 @@ Returns a pose of an entity, one of the following options
  * `'crouching'`
  * `'dying'`
 
-### `query(e,'sneaking')`
+### `query(e, 'sneaking')`
 
 Boolean, true if the entity is sneaking.
 
-### `query(e,'sprinting')`
+### `query(e, 'sprinting')`
 
 Boolean, true if the entity is sprinting.
 
-### `query(e,'swimming')`
+### `query(e, 'swimming')`
 
 Boolean, true if the entity is swimming.
 
-### `query(e,'jumping')`
+### `query(e, 'jumping')`
 
 Boolean, true if the entity is jumping.
 
-### `query(e,'gamemode')`
+### `query(e, 'gamemode')`
 
 String with gamemode, or `null` if not a player.
 
-### `query(e,'gamemode_id')`
+### `query(e, 'gamemode_id')`
 
 Good'ol gamemode id, or null if not a player.
 
-### `query(e,'player_type')`
+### `query(e, 'player_type')`
 
 Returns `null` if the argument is not a player, otherwise:
 
@@ -282,15 +282,15 @@ Returns a lowercase string containing the category of the entity (hostile, passi
 
 Team name for entity, or `null` if no team is assigned.
 
-### `query(e,'ping')`
+### `query(e, 'ping')`
     
 Player's ping in milliseconds, or `null` if its not a player.
 
-### `query(e,'permission_level')`
+### `query(e, 'permission_level')`
 
 Player's permission level, or `null` if not applicable for this entity.
 
-### `query(e,'effect',name?)`
+### `query(e, 'effect', name?)`
 
 Without extra arguments, it returns list of effect active on a living entity. Each entry is a triple of short 
 effect name, amplifier, and remaining duration in ticks. With an argument, if the living entity has not that potion active, 
@@ -302,11 +302,11 @@ query(p,'effect','haste')  => [0, 177]
 query(p,'effect','resistance')  => null
 </pre>
 
-### `query(e,'health')`
+### `query(e, 'health')`
 
 Number indicating remaining entity health, or `null` if not applicable.
 
-### `query(e,'holds',slot?)`
+### `query(e, 'holds', slot?)`
 
 Returns triple of short name, stack count, and NBT of item held in `slot`, or `null` if nothing or not applicable. Available options for `slot` are:
 
@@ -319,16 +319,16 @@ Returns triple of short name, stack count, and NBT of item held in `slot`, or `n
 
 If `slot` is not specified, it defaults to the main hand.
 
-### `query(e,'selected_slot')`
+### `query(e, 'selected_slot')`
 
 Number indicating the selected slot of entity's inventory. Currently only applicable to players.
 
-### `query(e,'facing', order?)`
+### `query(e, 'facing', order?)`
 
 Returns where the entity is facing. optional order (number from 0 to 5, and negative), indicating primary directions 
 where entity is looking at. From most prominent (order 0) to opposite (order 5, or -1)
 
-### `query(e,'trace', reach?, options?...)`
+### `query(e, 'trace', reach?, options?...)`
 
 Returns the result of ray tracing from entity perspective, indicating what it is looking at. Default reach is 4.5 
 blocks (5 for creative players), and by default it traces for blocks and entities, identical to player attack tracing 
@@ -340,7 +340,7 @@ entities and blocks, blocks will take over the priority even if transparent or n
 Regardless of the options selected, the result could be `null` if nothing is in reach, entity, if look targets an
 entity, and block value if block is in reach.
 
-### `query(e,'nbt',path?)`
+### `query(e, 'nbt', path?)`
 
 Returns full NBT of the entity. If path is specified, it fetches only the portion of the NBT that corresponds to the 
 path. For specification of `path` attribute, consult vanilla `/data get entity` command.
@@ -356,11 +356,11 @@ don't work currently on players as their position is controlled by clients.
 
 Currently there is no ability to modify NBT directly, but you could always use `run('data modify entity ...')`
 
-### `modify(e,'remove')`
+### `modify(e, 'remove')`
 
 Removes (not kills) entity from the game.
 
-### `modify(e,'kill')`
+### `modify(e, 'kill')`
 
 Kills the entity.
 
@@ -396,7 +396,9 @@ Sets the corresponding component of the motion vector.
 
 Adds a vector to the motion vector. Most realistic way to apply a force to an entity.
 
-### `modify(e, 'custom_name'), modify(e, 'custom_name', name )`
+### `modify(e, 'custom_name'), modify(e, 'custom_name', name)`
+
+Sets the custom name of the entity.
 
 ### `modify(e, 'age', number)`
 
@@ -405,7 +407,11 @@ entities, so use it with caution.
 
 ### `modify(e, 'pickup_delay', number)`
 
+Sets the pickup delay for the item entity.
+
 ### `modify(e, 'breeding_age', number)`
+
+Sets the breeding age for the animal.
 
 ### `modify(e, 'despawn_timer', number)`
 
@@ -458,7 +464,7 @@ and `true`. If no duration is specified, or if it's null or 0, the effect is rem
 Sets AI to stay around the home position, within `distance` blocks from it. `distance` defaults to 16 blocks. 
 `null` removes it. _May_ not work fully with mobs that have this AI built in, like Villagers.
 
-### `modify(e, 'gamemode', gamemode?), modify(e, 'gamemode',gamemode_id?)`
+### `modify(e, 'gamemode', gamemode?), modify(e, 'gamemode', gamemode_id?)`
 
 Modifies gamemode of player to whatever string (case-insensitive) or number you put in.
 
@@ -467,7 +473,7 @@ Modifies gamemode of player to whatever string (case-insensitive) or number you 
 * 2: adventure
 * 3: spectator
 
-### `modify(e, 'jumping', true/false)`
+### `modify(e, 'jumping', boolean)`
 
 Will make the entity constantly jump if set to true, and will stop the entity from jumping if set to false.
 Note that jumping parameter can be fully controlled by the entity AI, so don't expect that this will have 
@@ -479,11 +485,11 @@ Requires a living entity as an argument.
 
 Will make the entity jump once.
 
-### `modify(e, 'silent', true/false)`
+### `modify(e, 'silent', boolean)`
 
 Silences or unsilences the entity.
 
-### `modify(e, 'gravity', true/false)`
+### `modify(e, 'gravity', boolean)`
 
 Toggles gravity for the entity.
 


### PR DESCRIPTION
In the first half of ..\docs\scarpet\api, I have fixed many grammer, spelling, and consistency issues, as well as clarified some things that lacked explanation.

Let me know if there's anything that I can do to improve my contribution here.