### PR TITLE
Sync extension's custom SettingsManager's rules

### DIFF
--- a/src/main/java/carpet/network/ClientNetworkHandler.java
+++ b/src/main/java/carpet/network/ClientNetworkHandler.java
@@ -35,7 +35,7 @@ public class ClientNetworkHandler
                 {
                     ruleName = ruleNBT.getString("Rule");
                     String managerName = ruleNBT.getString("Manager");
-                    if (managerName == "carpet")
+                    if (managerName.equals("carpet"))
                     {
                         manager = CarpetServer.settingsManager;
                     }

--- a/src/main/java/carpet/network/ClientNetworkHandler.java
+++ b/src/main/java/carpet/network/ClientNetworkHandler.java
@@ -28,30 +28,30 @@ public class ClientNetworkHandler
             CompoundTag ruleset = (CompoundTag)t;
             for (String fullRuleName: ruleset.getKeys())
             {
-            	int separatorPos = fullRuleName.indexOf(':');
-            	SettingsManager manager = null;
-            	String ruleName;
-            	if (separatorPos > -1)
-            	{
-            		String identifier = fullRuleName.substring(0,separatorPos);
-                	ruleName = fullRuleName.substring(separatorPos + 1);
-                	for (CarpetExtension extension:CarpetServer.extensions) {
-                		SettingsManager eManager = extension.customSettingsManager();
-                		if (eManager != null && identifier.equals(eManager.getIdentifier()))
-                		{
-                			manager = eManager;
-                			break;
-                		}
-                	}
-            	}
-            	else
-            	{
-            		ruleName = fullRuleName;
-            		manager = CarpetServer.settingsManager;
-            	}
+                int separatorPos = fullRuleName.indexOf(':');
+                SettingsManager manager = null;
+                String ruleName;
+                if (separatorPos > -1)
+                {
+                    String identifier = fullRuleName.substring(0, separatorPos);
+                    ruleName = fullRuleName.substring(separatorPos + 1);
+                    for (CarpetExtension extension: CarpetServer.extensions) {
+                        SettingsManager eManager = extension.customSettingsManager();
+                        if (eManager != null && identifier.equals(eManager.getIdentifier()))
+                        {
+                            manager = eManager;
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    ruleName = fullRuleName;
+                    manager = CarpetServer.settingsManager;
+                }
                 ParsedRule<?> rule = (manager != null) ? manager.getRule(ruleName) : null;
                 if (rule == null)
-                    CarpetSettings.LOG.error("Received unknown rule: "+fullRuleName);
+                    CarpetSettings.LOG.error("Received unknown rule: " + fullRuleName);
                 else
                 {
                     CompoundTag ruleNBT = (CompoundTag) ruleset.get(fullRuleName);

--- a/src/main/java/carpet/network/ServerNetworkHandler.java
+++ b/src/main/java/carpet/network/ServerNetworkHandler.java
@@ -80,10 +80,10 @@ public class ServerNetworkHandler
         DataBuilder data = DataBuilder.create().withTickRate();
         CarpetServer.settingsManager.getRules().forEach(data::withRule);
         CarpetServer.extensions.forEach(e -> {
-        	SettingsManager eManager = e.customSettingsManager();
-        	if (eManager != null) {
-        		eManager.getRules().forEach(data::withRule);
-        	}
+            SettingsManager eManager = e.customSettingsManager();
+            if (eManager != null) {
+                eManager.getRules().forEach(data::withRule);
+            }
         });
         playerEntity.networkHandler.sendPacket(new CustomPayloadS2CPacket(CarpetClient.CARPET_CHANNEL, data.build() ));
     }

--- a/src/main/java/carpet/network/ServerNetworkHandler.java
+++ b/src/main/java/carpet/network/ServerNetworkHandler.java
@@ -241,10 +241,14 @@ public class ServerNetworkHandler
                 rules = new CompoundTag();
                 tag.put("Rules", rules);
             }
-            String identifier = (rule.settingsManager != CarpetServer.settingsManager) ? rule.settingsManager.getIdentifier()+":" : "";
+            String identifier = rule.settingsManager.getIdentifier();
+            String key = rule.name;
+            while (rules.contains(key)) { key = key+"2";}
             CompoundTag ruleNBT = new CompoundTag();
             ruleNBT.putString("Value", rule.getAsString());
-            rules.put(identifier+rule.name, ruleNBT);
+            ruleNBT.putString("Manager",identifier);
+            ruleNBT.putString("Rule",rule.name);
+            rules.put(key, ruleNBT);
             return this;
         }
 


### PR DESCRIPTION
Actually fixes #546.

As I commented in that issue, rules from extension's custom `SettingsManager`s aren't synchronized with clients, they are only sent when changing a rule (as a product of calling the same method), but the client doesn't know where to place them since it only looks for the rule in Carpet's `SettingsManager`. That issue was incorrectly closed after a PR that touched a similar subject: client-side-only rules. But it wasn't fixed yet.

~This fix consists in looping through extension's custom SettingsManager's too when sending rules, and adding a namespace to them (`identifier:rule`), so the client can know where to place them. Carpet's own rules are sent without namespace to allow backwards compatibility (the client assumes a rule without namespace is from Carpet's `SettingsManager`. That also means that the "error" message when receiving unknown rules will also send the identifier, and will allow users to know where does it come from.~

This fix now consists, as suggested, in adding a `Manager` key into the rule NBT map, along with setting the rule name into its own `Rule` key instead of only relying on the external key name (that allows for rules with same names in different managers, by appending a number to it if it's already present). For backwards compatibility, this requires some extra code (as opposed to the previous solution), since clients connected to old server would not be able to find any `Manager` or `Rule` keys, so we check for one of those, and if it's not present, we fallback to using Carpet's manager with the map's name as rule name.

I also changed the way the handler map is initialized to be in a static block instead of a subclass of the HashMap (did it while testing and forgot to change it, doesn't hurt, can revert if you want).

Tested and working:
- [x] Server with extensions, client without them
- [x] Client with extensions, server without them
- [x] Both with extensions
- [x] Both without extensions
- [x] Old server, new client
- [x] Old server, new client with extensions

This PR is ready to merge (except if you request changes ofc) and doesn't conflict with anything in Carpet. However, some external extensions do have conflicts (because they didn't expect the rules to be synced/the `source` to be `null`). Those bugs only exist when both server and client have this updated Carpet version.

Those issues are tracked in the following issues, if you prefer waiting for them to fix their issues before merging:
- [ ] Skyblock: skyrising/skyblock#23 (assigned, simple fix, bug is NPE kicking player)
- [x] ~Carpet-Discarpet: replaceitem/carpet-discarpet#3 (with PR fixing it at replaceitem/carpet-discarpet#4, privacy thing)~ Fixed

I will update this checklist when those get fixed.

------

Sorry about 2 commits, I swear I changed my IDE config to use spaces.