### PR TITLE
Allow loading apps from a global path

### DIFF
--- a/docs/scarpet/api/Overview.md
+++ b/docs/scarpet/api/Overview.md
@@ -6,7 +6,8 @@ Here is the gist of the Minecraft related functions. Otherwise the CarpetScript 
 ## App structure
 
 The main delivery method for scarpet programs into the game is in the form of apps in `*.sc` files located in the world `scripts` 
-folder. When loaded (via `/script load` command, etc.), the game will run the content of the app once, regardless of its scope
+folder. In singleplayer, you can also save apps in `.minecraft/config/carpet/scripts` for them to be available in any world. 
+When loaded (via `/script load` command, etc.), the game will run the content of the app once, regardless of its scope
 (more about the app scopes below), without executing of any functions, unless called directly, and with the exception of the
 `__config()` function, if present, which will be executed once. Loading the app will also bind specific 
 events to the event system (check Events section for details).
@@ -40,7 +41,7 @@ running anything in the global scope for a `'player'` scoped app is not recommen
 stay loaded after startup. Otherwise, after reading the app the first time, and fetching the config, server will drop them down. 
 This is to allow to store multiple apps on the server/world and selectively decide which one should be running at 
 startup. WARNING: all apps will run once at startup anyways, so be aware that their actions that are called 
-statically, will be performed once anyways.
+statically, will be performed once anyways. Only apps present in the world's `scripts` folder will be autoloaded.
 *   `'legacy_command_type_support'` - if `true`, and the app defines the legacy command system via `__command()` function,
 all parameters of command functions will be interpreted and used using brigadier / vanilla style argument parser and their type
 will be inferred from their names, otherwise

--- a/docs/scarpet/api/ScriptCommand.md
+++ b/docs/scarpet/api/ScriptCommand.md
@@ -8,13 +8,15 @@ to simulate running commands in a different scope.
 
 # `/script load / unload <app> (global?)`, `/script in <app>` commands
 
-`load / unload` commands allow for very conventient way of writing your code, providing it to the game and 
-distribute with your worlds without the need of use of commandblocks. Just place your scarpet code in the 
-/scripts folder of your world files and make sure it ends with `.sc` extension. The good thing about editing that 
-code is that you can no only use normal editing without the need of marking of newlines, 
+`load / unload` commands allow for very convenient way of writing your code, providing it to the game and 
+distribute with your worlds without the need of use of commandblocks. Just place your Scarpet code in the 
+`/scripts` folder of your world files and make sure it ends with `.sc` extension. In singleplayer, you can 
+also save your scripts in `.minecraft/config/carpet/scripts` to make them available in any world.
+
+The good thing about editing that code is that you can not only use normal editing without the need of marking of newlines,  
 but you can also use comments in your code.
 
-a comment is anything that starts with a double slash, and continues to the end of the line:
+A comment is anything that starts with a double slash, and continues to the end of the line:
 
 <pre>
 foo = 1;

--- a/docs/scarpet/language/Overview.md
+++ b/docs/scarpet/language/Overview.md
@@ -151,9 +151,10 @@ have memory and act like objects so to speak. Check `outer(var)` for details.
 ## Code delivery, line indicators
 
 Note that this should only apply to pasting your code to execute with commandblock. Scarpet recommends placing 
-your code in apps (files with `.sc` extension that can be placed inside "/scripts" folder in the world files and 
-loaded as a scarpet app with command `/script load [app_name]`. Scarpet apps loaded from disk should only 
-contain code, no need to start with "/script run" prefix
+your code in apps (files with `.sc` extension that can be placed inside `/scripts` folder in the world files 
+or as a globally available app in singleplayer in the `.minecraft/config/carpet/scripts` folder and loaded 
+as a Scarpet app with the command `/script load [app_name]`. Scarpet apps loaded from disk should only 
+contain code, no need to start with `/script run` prefix.
 
 The following is the code that could be provided in a `foo.sc` app file located in world `/scripts` folder
 

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -16,19 +16,24 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.CommandNode;
+
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.WorldSavePath;
 import net.minecraft.util.math.BlockPos;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -127,20 +132,30 @@ public class CarpetScriptServer
 
     public Module getModule(String name, boolean allowLibraries)
     {
-        File folder = server.getSavePath(WorldSavePath.ROOT).resolve("scripts").toFile();
-        File[] listOfFiles = folder.listFiles();
-        if (listOfFiles != null)
-            for (File script : listOfFiles)
-            {
-                if (script.getName().equalsIgnoreCase(name+".sc"))
-                {
-                    return new FileModule(script);
-                }
-                if (allowLibraries && script.getName().equalsIgnoreCase(name+".scl"))
-                {
-                    return new FileModule(script);
-                }
-            }
+        try {
+            Path folder = server.getSavePath(WorldSavePath.ROOT).resolve("scripts");
+            Files.createDirectories(folder);
+            Optional<Path>
+            scriptPath = Files.walk(folder)
+                .filter(script -> 
+                    script.getFileName().toString().equalsIgnoreCase(name+".sc") || 
+                    (allowLibraries && script.getFileName().toString().equalsIgnoreCase(name+".scl"))
+                ).findFirst();
+            if (scriptPath.isPresent())
+                return new FileModule(scriptPath.get());
+            
+            Path globalFolder = FabricLoader.getInstance().getConfigDir().resolve("carpet/scripts");
+            Files.createDirectories(globalFolder);
+            scriptPath = Files.walk(globalFolder)
+                .filter(script -> 
+                    script.getFileName().toString().equalsIgnoreCase(name+".sc") || 
+                    (allowLibraries && script.getFileName().toString().equalsIgnoreCase(name+".scl"))
+                ).findFirst();
+            if (scriptPath.isPresent())
+                return new FileModule(scriptPath.get());
+        } catch (IOException e) {
+            CarpetSettings.LOG.error("Exception while loading the app: ", e);
+        }
         for (Module moduleData : bundledModuleData)
         {
             if (moduleData.getName().equalsIgnoreCase(name) && (allowLibraries || !moduleData.isLibrary()))
@@ -173,17 +188,23 @@ public class CarpetScriptServer
                 if (!mi.isLibrary() && !mi.getName().endsWith("_beta")) moduleNames.add(mi.getName());
             }
         }
-        File folder = server.getSavePath(WorldSavePath.ROOT).resolve("scripts").toFile();
-        File[] listOfFiles = folder.listFiles();
-        if (listOfFiles == null)
-            return moduleNames;
-        for (File script : listOfFiles)
-        {
-            if (script.getName().endsWith(".sc"))
+        try {
+            Path worldScripts = server.getSavePath(WorldSavePath.ROOT).resolve("scripts");
+            Files.createDirectories(worldScripts);
+            Files.walk(worldScripts)
+                .filter(f -> f.toString().endsWith(".sc"))
+                .forEach(f -> moduleNames.add(f.getFileName().toString().replaceFirst("\\.sc","").toLowerCase(Locale.ROOT)));
+
+            if (includeBuiltIns)
             {
-                String name = script.getName().replaceFirst("\\.sc","").toLowerCase(Locale.ROOT);
-                moduleNames.add(name);
+                Path globalScripts = FabricLoader.getInstance().getConfigDir().resolve("carpet/scripts");
+                Files.createDirectories(globalScripts);
+                Files.walk(globalScripts)
+                    .filter(f -> f.toString().endsWith(".sc"))
+                    .forEach(f -> moduleNames.add(f.getFileName().toString().replaceFirst("\\.sc","").toLowerCase(Locale.ROOT)));
             }
+        } catch (IOException e) {
+            CarpetSettings.LOG.error("Exception while searching for apps: ", e);
         }
         return moduleNames;
     }

--- a/src/main/java/carpet/script/bundled/FileModule.java
+++ b/src/main/java/carpet/script/bundled/FileModule.java
@@ -16,6 +16,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,13 +27,13 @@ public class FileModule extends Module
     private String name;
     private String code;
     private boolean library;
-    public FileModule(File sourceFile)
+    public FileModule(Path sourcePath)
     {
-        library = sourceFile.getName().endsWith(".scl");
+        library = sourcePath.getFileName().toString().endsWith(".scl");
         try
         {
-            name = sourceFile.getName().replaceFirst("\\.scl?","").toLowerCase(Locale.ROOT);
-            code = new String(Files.readAllBytes(sourceFile.toPath()), StandardCharsets.UTF_8);
+            name = sourcePath.getFileName().toString().replaceFirst("\\.scl?","").toLowerCase(Locale.ROOT);
+            code = new String(Files.readAllBytes(sourcePath), StandardCharsets.UTF_8);
         }
         catch ( IOException e)
         {


### PR DESCRIPTION
This is an implementation that would resolve #577.

It works as defined in https://github.com/gnembon/fabric-carpet/issues/577#issuecomment-735025354 (global scripts would basically be stored at `[root]/config/carpet/scripts`, root being either `.minecraft` or the server's root).

I've also taken the time to change some things (can revert if you want), basically changing `File` -> `Path` everywhere related to this (that is, in `listAvailableModules`, `getModule` and `FileModule`). Therefore, it instead uses Streams to do the work of finding the appropriate script or to list those. Did this because many of those methods already start with a `Path` that they convert to a `File`, require a `Path` that they convert from a `File` or even do both steps. And because you introduced me into the magic of Streams.

This implementation would automatically create the `[root]/config/carpet/scripts` and `[world]/scripts` folders automatically when being called (that is, either when searching for an app under `/script load` or when loading a world with `scriptsAutoload`). Since using either of those usually means you would like to use Scarpet in that world, I think it would be ok to create them (makes them discoverable and user was probably already searching for them), but if you want I can change it in order to not create them (by wrapping it into `if(Files.exists(path))`, maybe for the global one at least on servers).