### PR TITLE
Added onTrade Scarpet Event

### DIFF
--- a/docs/scarpet/api/Events.md
+++ b/docs/scarpet/api/Events.md
@@ -114,7 +114,12 @@ adjusted.
 ### `__on_player_interacts_with_entity(player, entity, hand)`
 Triggered when player right clicks (interacts) with an entity, even if the entity has no vanilla interaction with the player or
 the item they are holding. The event is invoked after receiving a packet from the client, before anything happens server side
-with that interaction
+with that interaction.
+
+### `__on_player_trades(player, entity, buy, buyB, sell)`
+Triggered when player trades with a merchant. The event is invoked after the server allow the trade, but before the inventory
+changes and merchant updates its trade-uses counter.
+The parameter `entity` can be `null` if the merchant is not an entity.
 
 ### `__on_player_collides_with_entity(player, entity)`
 Triggered every time a player - entity collisions are calculated, before effects of collisions are applied in the game. 

--- a/src/main/java/carpet/mixins/TradeOutputSlot_scarpetEventMixin.java
+++ b/src/main/java/carpet/mixins/TradeOutputSlot_scarpetEventMixin.java
@@ -20,7 +20,7 @@ import static carpet.script.CarpetEventServer.Event.PLAYER_TRADES;
 public abstract class TradeOutputSlot_scarpetEventMixin {
     @Shadow @Final private Merchant merchant;
 
-    @Inject(method = "onTakeItem", require = 0, at = @At(value = "INVOKE",
+    @Inject(method = "onTakeItem", at = @At(value = "INVOKE",
             target = "Lnet/minecraft/village/Merchant;trade(Lnet/minecraft/village/TradeOffer;)V"),
             locals = LocalCapture.CAPTURE_FAILHARD
     )

--- a/src/main/java/carpet/mixins/TradeOutputSlot_scarpetEventMixin.java
+++ b/src/main/java/carpet/mixins/TradeOutputSlot_scarpetEventMixin.java
@@ -1,0 +1,33 @@
+package carpet.mixins;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.slot.TradeOutputSlot;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.village.Merchant;
+import net.minecraft.village.TradeOffer;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import static carpet.script.CarpetEventServer.Event.PLAYER_TRADES;
+
+@Mixin(value = TradeOutputSlot.class)
+public abstract class TradeOutputSlot_scarpetEventMixin {
+    @Shadow @Final private Merchant merchant;
+
+    @Inject(method = "onTakeItem", require = 0, at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/village/Merchant;trade(Lnet/minecraft/village/TradeOffer;)V"),
+            locals = LocalCapture.CAPTURE_FAILHARD
+    )
+    private void onTrade(PlayerEntity player, ItemStack stack, CallbackInfoReturnable cir, TradeOffer tradeOffer) {
+        if(PLAYER_TRADES.isNeeded() && !this.merchant.getMerchantWorld().isClient())
+        {
+            PLAYER_TRADES.onTrade((ServerPlayerEntity) player, merchant, tradeOffer);
+        }
+    }
+}

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -18,6 +18,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.passive.MerchantEntity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.entity.Entity;
@@ -35,6 +36,8 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.village.Merchant;
+import net.minecraft.village.TradeOffer;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import org.apache.commons.lang3.tuple.Pair;
@@ -548,6 +551,20 @@ public class CarpetEventServer
                 ), player::getCommandSource);
             }
         };
+        public static final Event PLAYER_TRADES = new Event("player_trades", 5, false)
+        {
+            @Override
+            public void onTrade(ServerPlayerEntity player, Merchant merchant, TradeOffer tradeOffer)
+            {
+                handler.call( () -> Arrays.asList(
+                        new EntityValue(player),
+                        merchant instanceof MerchantEntity ? new EntityValue((MerchantEntity) merchant) : Value.NULL,
+                        ValueConversions.of(tradeOffer.getOriginalFirstBuyItem()),
+                        ValueConversions.of(tradeOffer.getSecondBuyItem()),
+                        ValueConversions.of(tradeOffer.getSellItem())
+                ), player::getCommandSource);
+            }
+        };
         public static final Event PLAYER_PICKS_UP_ITEM = new Event("player_picks_up_item", 2, false)
         {
             @Override
@@ -926,6 +943,7 @@ public class CarpetEventServer
         public void onDamage(Entity target, float amount, DamageSource source) { }
         public void onRecipeSelected(ServerPlayerEntity player, Identifier recipe, boolean fullStack) {}
         public void onSlotSwitch(ServerPlayerEntity player, int from, int to) {}
+        public void onTrade(ServerPlayerEntity player, Merchant merchant, TradeOffer tradeOffer) {}
 
 
         public void onWorldEvent(ServerWorld world, BlockPos pos) { }

--- a/src/main/resources/assets/carpet/scripts/event_test.sc
+++ b/src/main/resources/assets/carpet/scripts/event_test.sc
@@ -292,3 +292,14 @@ __on_player_picks_up_item(player, item) ->
     print(' Player '+player+' injects '+item);
 );
 
+__on_player_trades(player, entity, buy, buyB, sell) ->
+(
+    print('');
+    print('__on_player_trades(player, item)');
+    print('player trades:');
+    print('  - player: '+player);
+    print('  - entity: '+ entity);
+    print('  - buy: '+ buy);
+    print('  - buyB: '+ buyB);
+    print('  - sell: '+ sell);
+);

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -164,6 +164,7 @@
     "BlockItem_scarpetEventMixin",
     "PlayerManager_scarpetEventsMixin",
     "PlayerInventory_scarpetEventMixin",
+    "TradeOutputSlot_scarpetEventMixin",
 
     "ChunkTicketManager_scarpetMixin",
     "StatType_scarpetMixin",


### PR DESCRIPTION
Implemented James103's suggestion #548
Added `__on_player_trades(player, entity, buy, buyB, sell)` event handler.
The parameter `entity` can be `null` if the merchant is not an entity _[in vanilla should not occur]_