### PR TITLE
Fix scarpet modify(e, 'effect', ...)

### DIFF
--- a/docs/scarpet/api/Entities.md
+++ b/docs/scarpet/api/Entities.md
@@ -641,10 +641,10 @@ If called with `false` value, it will disable AI in the mob. `true` will enable 
 Sets if the entity obeys any collisions, including collisions with the terrain and basic physics. Not affecting 
 players, since they are controlled client side.
 
-### `modify(e, 'effect', name?, duration?, amplifier?, show_particles?, show_icon?)`
+### `modify(e, 'effect', name?, duration?, amplifier?, show_particles?, show_icon?, ambient?)`
 
-Applies status effect to the living entity. Takes several optional parameters, which default to `0`, `true` 
-and `true`. If no duration is specified, or if it's null or 0, the effect is removed. If name is not specified,
+Applies status effect to the living entity. Takes several optional parameters, which default to `0`, `true`, 
+`true` and `false`. If no duration is specified, or if it's null or 0, the effect is removed. If name is not specified,
 it clears all effects.
 
 ### `modify(e, 'home', null), modify(e, 'home', block, distance?), modify(e, 'home', x, y, z, distance?)`

--- a/src/main/java/carpet/script/value/EntityValue.java
+++ b/src/main/java/carpet/script/value/EntityValue.java
@@ -1256,7 +1256,10 @@ public class EntityValue extends Value
                     boolean showIcon = true;
                     if (lv.size() > 4)
                         showIcon = lv.get(4).getBoolean();
-                    le.addStatusEffect(new StatusEffectInstance(effect, duration, amplifier, showParticles, showIcon));
+                    boolean ambient = false;
+                    if (lv.size() > 5)
+                        showIcon = lv.get(5).getBoolean();
+                    le.addStatusEffect(new StatusEffectInstance(effect, duration, amplifier, ambient, showParticles, showIcon));
                     return;
                 }
             }
@@ -1269,7 +1272,7 @@ public class EntityValue extends Value
                 le.removeStatusEffect(effect);
                 return;
             }
-            throw new InternalExpressionException("'effect' needs either no arguments (clear) or effect name, duration, and optional amplifier, show particles and show icon");
+            throw new InternalExpressionException("'effect' needs either no arguments (clear) or effect name, duration, and optional amplifier, show particles, show icon and ambient");
         });
 
         put("gamemode", (e,v)->{


### PR DESCRIPTION
The fourth parameter (before showParticles and showIcon) of StatusEffectInstance must be 'ambient' (which makes beacon effects less intrusive).