### PR TITLE
Add the rule bruteSpawningInBationRemnants

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -214,6 +214,9 @@ public class CarpetSettings
     @Rule( desc = "Shulkers will respawn in end cities", category = FEATURE )
     public static boolean shulkerSpawningInEndCities = false;
 
+    @Rule( desc = "Piglin brutes will respawn in bastion remnants", category = FEATURE )
+    public static boolean bruteSpawningInBastionRemnants = false;
+
     @Rule(desc = "Entities pushed or moved into unloaded chunks no longer disappear", category = {EXPERIMENTAL, BUGFIX})
     public static boolean unloadedEntityFix = false;
 

--- a/src/main/java/carpet/mixins/BastionRemnantFeatureMixin.java
+++ b/src/main/java/carpet/mixins/BastionRemnantFeatureMixin.java
@@ -1,0 +1,34 @@
+package carpet.mixins;
+
+import carpet.CarpetSettings;
+
+import com.google.common.collect.Lists;
+import com.mojang.serialization.Codec;
+import net.minecraft.entity.EntityType;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.feature.BastionRemnantFeature;
+import net.minecraft.world.gen.feature.BastionRemnantFeatureConfig;
+import net.minecraft.world.gen.feature.StructureFeature;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import java.util.Collections;
+import java.util.List;
+
+@Mixin(BastionRemnantFeature.class)
+public abstract class BastionRemnantFeatureMixin extends StructureFeature<BastionRemnantFeatureConfig> {
+
+    private static final List<Biome.SpawnEntry> spawnList = Lists.newArrayList(new Biome.SpawnEntry(EntityType.PIGLIN_BRUTE, 5, 1, 2), new Biome.SpawnEntry(EntityType.PIGLIN, 10, 2, 4));
+
+    public BastionRemnantFeatureMixin(Codec<BastionRemnantFeatureConfig> codec) {
+        super(codec);
+    }
+
+    @Override
+    public List<Biome.SpawnEntry> getMonsterSpawns()
+    {
+        if (CarpetSettings.bruteSpawningInBastionRemnants)
+            return spawnList;
+        return Collections.emptyList();
+    }
+}

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -136,6 +136,7 @@
     "EntityNavigation_pathfindingMixin",
 
     "EndCityFeatureMixin",
+    "BastionRemnantFeatureMixin",
 
     "InfestedBlockMixin",
     "PlayerEntityMixin_portalDelayMixin",


### PR DESCRIPTION
The way this setup would work: 
    piglin brutes: weight : 5, minimum group size: 1, maximum group size: 2
    piglins : weight : 10, minimum group size: 2, maximum group size: 4

This is currently not very helpful as the piglin brute doesn't drop much experience and doesn't drop interesting loot, however this is likely to change in a future version given the difficulty that the mob presents. 

Please let me know of any issues with this and I will try to fix quickly.