### PR TITLE
Ai_Tracker app bug

### DIFF
--- a/src/main/resources/assets/carpet/scripts/ai_tracker.sc
+++ b/src/main/resources/assets/carpet/scripts/ai_tracker.sc
@@ -245,7 +245,7 @@ global_functions = {
             [visuals, abnoxious_visuals, [
                ['hasbed', 'bed: ', format(if(bed, 'be has home', 'br no home'))], // ☖  ☽  ♨  ♡
                ['hasfood', 'food: ', format(if(food, 'be '+portions+' portions', 'br 0 portions'))],
-               ['breeding', 'timer: ',format(if(breeding_age, 'be ', 'br ')+breeding_age)],
+               ['breeding', 'timer: ',format(if(!breeding_age, 'be ', 'br ')+breeding_age)],
 
             ]];
          ),


### PR DESCRIPTION
Fixes #430 

Basically it showed breeding_age of 0 as red, when in fact it ought to be green, as it is a necessary requirement for breeding of villagers.