### PR TITLE
Corrected killed_by description

### DIFF
--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -392,7 +392,7 @@ Queries in-game statistics for certain values. Categories include:
 *   `picked_up`: items picked up
 *   `dropped`: items dropped
 *   `killed`: mobs killed
-*   `killed_by`: blocks mined
+*   `killed_by`: mobs killed by
 *   `custom`: various random stats
 
 For the options of `entry`, consult your statistics page, or give it a guess.


### PR DESCRIPTION
I think that is a correct description. Feel free to change it if you think there is a better way.