### PR TITLE
Fix optimizedTNT entity behaviour

### DIFF
--- a/src/main/java/carpet/helpers/OptimizedExplosion.java
+++ b/src/main/java/carpet/helpers/OptimizedExplosion.java
@@ -132,7 +132,8 @@ public class OptimizedExplosion
 
                 if (d12 <= 1.0D) {
                     double d5 = entity.getX() - eAccess.getX();
-                    double d7 = entity.getY() + (double) entity.getStandingEyeHeight() - eAccess.getY();
+                    // Change in 1.16 snapshots to fix a bug with TNT jumping
+                    double d7 = (entity instanceof TntEntity ? entity.getY() : entity.getEyeY()) - eAccess.getY();
                     double d9 = entity.getZ() - eAccess.getZ();
                     double d13 = (double) MathHelper.sqrt(d5 * d5 + d7 * d7 + d9 * d9);
 


### PR DESCRIPTION
Fixes gnembon#616

This is basically because in 1.16 snapshots the explosion code changed to not be eye height only for TNT.

I don't know if this fully fixes that or if it produces any other bug. I've just tested that it fixed visually (and in the end pos in the tnt logger) the specific case in the issue. I'm not an expert in explosion code. Please test.