### PR TITLE
Allow flippinCactus to rotate logs, hay bales and other pillars

### DIFF
--- a/src/main/java/carpet/helpers/BlockRotator.java
+++ b/src/main/java/carpet/helpers/BlockRotator.java
@@ -8,7 +8,6 @@ import net.minecraft.block.BedBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
-import net.minecraft.block.ChainBlock;
 import net.minecraft.block.ComparatorBlock;
 import net.minecraft.block.DispenserBlock;
 import net.minecraft.block.EndRodBlock;
@@ -360,7 +359,7 @@ public class BlockRotator
                 }
             }
         }
-        else if (block instanceof ChainBlock) 
+        else if (block instanceof PillarBlock) 
         {
             switch((Direction.Axis)state.get(PillarBlock.AXIS)) {
                 case X:


### PR DESCRIPTION
This basically changes the `instanceof ChainBlock` check to `PillarBlock`, since all changes used in that transformation can be applied to those. That makes cactus able to rotate any block that extends from there with a single word change.

Includes (but is probably not limited to): All logs, stripped logs, hay bales and actual pillars (and obviously chains).