### PR TITLE
Corrected while() documentation

### DIFF
--- a/docs/scarpet/Full.md
+++ b/docs/scarpet/Full.md
@@ -1109,7 +1109,7 @@ for(range(1000000,1100000),check_prime(_))  => 7216
 
 From which we can learn that there is 7216 primes between 1M and 1.1M
 
-### `while(cond, limit)`
+### `while(cond, limit,expr)`
 
 Evaluates expression `expr` repeatedly until condition `cond` becomes false, but not more than `limit` times. 
 Returns the result of the last `expr` evaluation, or `null` if nothing was successful. Both `expr` and `cond` will 

--- a/docs/scarpet/language/LoopsAndHigherOrderFunctions.md
+++ b/docs/scarpet/language/LoopsAndHigherOrderFunctions.md
@@ -49,7 +49,7 @@ for(range(1000000,1100000),check_prime(_))  => 7216
 
 From which we can learn that there is 7216 primes between 1M and 1.1M
 
-### `while(cond, limit,expr)`
+### `while(cond, limit, expr)`
 
 Evaluates expression `expr` repeatedly until condition `cond` becomes false, but not more than `limit` times. 
 Returns the result of the last `expr` evaluation, or `null` if nothing was successful. Both `expr` and `cond` will 

--- a/docs/scarpet/language/LoopsAndHigherOrderFunctions.md
+++ b/docs/scarpet/language/LoopsAndHigherOrderFunctions.md
@@ -49,7 +49,7 @@ for(range(1000000,1100000),check_prime(_))  => 7216
 
 From which we can learn that there is 7216 primes between 1M and 1.1M
 
-### `while(cond, limit)`
+### `while(cond, limit,expr)`
 
 Evaluates expression `expr` repeatedly until condition `cond` becomes false, but not more than `limit` times. 
 Returns the result of the last `expr` evaluation, or `null` if nothing was successful. Both `expr` and `cond` will 


### PR DESCRIPTION
Added `expr` to the args of while() in both places in the documentation
I noticed it was missing the other day, so here's a PR adding the args