### PR TITLE
Bots misc

### DIFF
--- a/src/main/java/carpet/CarpetServer.java
+++ b/src/main/java/carpet/CarpetServer.java
@@ -16,9 +16,12 @@ import carpet.utils.MobAI;
 import carpet.utils.SpawnReporter;
 import com.mojang.brigadier.CommandDispatcher;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.scoreboard.ServerScoreboard;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Formatting;
 
 public class CarpetServer // static for now - easier to handle all around the code, its one anyways
 {
@@ -49,8 +52,7 @@ public class CarpetServer // static for now - easier to handle all around the co
         extensions.forEach(CarpetExtension::onGameStarted);
     }
 
-    public static void onServerLoaded(MinecraftServer server)
-    {
+    public static void onServerLoaded(MinecraftServer server) {
         CarpetServer.minecraft_server = server;
         // shoudl not be needed - that bit needs refactoring, but not now.
         SpawnReporter.reset_spawn_stats(server, true);
@@ -71,6 +73,12 @@ public class CarpetServer // static for now - easier to handle all around the co
     {
         extensions.forEach(e -> e.onServerLoadedWorlds(minecraftServer));
         scriptServer.loadAllWorldScripts();
+
+        ServerScoreboard scoreboard = minecraft_server.getScoreboard();
+        if (scoreboard.getTeam("fake_players") == null) {
+            scoreboard.addTeam("fake_players");
+            scoreboard.getTeam("fake_players").setColor(Formatting.DARK_GREEN);
+        }
     }
 
     public static void tick(MinecraftServer server)

--- a/src/main/java/carpet/CarpetServer.java
+++ b/src/main/java/carpet/CarpetServer.java
@@ -1,27 +1,26 @@
 package carpet;
 
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-
 import carpet.commands.*;
-import carpet.network.ServerNetworkHandler;
 import carpet.helpers.TickSpeed;
+import carpet.logging.HUDController;
 import carpet.logging.LoggerRegistry;
+import carpet.network.ServerNetworkHandler;
 import carpet.script.CarpetScriptServer;
 import carpet.settings.SettingsManager;
-import carpet.logging.HUDController;
 import carpet.utils.MobAI;
 import carpet.utils.SpawnReporter;
 import com.mojang.brigadier.CommandDispatcher;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.scoreboard.Scoreboard;
 import net.minecraft.scoreboard.ServerScoreboard;
-import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Formatting;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 public class CarpetServer // static for now - easier to handle all around the code, its one anyways
 {
@@ -52,7 +51,8 @@ public class CarpetServer // static for now - easier to handle all around the co
         extensions.forEach(CarpetExtension::onGameStarted);
     }
 
-    public static void onServerLoaded(MinecraftServer server) {
+    public static void onServerLoaded(MinecraftServer server)
+    {
         CarpetServer.minecraft_server = server;
         // shoudl not be needed - that bit needs refactoring, but not now.
         SpawnReporter.reset_spawn_stats(server, true);

--- a/src/main/java/carpet/CarpetServer.java
+++ b/src/main/java/carpet/CarpetServer.java
@@ -75,7 +75,8 @@ public class CarpetServer // static for now - easier to handle all around the co
         scriptServer.loadAllWorldScripts();
 
         ServerScoreboard scoreboard = minecraft_server.getScoreboard();
-        if (scoreboard.getTeam("fake_players") == null) {
+        if (scoreboard.getTeam("fake_players") == null)
+        {
             scoreboard.addTeam("fake_players");
             scoreboard.getTeam("fake_players").setColor(Formatting.DARK_GREEN);
         }

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -674,4 +674,15 @@ public class CarpetSettings
             category = {CREATIVE}
     )
     public static boolean fakePlayersTeam = false;
+
+    @Rule(
+            desc = "If false, prevents fake players from getting stats",
+            extra = {
+                    "Useful when you don't want certain scoreboards",
+                    "to get filled by bots",
+                    "by samipourquoi"
+            },
+            category = {CREATIVE}
+    )
+    public static boolean fakePlayersStats = true;
 }

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -663,4 +663,15 @@ public class CarpetSettings
             category = {SURVIVAL, CLIENT}
     )
     public static boolean cleanLogs = false;
+
+    @Rule(
+            desc = "Adds a team that will be given to any fake players",
+            extra = {
+                    "The team is named 'fake_players'",
+                    "You can't delete the 'fake_players' team",
+                    "by samipourquoi"
+            },
+            category = {CREATIVE}
+    )
+    public static boolean fakePlayersTeam = false;
 }

--- a/src/main/java/carpet/mixins/TeamCommandMixin.java
+++ b/src/main/java/carpet/mixins/TeamCommandMixin.java
@@ -1,0 +1,23 @@
+package carpet.mixins;
+
+import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.scoreboard.Team;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.command.TeamCommand;
+import net.minecraft.text.TranslatableText;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(TeamCommand.class)
+public class TeamCommandMixin {
+    @Inject(method = "executeRemove", at = @At("HEAD"))
+    private static void preventRemovingBotTeam(ServerCommandSource source, Team team, CallbackInfoReturnable<Integer> cir) {
+        Scoreboard scoreboard = source.getMinecraftServer().getScoreboard();
+        if (scoreboard.getTeam("fake_players").equals(team)) {
+            cir.setReturnValue(scoreboard.getTeams().size());
+            cir.cancel();
+        }
+    }
+}

--- a/src/main/java/carpet/mixins/TeamCommandMixin.java
+++ b/src/main/java/carpet/mixins/TeamCommandMixin.java
@@ -4,7 +4,6 @@ import net.minecraft.scoreboard.Scoreboard;
 import net.minecraft.scoreboard.Team;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.command.TeamCommand;
-import net.minecraft.text.TranslatableText;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -1,5 +1,6 @@
 package carpet.patches;
 
+import carpet.CarpetSettings;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.block.entity.SkullBlockEntity;
 import net.minecraft.network.packet.s2c.play.EntityPositionS2CPacket;
@@ -22,6 +23,8 @@ import net.minecraft.world.World;
 import net.minecraft.world.dimension.DimensionType;
 import carpet.fakes.ServerPlayerEntityInterface;
 import carpet.utils.Messenger;
+
+import java.util.Objects;
 
 @SuppressWarnings("EntityConstructor")
 public class EntityPlayerMPFake extends ServerPlayerEntity
@@ -58,7 +61,7 @@ public class EntityPlayerMPFake extends ServerPlayerEntity
 
         ServerScoreboard scoreboard = instance.server.getScoreboard();
         Team team = scoreboard.getTeam("fake_players");
-        if (team != null) {
+        if (team != null && CarpetSettings.fakePlayersTeam) {
             scoreboard.addPlayerToTeam(username, team);
         }
 
@@ -101,7 +104,8 @@ public class EntityPlayerMPFake extends ServerPlayerEntity
     {
         ServerScoreboard scoreboard = this.server.getScoreboard();
         Team team = scoreboard.getTeam("fake_players");
-        if (team != null) {
+        boolean inTeam = (scoreboard.getPlayerTeam(this.getEntityName()) != null);
+        if (team != null && inTeam) {
             scoreboard.removePlayerFromTeam(this.getEntityName(), team);
         }
 

--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.player.HungerManager;
 import net.minecraft.network.NetworkSide;
 import net.minecraft.scoreboard.ServerScoreboard;
 import net.minecraft.scoreboard.Team;
+import net.minecraft.stat.Stat;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.ServerTask;
@@ -136,5 +137,10 @@ public class EntityPlayerMPFake extends ServerPlayerEntity
         setHealth(20);
         this.hungerManager = new HungerManager();
         kill();
+    }
+
+    @Override
+    public void increaseStat(Stat<?> stat, int amount) {
+        if (CarpetSettings.fakePlayersStats) super.increaseStat(stat, amount);
     }
 }

--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -61,7 +61,8 @@ public class EntityPlayerMPFake extends ServerPlayerEntity
 
         ServerScoreboard scoreboard = instance.server.getScoreboard();
         Team team = scoreboard.getTeam("fake_players");
-        if (team != null && CarpetSettings.fakePlayersTeam) {
+        if (team != null && CarpetSettings.fakePlayersTeam)
+        {
             scoreboard.addPlayerToTeam(username, team);
         }
 
@@ -105,7 +106,8 @@ public class EntityPlayerMPFake extends ServerPlayerEntity
         ServerScoreboard scoreboard = this.server.getScoreboard();
         Team team = scoreboard.getTeam("fake_players");
         boolean inTeam = (scoreboard.getPlayerTeam(this.getEntityName()) != null);
-        if (team != null && inTeam) {
+        if (team != null && inTeam)
+        {
             scoreboard.removePlayerFromTeam(this.getEntityName(), team);
         }
 

--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -8,6 +8,8 @@ import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.player.HungerManager;
 import net.minecraft.network.NetworkSide;
+import net.minecraft.scoreboard.ServerScoreboard;
+import net.minecraft.scoreboard.Team;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.ServerTask;
@@ -53,6 +55,13 @@ public class EntityPlayerMPFake extends ServerPlayerEntity
         server.getPlayerManager().sendToDimension(new EntityPositionS2CPacket(instance), dimensionId);//instance.dimension);
         instance.getServerWorld().getChunkManager().updateCameraPosition(instance);
         instance.dataTracker.set(PLAYER_MODEL_PARTS, (byte) 0x7f); // show all model layers (incl. capes)
+
+        ServerScoreboard scoreboard = instance.server.getScoreboard();
+        Team team = scoreboard.getTeam("fake_players");
+        if (team != null) {
+            scoreboard.addPlayerToTeam(username, team);
+        }
+
         return instance;
     }
 
@@ -90,6 +99,12 @@ public class EntityPlayerMPFake extends ServerPlayerEntity
     @Override
     public void kill()
     {
+        ServerScoreboard scoreboard = this.server.getScoreboard();
+        Team team = scoreboard.getTeam("fake_players");
+        if (team != null) {
+            scoreboard.removePlayerFromTeam(this.getEntityName(), team);
+        }
+
         this.server.send(new ServerTask(this.server.getTicks(), () -> {
             this.networkHandler.onDisconnected(Messenger.s("Killed"));
         }));

--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -1,31 +1,28 @@
 package carpet.patches;
 
 import carpet.CarpetSettings;
+import carpet.fakes.ServerPlayerEntityInterface;
+import carpet.utils.Messenger;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.block.entity.SkullBlockEntity;
-import net.minecraft.network.packet.s2c.play.EntityPositionS2CPacket;
-import net.minecraft.network.packet.s2c.play.EntitySetHeadYawS2CPacket;
-import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.player.HungerManager;
 import net.minecraft.network.NetworkSide;
+import net.minecraft.network.packet.s2c.play.EntityPositionS2CPacket;
+import net.minecraft.network.packet.s2c.play.EntitySetHeadYawS2CPacket;
+import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
 import net.minecraft.scoreboard.ServerScoreboard;
 import net.minecraft.scoreboard.Team;
-import net.minecraft.stat.Stat;
-import net.minecraft.text.TranslatableText;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.ServerTask;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.network.ServerPlayerInteractionManager;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.stat.Stat;
+import net.minecraft.text.TranslatableText;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.GameMode;
 import net.minecraft.world.World;
-import net.minecraft.world.dimension.DimensionType;
-import carpet.fakes.ServerPlayerEntityInterface;
-import carpet.utils.Messenger;
-
-import java.util.Objects;
 
 @SuppressWarnings("EntityConstructor")
 public class EntityPlayerMPFake extends ServerPlayerEntity
@@ -140,7 +137,8 @@ public class EntityPlayerMPFake extends ServerPlayerEntity
     }
 
     @Override
-    public void increaseStat(Stat<?> stat, int amount) {
+    public void increaseStat(Stat<?> stat, int amount)
+    {
         if (CarpetSettings.fakePlayersStats) super.increaseStat(stat, amount);
     }
 }

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -181,8 +181,9 @@
     "PlayerEntity_creativeNoClipMixin",
     "PistonBlockEntity_creativeNoClipMixin",
     "BlockItem_creativeNoClipMixin",
-    "LivingEntity_creativeFlyMixin"
+    "LivingEntity_creativeFlyMixin",
 
+    "TeamCommandMixin"
   ],
   "client": [
     "RenderTickCounter_tickSpeedMixin",


### PR DESCRIPTION
Added two miscellaneous rules regarding fake players:
- `fakePlayersTeam`: creates a `fake_players` team which will get added to every fake players joining the server, and will get removed once they leave. You can't remove that team using `/team remove fake_players`
- `fakePlayersStats`: when false, it will prevent fake players from getting stats (useful for a playtime scoreboard for instance, where you don't want bots to hide every other players..)