### PR TITLE
Made the Event Constructor public

### DIFF
--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -675,7 +675,7 @@ public class CarpetEventServer
 
         public final CallbackList handler;
         public final boolean globalOnly;
-        Event(String name, int reqArgs, boolean isGlobalOnly)
+        public Event(String name, int reqArgs, boolean isGlobalOnly)
         {
             this.name = name;
             this.handler = new CallbackList(reqArgs);


### PR DESCRIPTION
It's not possible to create a new event outside the carpet.script package (Commit 3105d5bb719338a511eeac7ee3a3500c6a562f88 fix)