### PR TITLE
Allow "/player look" to target locations in the world with "/player look at"

### DIFF
--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -73,6 +73,7 @@ public class PlayerCommand
                                 .then(literal("west").executes(manipulation(ap -> ap.look(Direction.WEST))))
                                 .then(literal("up").executes(manipulation(ap -> ap.look(Direction.UP))))
                                 .then(literal("down").executes(manipulation(ap -> ap.look(Direction.DOWN))))
+                                .then(literal("at").then(argument("position", Vec3ArgumentType.vec3()).executes(PlayerCommand::lookAt)))
                                 .then(argument("direction", RotationArgumentType.rotation())
                                         .executes(c -> manipulate(c, ap -> ap.look(RotationArgumentType.getRotation(c, "direction").toAbsoluteRotation(c.getSource())))))
                         ).then(literal("turn")
@@ -202,6 +203,15 @@ public class PlayerCommand
         if (cantReMove(context)) return 0;
         getPlayer(context).kill();
         return 1;
+    }
+
+    private static int lookAt(CommandContext<ServerCommandSource> context)
+    {
+        return manipulate(context, ap -> {
+            try {
+                ap.lookAt(Vec3ArgumentType.getVec3(context, "position"));
+            } catch (CommandSyntaxException ignored) {}
+        });
     }
 
     @FunctionalInterface

--- a/src/main/java/carpet/helpers/EntityPlayerActionPack.java
+++ b/src/main/java/carpet/helpers/EntityPlayerActionPack.java
@@ -2,6 +2,7 @@ package carpet.helpers;
 
 import carpet.fakes.ServerPlayerEntityInterface;
 import net.minecraft.block.BlockState;
+import net.minecraft.command.arguments.EntityAnchorArgumentType;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.passive.HorseBaseEntity;
 import net.minecraft.entity.player.PlayerInventory;
@@ -124,6 +125,12 @@ public class EntityPlayerActionPack
         player.yaw = yaw % 360;
         player.pitch = MathHelper.clamp(pitch, -90, 90);
         // maybe player.setPositionAndAngles(player.x, player.y, player.z, yaw, MathHelper.clamp(pitch,-90.0F, 90.0F));
+        return this;
+    }
+
+    public EntityPlayerActionPack lookAt(Vec3d position)
+    {
+        player.lookAt(EntityAnchorArgumentType.EntityAnchor.EYES, position);
         return this;
     }
 


### PR DESCRIPTION
Hi. This pull request adds the ability for fake players to look at a location in the world with `/player <name> look at <x> <y> <z>` as an alternative to supplying cardinal directions or angles. This is useful if you ever want to have a fake player do something that requires precise aim like activating a button.

Here's a quick demo of the change in action: https://youtu.be/njLHSUuTt44