### PR TITLE
Add rule to make phantoms respect the Hostile MobCap when spawning

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -268,6 +268,9 @@ public class CarpetSettings
     @Rule( desc = "Silverfish drop a gravel item when breaking out of a block", category = FEATURE )
     public static boolean silverFishDropGravel = false;
 
+    @Rule( desc = "Phantoms will not spawn when the hostile mobcap is full.", category = {FEATURE, SURVIVAL} )
+    public static boolean phantomsRespectMobCap = false;
+
     @Rule( desc = "summoning a lightning bolt has all the side effects of natural lightning", category = CREATIVE )
     public static boolean summonNaturalLightning = false;
 

--- a/src/main/java/carpet/mixins/PhantomEntityMixin.java
+++ b/src/main/java/carpet/mixins/PhantomEntityMixin.java
@@ -1,0 +1,28 @@
+package carpet.mixins;
+
+import carpet.CarpetSettings;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.SpawnGroup;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.SpawnHelper;
+import net.minecraft.world.gen.PhantomSpawner;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PhantomSpawner.class)
+public class PhantomEntityMixin {
+    @Inject(method = "spawn", at = @At("HEAD"), cancellable = true)
+    public void checkMobCap(ServerWorld serverWorld, boolean spawnMonsters, boolean spawnAnimals, CallbackInfoReturnable<Integer> cir) {
+        SpawnHelper.Info spawnInfo = serverWorld.getChunkManager().getSpawnInfo();
+        Object2IntMap<SpawnGroup> count = spawnInfo.getGroupToCount();
+
+
+        if(CarpetSettings.phantomsRespectMobCap && count.getOrDefault(SpawnGroup.MONSTER, -1) < SpawnGroup.MONSTER.getCapacity()) {
+            cir.setReturnValue(0);
+            cir.cancel();
+        }
+    }
+}

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -100,6 +100,7 @@
     "GuardianEntityMixin",
     "DesertPyramidFeatureMixin",
     "HuskEntityMixin",
+    "PhantomEntityMixin",
 
     "SurfaceChunkGenerator_husksSpawnMixin",
 


### PR DESCRIPTION
So basically we were talking about this and xcom said that this was the best idea instead of just toggling the gamerule. I agree so yea i made this :)