### PR TITLE
Allow rules to manage Scarpet apps (Scarpet Rules)

### DIFF
--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -469,7 +469,7 @@ Available options in the scarpet app space:
   * `world_seed` - a numeric seed of the world
   * `world_path` - full path to the world saves folder
   * `world_folder` - name of the direct folder in the saves that holds world files
-  * `world_carpet_rules` - returns all Carpet rules in a map form (rule->value). Includes rules from extensions with their namespace (namespace:rule->value)
+  * `world_carpet_rules` - returns all Carpet rules in a map form (`rule`->`value`). Includes rules from extensions with their namespace (`namespace:rule`->`value`). You can later listen to rule changes with the `on_carpet_rule_change(rule, newValue)` event.
  
  Relevant gameplay related properties
   * `game_difficulty` - current difficulty of the game: `'peacefu'`, `'easy'`, `'normal'`, or `'hard'`

--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -469,6 +469,7 @@ Available options in the scarpet app space:
   * `world_seed` - a numeric seed of the world
   * `world_path` - full path to the world saves folder
   * `world_folder` - name of the direct folder in the saves that holds world files
+  * `world_carpet_rules` - returns all Carpet rules in a map form (rule->value). Includes rules from extensions with their namespace (namespace:rule->value)
  
  Relevant gameplay related properties
   * `game_difficulty` - current difficulty of the game: `'peacefu'`, `'easy'`, `'normal'`, or `'hard'`

--- a/docs/scarpet/api/Events.md
+++ b/docs/scarpet/api/Events.md
@@ -43,6 +43,9 @@ at the same time.
 ### `__on_lightning(block, mode)`
 Triggered right after a lightning strikes. Lightning entity as well as potential horseman trap would 
 already be spawned at that point. `mode` is `true` if the lightning did cause a trap to spawn. 
+
+### `__on_carpet_rule_change(rule, new_value)`
+Triggered when a Carpet rule is changed. It includes extension rules, which will be namespaced as `namespace:rule`.
  
 ## Player events
 

--- a/docs/scarpet/api/Events.md
+++ b/docs/scarpet/api/Events.md
@@ -44,7 +44,7 @@ at the same time.
 Triggered right after a lightning strikes. Lightning entity as well as potential horseman trap would 
 already be spawned at that point. `mode` is `true` if the lightning did cause a trap to spawn. 
 
-### `__on_carpet_rule_change(rule, new_value)`
+### `__on_carpet_rule_changes(rule, new_value)`
 Triggered when a Carpet rule is changed. It includes extension rules, which will be namespaced as `namespace:rule`.
  
 ## Player events

--- a/src/main/java/carpet/CarpetServer.java
+++ b/src/main/java/carpet/CarpetServer.java
@@ -84,7 +84,7 @@ public class CarpetServer implements ClientModInitializer,DedicatedServerModInit
     public static void onServerLoadedWorlds(MinecraftServer minecraftServer)
     {
         extensions.forEach(e -> e.onServerLoadedWorlds(minecraftServer));
-        scriptServer.loadAllWorldScripts();
+        scriptServer.initializeForWorld();
     }
 
     public static void tick(MinecraftServer server)

--- a/src/main/java/carpet/commands/ScriptCommand.java
+++ b/src/main/java/carpet/commands/ScriptCommand.java
@@ -258,10 +258,10 @@ public class ScriptCommand
                 );
         LiteralArgumentBuilder<ServerCommandSource> f = literal("unload").requires( (player) -> SettingsManager.canUseCommand(player, CarpetSettings.commandScriptACE) ).
                 then(argument("app", StringArgumentType.word()).
-                        suggests( (cc, bb) -> suggestMatching(CarpetServer.scriptServer.modules.keySet(),bb)).
+                        suggests( (cc, bb) -> suggestMatching(CarpetServer.scriptServer.unloadableModules,bb)).
                         executes((cc) ->
                         {
-                            boolean success =CarpetServer.scriptServer.removeScriptHost(cc.getSource(), StringArgumentType.getString(cc, "app"), true);
+                            boolean success =CarpetServer.scriptServer.removeScriptHost(cc.getSource(), StringArgumentType.getString(cc, "app"), true, false);
                             return success?1:0;
                         }));
 

--- a/src/main/java/carpet/commands/ScriptCommand.java
+++ b/src/main/java/carpet/commands/ScriptCommand.java
@@ -244,13 +244,13 @@ public class ScriptCommand
                         suggests( (cc, bb) -> suggestMatching(CarpetServer.scriptServer.listAvailableModules(true),bb)).
                         executes((cc) ->
                         {
-                            boolean success = CarpetServer.scriptServer.addScriptHost(cc.getSource(), StringArgumentType.getString(cc, "app"), true, false);
+                            boolean success = CarpetServer.scriptServer.addScriptHost(cc.getSource(), StringArgumentType.getString(cc, "app"), true, false, false);
                             return success?1:0;
                         }).
                         then(literal("global").
                                 executes((cc) ->
                                 {
-                                    boolean success = CarpetServer.scriptServer.addScriptHost(cc.getSource(), StringArgumentType.getString(cc, "app"), false, false);
+                                    boolean success = CarpetServer.scriptServer.addScriptHost(cc.getSource(), StringArgumentType.getString(cc, "app"), false, false, false);
                                     return success?1:0;
                                 }
                                 )

--- a/src/main/java/carpet/mixins/ArmorStandEntity_scarpetMarkerMixin.java
+++ b/src/main/java/carpet/mixins/ArmorStandEntity_scarpetMarkerMixin.java
@@ -30,7 +30,7 @@ public abstract class ArmorStandEntity_scarpetMarkerMixin extends LivingEntity
     @Inject(method = "readCustomDataFromTag", at = @At("HEAD"))
     private void checkScarpetMarkerUnloaded(CallbackInfo ci)
     {
-        if ((CarpetSettings.scriptsAutoload || !CarpetSettings.commandScript.equals("false")) && !world.isClient)
+        if (!world.isClient)
         {
             if (getScoreboardTags().contains(Auxiliary.MARKER_STRING))
             {

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -654,7 +654,7 @@ public class CarpetEventServer
                 );
             }
         };
-        public static final Event CARPET_RULE_CHANGE = new Event("carpet_rule_change", 2, true)
+        public static final Event CARPET_RULE_CHANGES = new Event("carpet_rule_changes", 2, true)
         {
         	@Override
         	public void onCarpetRuleChange(ParsedRule<?> rule, ServerCommandSource source)

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -11,6 +11,7 @@ import carpet.script.value.NBTSerializableValue;
 import carpet.script.value.NumericValue;
 import carpet.script.value.StringValue;
 import carpet.script.value.Value;
+import carpet.settings.ParsedRule;
 import carpet.utils.Messenger;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.damage.DamageSource;
@@ -694,6 +695,25 @@ public class CarpetEventServer
                 );
             }
         };
+        public static final Event CARPET_RULE_CHANGE = new Event("carpet_rule_change", 2, true)
+        {
+        	@Override
+        	public void onCarpetRuleChange(ParsedRule<?> rule, ServerCommandSource source)
+        	{
+        		String identifier = rule.settingsManager.getIdentifier();
+        		final String namespace;
+        		if (!identifier.equals("carpet")) 
+        		{
+        			namespace = identifier+":";
+        		} else { namespace = "";}
+        		handler.call(
+        				() -> Arrays.asList(
+        						((c,t) -> new StringValue(namespace+rule.name)),
+        						((c,t) -> new StringValue(rule.getAsString()))
+        				), () -> source
+        		);
+        	}
+        };
 
         // on projectile thrown (arrow from bows, crossbows, tridents, snoballs, e-pearls
 
@@ -733,6 +753,7 @@ public class CarpetEventServer
 
         public void onWorldEvent(ServerWorld world, BlockPos pos) { }
         public void onWorldEventFlag(ServerWorld world, BlockPos pos, int flag) { }
+        public void onCarpetRuleChange(ParsedRule<?> rule, ServerCommandSource source) { }
     }
 
 

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -656,22 +656,22 @@ public class CarpetEventServer
         };
         public static final Event CARPET_RULE_CHANGES = new Event("carpet_rule_changes", 2, true)
         {
-        	@Override
-        	public void onCarpetRuleChange(ParsedRule<?> rule, ServerCommandSource source)
-        	{
-        		String identifier = rule.settingsManager.getIdentifier();
-        		final String namespace;
-        		if (!identifier.equals("carpet")) 
-        		{
-        			namespace = identifier+":";
-        		} else { namespace = "";}
-        		handler.call(
-        				() -> Arrays.asList(
-        						new StringValue(namespace+rule.name),
-        						new StringValue(rule.getAsString())
-        				), () -> source
-        		);
-        	}
+            @Override
+            public void onCarpetRuleChanges(ParsedRule<?> rule, ServerCommandSource source)
+            {
+                String identifier = rule.settingsManager.getIdentifier();
+                final String namespace;
+                if (!identifier.equals("carpet")) 
+                {
+                    namespace = identifier+":";
+                } else { namespace = "";}
+                handler.call(
+                        () -> Arrays.asList(
+                                new StringValue(namespace+rule.name),
+                                new StringValue(rule.getAsString())
+                        ), () -> source
+                );
+            }
         };
 
         public static String getLoadEvent(EntityType<? extends Entity> et)
@@ -741,7 +741,7 @@ public class CarpetEventServer
 
         public void onWorldEvent(ServerWorld world, BlockPos pos) { }
         public void onWorldEventFlag(ServerWorld world, BlockPos pos, int flag) { }
-        public void onCarpetRuleChange(ParsedRule<?> rule, ServerCommandSource source) { }
+        public void onCarpetRuleChanges(ParsedRule<?> rule, ServerCommandSource source) { }
     }
 
 

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -667,8 +667,8 @@ public class CarpetEventServer
         		} else { namespace = "";}
         		handler.call(
         				() -> Arrays.asList(
-        						((c,t) -> new StringValue(namespace+rule.name)),
-        						((c,t) -> new StringValue(rule.getAsString()))
+        						new StringValue(namespace+rule.name),
+        						new StringValue(rule.getAsString())
         				), () -> source
         		);
         	}

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -194,7 +194,8 @@ public class CarpetScriptServer
         boolean reload = false;
         if (modules.containsKey(name))
         {
-            removeScriptHost(source, name, false, isRuleApp);
+            if (isRuleApp) return false;
+        	removeScriptHost(source, name, false, isRuleApp);
             reload = true;
         }
         Module module = isRuleApp ? getRuleModule(name) : getModule(name, false);

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -88,7 +88,12 @@ public class CarpetScriptServer
     public void initializeForWorld()
     {
     	worldInitialized = true;
-    	CarpetServer.settingsManager.initializeScarpetRules(server.getCommandSource());
+    	CarpetServer.settingsManager.initializeScarpetRules();
+    	CarpetServer.extensions.forEach(e -> {
+    		if(e.customSettingsManager() != null) {
+    			e.customSettingsManager().initializeScarpetRules();
+    		}
+    	});
         if (CarpetSettings.scriptsAutoload)
         {
             Messenger.m(server.getCommandSource(), "Auto-loading world scarpet apps");

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -94,7 +94,7 @@ public class CarpetScriptServer
             Messenger.m(server.getCommandSource(), "Auto-loading world scarpet apps");
             for (String moduleName: listAvailableModules(false))
             {
-                addScriptHost(server.getCommandSource(), moduleName, true, true);
+                addScriptHost(server.getCommandSource(), moduleName, true, true, false);
             }
         }
 
@@ -170,27 +170,11 @@ public class CarpetScriptServer
         return modules.get(name);
     }
 
-    public boolean addRuleScriptHost(ServerCommandSource source, String name)
-    {
-    	if (!worldInitialized)
-    		return false;
-    	name = name.toLowerCase(Locale.ROOT);
-        boolean reload = false;
-        if (modules.containsKey(name))
-        {
-            removeScriptHost(source, name, false);
-            reload = true;
-        }
-        Module module = getRuleModule(name);
-        CarpetScriptHost newHost = CarpetScriptHost.create(this, module, false, source);
-        modules.put(name, newHost);
-        addCommand(source, name, reload, false);
-        return true;
-    }
-
-    public boolean addScriptHost(ServerCommandSource source, String name, boolean perPlayer, boolean autoload)
+    public boolean addScriptHost(ServerCommandSource source, String name, boolean perPlayer, boolean autoload, boolean isRuleApp)
     {
         //TODO add per player modules to support player actions better on a server
+        if (!worldInitialized) return false;
+        
         name = name.toLowerCase(Locale.ROOT);
         boolean reload = false;
         if (modules.containsKey(name))
@@ -198,7 +182,13 @@ public class CarpetScriptServer
             removeScriptHost(source, name, false);
             reload = true;
         }
-        Module module = getModule(name, false);
+        Module module = null;
+        if (isRuleApp) 
+        {
+        	module = getModule(name, false);
+        } else {
+        	module = getRuleModule(name);
+        }
         if (module == null)
         {
             Messenger.m(source, "r Failed to add "+name+" app");
@@ -231,7 +221,7 @@ public class CarpetScriptServer
             return false;
         }
         //addEvents(source, name);
-        addCommand(source, name, reload, false);
+        addCommand(source, name, reload, !isRuleApp);
         return true;
     }
 
@@ -351,6 +341,6 @@ public class CarpetScriptServer
         apps.keySet().forEach(s -> removeScriptHost(server.getCommandSource(), s, false));
         events.clearAll();
         init();
-        apps.forEach((s, pp) -> addScriptHost(server.getCommandSource(), s, pp, false));
+        apps.forEach((s, pp) -> addScriptHost(server.getCommandSource(), s, pp, false, false));
     }
 }

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -97,13 +97,13 @@ public class CarpetScriptServer
 
     public void initializeForWorld()
     {
-    	worldInitialized = true;
-    	CarpetServer.settingsManager.initializeScarpetRules();
-    	CarpetServer.extensions.forEach(e -> {
-    		if(e.customSettingsManager() != null) {
-    			e.customSettingsManager().initializeScarpetRules();
-    		}
-    	});
+        worldInitialized = true;
+        CarpetServer.settingsManager.initializeScarpetRules();
+        CarpetServer.extensions.forEach(e -> {
+            if (e.customSettingsManager() != null) {
+                e.customSettingsManager().initializeScarpetRules();
+            }
+        });
         if (CarpetSettings.scriptsAutoload)
         {
             Messenger.m(server.getCommandSource(), "Auto-loading world scarpet apps");
@@ -143,14 +143,14 @@ public class CarpetScriptServer
     
     public Module getRuleModule(String name) 
     {
-    	for (Module moduleData : ruleModuleData)
+        for (Module moduleData : ruleModuleData)
         {
             if (moduleData.getName().equalsIgnoreCase(name))
             {
                 return moduleData;
             }
         }
-    	return null;
+        return null;
     }
 
     public List<String> listAvailableModules(boolean includeBuiltIns)
@@ -195,7 +195,7 @@ public class CarpetScriptServer
         if (modules.containsKey(name))
         {
             if (isRuleApp) return false;
-        	removeScriptHost(source, name, false, isRuleApp);
+            removeScriptHost(source, name, false, isRuleApp);
             reload = true;
         }
         Module module = isRuleApp ? getRuleModule(name) : getModule(name, false);
@@ -224,10 +224,7 @@ public class CarpetScriptServer
         }
 
         modules.put(name, newHost);
-        if (!isRuleApp) 
-        {
-        	unloadableModules.add(name);
-        }
+        if (!isRuleApp) unloadableModules.add(name);
 
         if (autoload && !newHost.persistenceRequired)
         {

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -55,6 +55,13 @@ public class CarpetScriptServer
         bundledModuleData.add(app);
     }
     
+    /**
+     * Registers a Scarpet App to be used as a Rule App
+     * (to be controlled with the value of a Carpet rule)
+     * 
+     * @param app is the BundledModule of an app. Libraries
+     * should be registered as builtInScripts instead
+     */
     public static void registerRuleScript(BundledModule app) {
     	ruleModuleData.add(app);
     }

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -45,10 +45,15 @@ public class CarpetScriptServer
     public  CarpetEventServer events;
 
     private static final List<Module> bundledModuleData = new ArrayList<>();
+    private static final List<Module> ruleModuleData = new ArrayList<>();
 
     public static void registerBuiltInScript(BundledModule app)
     {
         bundledModuleData.add(app);
+    }
+    
+    public static void registerRuleScript(BundledModule app) {
+    	ruleModuleData.add(app);
     }
 
     static
@@ -117,6 +122,18 @@ public class CarpetScriptServer
         }
         return null;
     }
+    
+    public Module getRuleModule(String name) 
+    {
+    	for (Module moduleData : ruleModuleData)
+        {
+            if (moduleData.getName().equalsIgnoreCase(name))
+            {
+                return moduleData;
+            }
+        }
+    	return null;
+    }
 
     public List<String> listAvailableModules(boolean includeBuiltIns)
     {
@@ -148,6 +165,22 @@ public class CarpetScriptServer
         if (name == null)
             return globalHost;
         return modules.get(name);
+    }
+
+    public boolean addRuleScriptHost(ServerCommandSource source, String name)
+    {
+    	name = name.toLowerCase(Locale.ROOT);
+        boolean reload = false;
+        if (modules.containsKey(name))
+        {
+            removeScriptHost(source, name, false);
+            reload = true;
+        }
+        Module module = getRuleModule(name);
+        CarpetScriptHost newHost = CarpetScriptHost.create(this, module, false, source);
+        modules.put(name, newHost);
+        addCommand(source, name, reload);
+        return true;
     }
 
     public boolean addScriptHost(ServerCommandSource source, String name, boolean perPlayer, boolean autoload)

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -183,7 +183,7 @@ public class CarpetScriptServer
             reload = true;
         }
         Module module = null;
-        if (isRuleApp) 
+        if (!isRuleApp) 
         {
         	module = getModule(name, false);
         } else {

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -184,7 +184,7 @@ public class CarpetScriptServer
         Module module = getRuleModule(name);
         CarpetScriptHost newHost = CarpetScriptHost.create(this, module, false, source);
         modules.put(name, newHost);
-        addCommand(source, name, reload);
+        addCommand(source, name, reload, false);
         return true;
     }
 
@@ -231,11 +231,11 @@ public class CarpetScriptServer
             return false;
         }
         //addEvents(source, name);
-        addCommand(source, name, reload);
+        addCommand(source, name, reload, false);
         return true;
     }
 
-    private void addCommand(ServerCommandSource source, String hostName, boolean isReload)
+    private void addCommand(ServerCommandSource source, String hostName, boolean isReload, boolean notifySource)
     {
         ScriptHost host = modules.get(hostName);
         String loaded = isReload?"reloaded":"loaded";
@@ -245,7 +245,7 @@ public class CarpetScriptServer
         }
         if (host.getFunction("__command") == null)
         {
-            Messenger.m(source, "gi "+hostName+" app "+loaded+".");
+            if (notifySource) Messenger.m(source, "gi "+hostName+" app "+loaded+".");
             return;
         }
         if (holyMoly.contains(hostName))
@@ -284,7 +284,7 @@ public class CarpetScriptServer
                                         return (int)response.readInteger();
                                     })));
         }
-        Messenger.m(source, "gi "+hostName+" app "+loaded+" with /"+hostName+" command");
+        if (notifySource) Messenger.m(source, "gi "+hostName+" app "+loaded+" with /"+hostName+" command");
         server.getCommandManager().getDispatcher().register(command);
         CarpetServer.settingsManager.notifyPlayersCommandsChanged();
     }

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -45,7 +45,6 @@ public class CarpetScriptServer
     public boolean stopAll;
     private  Set<String> holyMoly;
     public  CarpetEventServer events;
-    private boolean worldInitialized = false;
 
     private static final List<Module> bundledModuleData = new ArrayList<>();
     private static final List<Module> ruleModuleData = new ArrayList<>();
@@ -97,7 +96,6 @@ public class CarpetScriptServer
 
     public void initializeForWorld()
     {
-        worldInitialized = true;
         CarpetServer.settingsManager.initializeScarpetRules();
         CarpetServer.extensions.forEach(e -> {
             if (e.customSettingsManager() != null) {
@@ -188,8 +186,6 @@ public class CarpetScriptServer
     public boolean addScriptHost(ServerCommandSource source, String name, boolean perPlayer, boolean autoload, boolean isRuleApp)
     {
         //TODO add per player modules to support player actions better on a server
-        if (!worldInitialized) return false;
-        
         name = name.toLowerCase(Locale.ROOT);
         boolean reload = false;
         if (modules.containsKey(name))

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -43,6 +43,7 @@ public class CarpetScriptServer
     public boolean stopAll;
     private  Set<String> holyMoly;
     public  CarpetEventServer events;
+    private boolean worldInitialized = false;
 
     private static final List<Module> bundledModuleData = new ArrayList<>();
     private static final List<Module> ruleModuleData = new ArrayList<>();
@@ -84,8 +85,10 @@ public class CarpetScriptServer
         globalHost = CarpetScriptHost.create(this, null, false, null);
     }
 
-    public void loadAllWorldScripts()
+    public void initializeForWorld()
     {
+    	worldInitialized = true;
+    	CarpetServer.settingsManager.initializeScarpetRules(server.getCommandSource());
         if (CarpetSettings.scriptsAutoload)
         {
             Messenger.m(server.getCommandSource(), "Auto-loading world scarpet apps");
@@ -169,6 +172,8 @@ public class CarpetScriptServer
 
     public boolean addRuleScriptHost(ServerCommandSource source, String name)
     {
+    	if (!worldInitialized)
+    		return false;
     	name = name.toLowerCase(Locale.ROOT);
         boolean reload = false;
         if (modules.containsKey(name))

--- a/src/main/java/carpet/script/utils/SystemInfo.java
+++ b/src/main/java/carpet/script/utils/SystemInfo.java
@@ -1,5 +1,6 @@
 package carpet.script.utils;
 
+import carpet.CarpetServer;
 import carpet.script.CarpetContext;
 import carpet.script.CarpetScriptHost;
 import carpet.script.value.ListValue;
@@ -7,11 +8,14 @@ import carpet.script.value.MapValue;
 import carpet.script.value.NumericValue;
 import carpet.script.value.StringValue;
 import carpet.script.value.Value;
+import carpet.settings.ParsedRule;
+import carpet.settings.SettingsManager;
 import com.sun.management.OperatingSystemMXBean;
 import net.minecraft.util.WorldSavePath;
 
 import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -101,6 +105,23 @@ public class SystemInfo {
             OperatingSystemMXBean osBean = ManagementFactory.getPlatformMXBean(
                     OperatingSystemMXBean.class);
             return new NumericValue(osBean.getProcessCpuLoad());
+        });
+        put("world_carpet_rules", c -> {
+        	Collection<ParsedRule<?>> rules = CarpetServer.settingsManager.getRules();
+        	MapValue carpetRules = new MapValue(Collections.emptyList());
+        	rules.forEach(rule -> {
+        		carpetRules.put(new StringValue(rule.name), new StringValue(rule.getAsString()));
+        	});
+        	CarpetServer.extensions.forEach(e -> {
+        		SettingsManager manager = e.customSettingsManager();
+        		if (manager == null) return;
+        		
+        		Collection<ParsedRule<?>> extensionRules = manager.getRules();
+        		extensionRules.forEach(rule -> {
+        			carpetRules.put(new StringValue(manager.getIdentifier()+":"+rule.name), new StringValue(rule.getAsString()));
+        		});
+        	});
+        	return carpetRules;
         });
 
 

--- a/src/main/java/carpet/script/utils/SystemInfo.java
+++ b/src/main/java/carpet/script/utils/SystemInfo.java
@@ -107,21 +107,21 @@ public class SystemInfo {
             return new NumericValue(osBean.getProcessCpuLoad());
         });
         put("world_carpet_rules", c -> {
-        	Collection<ParsedRule<?>> rules = CarpetServer.settingsManager.getRules();
-        	MapValue carpetRules = new MapValue(Collections.emptyList());
-        	rules.forEach(rule -> {
-        		carpetRules.put(new StringValue(rule.name), new StringValue(rule.getAsString()));
-        	});
-        	CarpetServer.extensions.forEach(e -> {
-        		SettingsManager manager = e.customSettingsManager();
-        		if (manager == null) return;
-        		
-        		Collection<ParsedRule<?>> extensionRules = manager.getRules();
-        		extensionRules.forEach(rule -> {
-        			carpetRules.put(new StringValue(manager.getIdentifier()+":"+rule.name), new StringValue(rule.getAsString()));
-        		});
-        	});
-        	return carpetRules;
+            Collection<ParsedRule<?>> rules = CarpetServer.settingsManager.getRules();
+            MapValue carpetRules = new MapValue(Collections.emptyList());
+            rules.forEach(rule -> {
+                carpetRules.put(new StringValue(rule.name), new StringValue(rule.getAsString()));
+            });
+            CarpetServer.extensions.forEach(e -> {
+                SettingsManager manager = e.customSettingsManager();
+                if (manager == null) return;
+                
+                Collection<ParsedRule<?>> extensionRules = manager.getRules();
+                extensionRules.forEach(rule -> {
+                    carpetRules.put(new StringValue(manager.getIdentifier()+":"+rule.name), new StringValue(rule.getAsString()));
+                });
+            });
+            return carpetRules;
         });
 
 

--- a/src/main/java/carpet/settings/ParsedRule.java
+++ b/src/main/java/carpet/settings/ParsedRule.java
@@ -71,8 +71,8 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
         }
         if (!scarpetApp.isEmpty())
         {
-        	this.hasScarpet = true;
-        	this.validators.add((Validator<T>) callConstructor(Validator._SCARPET.class));
+            this.hasScarpet = true;
+            this.validators.add((Validator<T>) callConstructor(Validator._SCARPET.class));
         }
         this.isClient = categories.contains(RuleCategory.CLIENT);
         if (this.isClient)

--- a/src/main/java/carpet/settings/ParsedRule.java
+++ b/src/main/java/carpet/settings/ParsedRule.java
@@ -10,8 +10,11 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import static carpet.utils.Translations.tr;
 
@@ -31,6 +34,17 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
     public final T defaultValue;
     public final String defaultAsString;
     public final SettingsManager settingsManager;
+    private static final Set<Class<?>> NUMBER_CLASSES;
+    static {
+        Set<Class<?>> s = new HashSet<>();
+        s.add(byte.class);
+        s.add(short.class);
+        s.add(int.class);
+        s.add(long.class);
+        s.add(float.class);
+        s.add(double.class);
+        NUMBER_CLASSES = Collections.unmodifiableSet(s);
+    }
 
     ParsedRule(Field field, Rule rule, SettingsManager settingsManager)
     {
@@ -197,7 +211,7 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
     public boolean getBoolValue()
     {
         if (type == boolean.class) return (Boolean) get();
-        if (type.isAssignableFrom(Number.class)) return ((Number) get()).doubleValue() > 0;
+        if (NUMBER_CLASSES.contains(type)) return ((Number) get()).doubleValue() > 0;
         return false;
     }
 

--- a/src/main/java/carpet/settings/ParsedRule.java
+++ b/src/main/java/carpet/settings/ParsedRule.java
@@ -5,15 +5,12 @@ import carpet.utils.Translations;
 import carpet.utils.Messenger;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
-
 import net.minecraft.server.command.ServerCommandSource;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;

--- a/src/main/java/carpet/settings/ParsedRule.java
+++ b/src/main/java/carpet/settings/ParsedRule.java
@@ -28,7 +28,6 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
     public final ImmutableList<String> options;
     public boolean isStrict;
     public boolean isClient;
-    public boolean hasScarpet;
     public final Class<T> type;
     public final List<Validator<T>> validators;
     public final T defaultValue;
@@ -71,7 +70,6 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
         }
         if (!scarpetApp.isEmpty())
         {
-            this.hasScarpet = true;
             this.validators.add((Validator<T>) callConstructor(Validator._SCARPET.class));
         }
         this.isClient = categories.contains(RuleCategory.CLIENT);

--- a/src/main/java/carpet/settings/ParsedRule.java
+++ b/src/main/java/carpet/settings/ParsedRule.java
@@ -30,8 +30,9 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
     public final List<Validator<T>> validators;
     public final T defaultValue;
     public final String defaultAsString;
+    public final SettingsManager settingsManager;
 
-    ParsedRule(Field field, Rule rule)
+    ParsedRule(Field field, Rule rule, SettingsManager settingsManager)
     {
         this.field = field;
         this.name = rule.name().isEmpty() ? field.getName() : rule.name();
@@ -41,6 +42,7 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
         this.extraInfo = ImmutableList.copyOf(rule.extra());
         this.categories = ImmutableList.copyOf(rule.category());
         this.scarpetApp = rule.scarpetApp();
+        this.settingsManager = settingsManager;
         this.validators = new ArrayList<>();
         for (Class v : rule.validate())
             this.validators.add((Validator<T>) callConstructor(v));
@@ -113,7 +115,7 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
 
     public ParsedRule<T> set(ServerCommandSource source, String value)
     {
-        if (CarpetServer.settingsManager != null && CarpetServer.settingsManager.locked)
+        if (settingsManager != null && settingsManager.locked)
             return null;
         if (type == String.class)
         {
@@ -164,7 +166,7 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
             if (!value.equals(get()) || source == null)
             {
                 this.field.set(null, value);
-                if (source != null) CarpetServer.settingsManager.notifyRuleChanged(source, this, stringValue);
+                if (source != null) settingsManager.notifyRuleChanged(source, this, stringValue);
             }
         }
         catch (IllegalAccessException e)

--- a/src/main/java/carpet/settings/ParsedRule.java
+++ b/src/main/java/carpet/settings/ParsedRule.java
@@ -53,7 +53,11 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
                 this.validators.add((Validator<T>) callConstructor(Validator._COMMAND_LEVEL_VALIDATOR.class));
             }
         }
-        this.hasScarpet = !scarpetApp.isEmpty();
+        if (!scarpetApp.isEmpty())
+        {
+        	this.hasScarpet = true;
+        	this.validators.add((Validator<T>) callConstructor(Validator._SCARPET.class));
+        }
         this.isClient = categories.contains(RuleCategory.CLIENT);
         if (this.isClient)
         {

--- a/src/main/java/carpet/settings/ParsedRule.java
+++ b/src/main/java/carpet/settings/ParsedRule.java
@@ -19,11 +19,13 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
     public final Field field;
     public final String name;
     public final String description;
+    public final String scarpetApp;
     public final ImmutableList<String> extraInfo;
     public final ImmutableList<String> categories;
     public final ImmutableList<String> options;
     public boolean isStrict;
     public boolean isClient;
+    public boolean hasScarpet;
     public final Class<T> type;
     public final List<Validator<T>> validators;
     public final T defaultValue;
@@ -38,6 +40,7 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
         this.isStrict = rule.strict();
         this.extraInfo = ImmutableList.copyOf(rule.extra());
         this.categories = ImmutableList.copyOf(rule.category());
+        this.scarpetApp = rule.scarpetApp();
         this.validators = new ArrayList<>();
         for (Class v : rule.validate())
             this.validators.add((Validator<T>) callConstructor(v));
@@ -50,6 +53,7 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
                 this.validators.add((Validator<T>) callConstructor(Validator._COMMAND_LEVEL_VALIDATOR.class));
             }
         }
+        this.hasScarpet = !scarpetApp.isEmpty();
         this.isClient = categories.contains(RuleCategory.CLIENT);
         if (this.isClient)
         {

--- a/src/main/java/carpet/settings/ParsedRule.java
+++ b/src/main/java/carpet/settings/ParsedRule.java
@@ -4,6 +4,8 @@ import carpet.CarpetServer;
 import carpet.utils.Translations;
 import carpet.utils.Messenger;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+
 import net.minecraft.server.command.ServerCommandSource;
 
 import java.lang.reflect.Constructor;
@@ -33,17 +35,7 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
     public final T defaultValue;
     public final String defaultAsString;
     public final SettingsManager settingsManager;
-    private static final Set<Class<?>> NUMBER_CLASSES;
-    static {
-        Set<Class<?>> s = new HashSet<>();
-        s.add(byte.class);
-        s.add(short.class);
-        s.add(int.class);
-        s.add(long.class);
-        s.add(float.class);
-        s.add(double.class);
-        NUMBER_CLASSES = Collections.unmodifiableSet(s);
-    }
+    private static final Set<Class<?>> NUMBER_CLASSES = Sets.newHashSet(byte.class, short.class, int.class, long.class, float.class, double.class);
 
     ParsedRule(Field field, Rule rule, SettingsManager settingsManager)
     {

--- a/src/main/java/carpet/settings/Rule.java
+++ b/src/main/java/carpet/settings/Rule.java
@@ -52,11 +52,9 @@ public @interface Rule
      */
     boolean strict() default true;
     
-    
     /**
-     * If specified, a rule will be connected with the 
-     * builtin Scarpet app with that name.
-     * 
+     * If specified, the rule will automatically enable or disable 
+     * a builtin Scarpet Rule App with this name.
      */
     String scarpetApp() default "";
 

--- a/src/main/java/carpet/settings/Rule.java
+++ b/src/main/java/carpet/settings/Rule.java
@@ -51,6 +51,8 @@ public @interface Rule
      * For enums, its always strict, same for booleans - no need to set that for them.
      */
     boolean strict() default true;
+    
+    String scarpet() default "";
 
     /**
      * The class of the validator checked when the rule is changed.

--- a/src/main/java/carpet/settings/Rule.java
+++ b/src/main/java/carpet/settings/Rule.java
@@ -56,6 +56,7 @@ public @interface Rule
      * If specified, the rule will automatically enable or disable 
      * a builtin Scarpet Rule App with this name.
      * Consider telling the rule name so users can edit globals
+     * (in case there are relevant globals to edit ofc)
      */
     String scarpetApp() default "";
 

--- a/src/main/java/carpet/settings/Rule.java
+++ b/src/main/java/carpet/settings/Rule.java
@@ -55,6 +55,7 @@ public @interface Rule
     /**
      * If specified, the rule will automatically enable or disable 
      * a builtin Scarpet Rule App with this name.
+     * Consider telling the rule name so users can edit globals
      */
     String scarpetApp() default "";
 

--- a/src/main/java/carpet/settings/Rule.java
+++ b/src/main/java/carpet/settings/Rule.java
@@ -52,7 +52,13 @@ public @interface Rule
      */
     boolean strict() default true;
     
-    String scarpet() default "";
+    
+    /**
+     * If specified, a rule will be connected with the 
+     * builtin Scarpet app with that name.
+     * 
+     */
+    String scarpetApp() default "";
 
     /**
      * The class of the validator checked when the rule is changed.

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -109,15 +109,24 @@ public class SettingsManager
     
     void switchScarpetRule(ServerCommandSource source, ParsedRule<?> rule)
     {
-    	if(rule.hasScarpet)
+    	if (rule.hasScarpet)
     	{
-    		if(rule.get().equals(true))
+    		if (rule.get().equals(true))
     		{
     			CarpetServer.scriptServer.addRuleScriptHost(source, rule.scarpetApp);
     		} else {
     			CarpetServer.scriptServer.removeScriptHost(source, rule.scarpetApp, false);
     		}
     	}
+    }
+    
+    public void initializeScarpetRules(ServerCommandSource source) {
+    	for (ParsedRule<?> rule : rules.values())
+        {
+            if (rule.hasScarpet) {
+                switchScarpetRule(source, rule);
+            }
+        }
     }
 
     public Iterable<String> getCategories()

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -125,11 +125,11 @@ public class SettingsManager
     	}
     }
     
-    public void initializeScarpetRules(ServerCommandSource source) {
+    public void initializeScarpetRules() {
     	for (ParsedRule<?> rule : rules.values())
         {
             if (rule.hasScarpet) {
-                switchScarpetRule(source, rule);
+                switchScarpetRule(server.getCommandSource(), rule);
             }
         }
     }

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -111,7 +111,7 @@ public class SettingsManager
     {
     	if(rule.hasScarpet)
     	{
-    		if(rule.field.equals(true))
+    		if(rule.get().equals(true))
     		{
     			CarpetServer.scriptServer.addRuleScriptHost(source, rule.scarpetApp);
     		} else {

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -114,7 +114,7 @@ public class SettingsManager
     
     void switchScarpetRule(ServerCommandSource source, ParsedRule<?> rule)
     {
-        if (rule.hasScarpet)
+        if (!rule.scarpetApp.isEmpty())
         {
             if (rule.getBoolValue() || (rule.type == String.class && !rule.get().equals("false")))
             {
@@ -128,7 +128,7 @@ public class SettingsManager
     public void initializeScarpetRules() {
         for (ParsedRule<?> rule : rules.values())
         {
-            if (rule.hasScarpet) {
+            if (!rule.scarpetApp.isEmpty()) {
                 switchScarpetRule(server.getCommandSource(), rule);
             }
         }

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -113,7 +113,7 @@ public class SettingsManager
     	{
     		if (rule.get().equals(true))
     		{
-    			CarpetServer.scriptServer.addRuleScriptHost(source, rule.scarpetApp);
+    			CarpetServer.scriptServer.addScriptHost(source, rule.scarpetApp, false, false, true);
     		} else {
     			CarpetServer.scriptServer.removeScriptHost(source, rule.scarpetApp, false);
     		}

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -104,6 +104,20 @@ public class SettingsManager
     {
         observers.forEach(observer -> observer.accept(source, rule, userTypedValue));
         ServerNetworkHandler.updateRuleWithConnectedClients(rule);
+        switchScarpetRule(source, rule);
+    }
+    
+    void switchScarpetRule(ServerCommandSource source, ParsedRule<?> rule)
+    {
+    	if(rule.hasScarpet)
+    	{
+    		if(rule.field.equals(true))
+    		{
+    			CarpetServer.scriptServer.addRuleScriptHost(source, rule.scarpetApp);
+    		} else {
+    			CarpetServer.scriptServer.removeScriptHost(source, rule.scarpetApp, false);
+    		}
+    	}
     }
 
     public Iterable<String> getCategories()

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -120,7 +120,7 @@ public class SettingsManager
     		{
     			CarpetServer.scriptServer.addScriptHost(source, rule.scarpetApp, false, false, true);
     		} else {
-    			CarpetServer.scriptServer.removeScriptHost(source, rule.scarpetApp, false);
+    			CarpetServer.scriptServer.removeScriptHost(source, rule.scarpetApp, false, true);
     		}
     	}
     }

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -111,7 +111,7 @@ public class SettingsManager
     {
     	if (rule.hasScarpet)
     	{
-    		if (rule.get().equals(true))
+    		if (rule.getBoolValue() || (rule.field.getType() == String.class && !rule.get().equals("false")))
     		{
     			CarpetServer.scriptServer.addScriptHost(source, rule.scarpetApp, false, false, true);
     		} else {

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -43,6 +43,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import static carpet.utils.Translations.tr;
+import static carpet.script.CarpetEventServer.Event.CARPET_RULE_CHANGE;
 import static net.minecraft.command.CommandSource.suggestMatching;
 import static net.minecraft.server.command.CommandManager.argument;
 import static net.minecraft.server.command.CommandManager.literal;
@@ -93,7 +94,7 @@ public class SettingsManager
         {
             Rule rule = f.getAnnotation(Rule.class);
             if (rule == null) continue;
-            ParsedRule parsed = new ParsedRule(f, rule);
+            ParsedRule parsed = new ParsedRule(f, rule, this);
             rules.put(parsed.name, parsed);
         }
     }
@@ -108,6 +109,7 @@ public class SettingsManager
         observers.forEach(observer -> observer.accept(source, rule, userTypedValue));
         ServerNetworkHandler.updateRuleWithConnectedClients(rule);
         switchScarpetRule(source, rule);
+        CARPET_RULE_CHANGE.onCarpetRuleChange(rule, source);
     }
     
     void switchScarpetRule(ServerCommandSource source, ParsedRule<?> rule)

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -71,7 +71,10 @@ public class SettingsManager
         this.fancyName = fancyName;
     }
 
-
+    public String getIdentifier() {
+		return identifier;
+	}
+    
     public void attachServer(MinecraftServer server)
     {
         this.server = server;

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -43,7 +43,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import static carpet.utils.Translations.tr;
-import static carpet.script.CarpetEventServer.Event.CARPET_RULE_CHANGE;
+import static carpet.script.CarpetEventServer.Event.CARPET_RULE_CHANGES;
 import static net.minecraft.command.CommandSource.suggestMatching;
 import static net.minecraft.server.command.CommandManager.argument;
 import static net.minecraft.server.command.CommandManager.literal;
@@ -73,8 +73,8 @@ public class SettingsManager
     }
 
     public String getIdentifier() {
-		return identifier;
-	}
+        return identifier;
+    }
     
     public void attachServer(MinecraftServer server)
     {
@@ -109,24 +109,24 @@ public class SettingsManager
         observers.forEach(observer -> observer.accept(source, rule, userTypedValue));
         ServerNetworkHandler.updateRuleWithConnectedClients(rule);
         switchScarpetRule(source, rule);
-        CARPET_RULE_CHANGE.onCarpetRuleChange(rule, source);
+        CARPET_RULE_CHANGES.onCarpetRuleChanges(rule, source);
     }
     
     void switchScarpetRule(ServerCommandSource source, ParsedRule<?> rule)
     {
-    	if (rule.hasScarpet)
-    	{
-    		if (rule.getBoolValue() || (rule.type == String.class && !rule.get().equals("false")))
-    		{
-    			CarpetServer.scriptServer.addScriptHost(source, rule.scarpetApp, false, false, true);
-    		} else {
-    			CarpetServer.scriptServer.removeScriptHost(source, rule.scarpetApp, false, true);
-    		}
-    	}
+        if (rule.hasScarpet)
+        {
+            if (rule.getBoolValue() || (rule.type == String.class && !rule.get().equals("false")))
+            {
+                CarpetServer.scriptServer.addScriptHost(source, rule.scarpetApp, false, false, true);
+            } else {
+                CarpetServer.scriptServer.removeScriptHost(source, rule.scarpetApp, false, true);
+            }
+        }
     }
     
     public void initializeScarpetRules() {
-    	for (ParsedRule<?> rule : rules.values())
+        for (ParsedRule<?> rule : rules.values())
         {
             if (rule.hasScarpet) {
                 switchScarpetRule(server.getCommandSource(), rule);

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -116,7 +116,7 @@ public class SettingsManager
     {
     	if (rule.hasScarpet)
     	{
-    		if (rule.getBoolValue() || (rule.field.getType() == String.class && !rule.get().equals("false")))
+    		if (rule.getBoolValue() || (rule.type == String.class && !rule.get().equals("false")))
     		{
     			CarpetServer.scriptServer.addScriptHost(source, rule.scarpetApp, false, false, true);
     		} else {

--- a/src/main/java/carpet/settings/Validator.java
+++ b/src/main/java/carpet/settings/Validator.java
@@ -59,14 +59,14 @@ public abstract class Validator<T>
     }
     
     public static class _SCARPET<T> extends Validator<T> {
-    	@Override
+        @Override
         public T validate(ServerCommandSource source, ParsedRule<T> currentRule, T newValue, String string)
         {
             return newValue;
         }
-    	public String description() {
-    		return "It controls an accompanying Scarpet App";
-    	}
+        public String description() {
+            return "It controls an accompanying Scarpet App";
+        }
     }
 
     public static class WIP<T> extends Validator<T>

--- a/src/main/java/carpet/settings/Validator.java
+++ b/src/main/java/carpet/settings/Validator.java
@@ -57,6 +57,17 @@ public abstract class Validator<T>
         }
         public String description() { return "Can be limited to 'ops' only, or a custom permission level";}
     }
+    
+    public static class _SCARPET<T> extends Validator<T> {
+    	@Override
+        public T validate(ServerCommandSource source, ParsedRule<T> currentRule, T newValue, String string)
+        {
+            return newValue;
+        }
+    	public String description() {
+    		return "It controls an accompanying Scarpet App";
+    	}
+    }
 
     public static class WIP<T> extends Validator<T>
     {


### PR DESCRIPTION
This PR adds the ability to define Scarpet apps in the `@Rule` annotation, and those will be enabled when the rule is enabled, and obviously disabled when disabled. This opens possibilities like replacing current Carpet rules or commands (like in #518) without the "hassle" for the user to change from rule to app, etc. It also mantains backwards compatibility with the rules users had before the change, allows to have both Java coded and Scarpet coded content in the same rule, and of course this also gets printed into the list of Current Available Settings and can be easily found in the `/carpet` command.

Extensions should also be able to register their own "Scarpet rules".

Working vs not working things:

- [x] Basic functionality: Rules load and unload apps when changed on the fly
- [x] Commands from Scarpet Rules are registered (when rule is edited on the fly)
- [x] Make sure apps and commands work from setDefaults (~~currently they don't register, probably called too early~~)
- [x] Check if rule boolean defaulting to true would load the script (~~currently it relies on the `set()` method, so if it doesn't get called with defaults the apps won't be loaded~~ now startup is deferred. It works)
- [x] Check that rule boolean defaulting to true wouldn't crash everything because of trying to load an app while unloading (~~`set()` is called to reset defaults if I recall correctly, and that is called on unload~~ it doesn't, and the CarpetScriptServer is killed anyways)
- [x] Test Scarpet events: They work correctly, according to `event_test`
- [x] Remove the app loaded message from Scarpet Rules (with something like what already exists in the unload function)
- [x] Get Scarpet rule's apps out of the unload command (the unload command reads `scriptServer.modules`, which contains them since loaded rule apps aren't separated in ScriptServer. Moving them out of there makes them not editable from `/script`, removing some of their versatility)
- [x] Maybe accept non-boolean rules to allow saving and editing some behaviour changes easily (like `int > 0` -> app loaded, then in app check that int, or even `string != "false"`, world of customization)
- [x] Add something like #520 to make previous point more useful and check command perms (Resolves #520)
- [x] Check compatibility with Command category (since it changes things): Should be compatible once strings are supported (would require a way to read rule value to fully work)

Feel free to suggest more points, give feedback and/or help with some. ~~Until now, I've only tested this with the overlay app and event_test as rules.~~ I've basically tested every built-in app at this point.

Extra:
- Fixes #525: Now changing a rule will call the appropriate code from the SettingsManager that registered the rule instead of always calling Carpet's. That means rule observers will also be separated from each manager, so in order to register an observer for all extensions the extension should register their observers at each extension's SettingsManager (probably never going to happen anyway).