### PR TITLE
Adding convert_date and unix_time to docs

### DIFF
--- a/docs/scarpet/resources/editors/idea/2.txt
+++ b/docs/scarpet/resources/editors/idea/2.txt
@@ -15,6 +15,7 @@ blocks_movement
 bossbar
 brightness
 chunk_tickets
+convert_date
 crafting_remaining_item
 create_marker
 current_dimension
@@ -125,6 +126,7 @@ ticks_randomly
 top
 transparent
 update
+unix_time
 view_distance
 volume
 without_updates

--- a/docs/scarpet/resources/editors/npp/scarpet.xml
+++ b/docs/scarpet/resources/editors/npp/scarpet.xml
@@ -58,6 +58,8 @@
                 structure_eligibility structures structure_references set_structure reset_chunk reload_chunk custom_dimension
                 add_chunk_ticket
 
+                convert_date unix_time
+
                 display_title
 
                 scoreboard scoreboard_add scoreboard_remove scoreboard_display


### PR DESCRIPTION
I almost forgot these existed (whic is embarassing, since I added them myself), but I needed them to debug the draw caching thing (to see how much of an effect it rly has) and realised it wasn't autocompleting.