### PR TITLE
Always flush chunk updates when tick freezes

### DIFF
--- a/src/main/java/carpet/fakes/ThreadedAnvilChunkStorageInterface.java
+++ b/src/main/java/carpet/fakes/ThreadedAnvilChunkStorageInterface.java
@@ -3,6 +3,7 @@ package carpet.fakes;
 import java.util.List;
 import java.util.Map;
 
+import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.util.math.ChunkPos;
 
 public interface ThreadedAnvilChunkStorageInterface
@@ -12,4 +13,6 @@ public interface ThreadedAnvilChunkStorageInterface
     void relightChunk(ChunkPos pos);
 
     void releaseRelightTicket(ChunkPos pos);
+
+    Iterable<ChunkHolder> getChunks();
 }

--- a/src/main/java/carpet/mixins/ThreadedAnvilChunkStorage_scarpetChunkCreationMixin.java
+++ b/src/main/java/carpet/mixins/ThreadedAnvilChunkStorage_scarpetChunkCreationMixin.java
@@ -95,6 +95,9 @@ public abstract class ThreadedAnvilChunkStorage_scarpetChunkCreationMixin implem
     @Shadow
     protected abstract CompletableFuture<Either<List<Chunk>, Unloaded>> getRegion (final ChunkPos centerChunk, final int margin, final IntFunction<ChunkStatus> distanceToStatus);
 
+    @Shadow
+    protected abstract Iterable<ChunkHolder> entryIterator();
+
     //in method_20617
     //method_19534(Lnet/minecraft/server/world/ChunkHolder;Lnet/minecraft/world/chunk/Chunk;)Ljava/util/concurrent/CompletableFuture;
     // incmopatibility with optifine makes this mixin fail.
@@ -425,5 +428,10 @@ public abstract class ThreadedAnvilChunkStorage_scarpetChunkCreationMixin implem
         report.put("relight_time", (int) (System.currentTimeMillis() - relightStart));
 
         return report;
+    }
+
+    @Override
+    public Iterable<ChunkHolder> getChunks() {
+        return entryIterator();
     }
 }


### PR DESCRIPTION
Fixes the timing issue when using `/tick freeze`. Since `/tick freeze` skips chunk ticking also skips syncing chunk updates with clients, block updates are only visible to the clients after a `/tick step`. So some non-delay blocks like as redstone lamps or fence gates would behave as if there's a one tick delay when using `/tick step`. Blocks updated in block actions like pistons would make things worse since they sync with clients instantly. These issues make the timing analyse of redstone contraptions with `/tick freeze` very inconvenient.