### PR TITLE
[Actions] Fix and compatibility

### DIFF
--- a/.github/workflows/merge-docs.yml
+++ b/.github/workflows/merge-docs.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Merge docs
         run: ./mergedoc.sh
       - name: Commit merged docs
+        continue-on-error: true
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/rules-to-wiki.yml
+++ b/.github/workflows/rules-to-wiki.yml
@@ -64,7 +64,15 @@ jobs:
           repository: ${{github.repository}}.wiki
           path: wiki
       - name: Proccess Gradle log into a pretty wiki page
-        run: from1="# Carpet"; to2="BUILD SUCCESSFUL"; a="$(cat settings-toProccess.txt)"; a="$(echo "${a#*"$from1"}")"; echo "$from1${a%%"$to2"*}" > wiki/Current-Available-Settings.md
+        run: |
+          from1="# Carpet";
+          File=settings-toProccess.txt
+          if grep -q "Deprecated Gradle features" "$File"; then # Happens after update to Gradle 6
+            to2="Deprecated Gradle features";
+          else
+            to2="BUILD SUCCESSFUL"
+          fi
+          a="$(cat settings-toProccess.txt)"; a="$(echo "${a#*"$from1"}")"; echo "$from1${a%%"$to2"*}" > wiki/Current-Available-Settings.md
       - name: Commit updated wiki page
         continue-on-error: true
         run: |


### PR DESCRIPTION
- Fixes `merge-docs` failing if there is nothing new to merge (was implemented in rules to wiki, but not for this)
   - See 7d98f023efdb2d1c628474f137a9f361a7af2094 and its [Action Run](https://github.com/gnembon/fabric-carpet/runs/1303970195?check_suite_focus=true)
- Adds "compatibility" with Gradle 6 in rules to wiki (see also gnembon/carpet-extra#143)
  - Doesn't update this Gradle to 6, just makes the action compatible
  - Also useful for any other version or change using deprecated Gradle features