### PR TITLE
[Actions] Only run mergedocs in master

### DIFF
--- a/.github/workflows/merge-docs.yml
+++ b/.github/workflows/merge-docs.yml
@@ -1,6 +1,8 @@
 name: Merge docs
 on:
   push:
+    branches: 
+      - master
     paths:
     - "docs/**"
     - "!docs/scarpet/Full.md"


### PR DESCRIPTION
This is to minify conflicts when merging PRs, I didn't think that PRs can come from main repo.