### PR TITLE
Add FormattedText addition

### DIFF
--- a/src/main/java/carpet/script/value/FormattedTextValue.java
+++ b/src/main/java/carpet/script/value/FormattedTextValue.java
@@ -48,10 +48,25 @@ public class FormattedTextValue extends StringValue
         return StringTag.of(Text.Serializer.toJson(text));
     }
 
+    @Override
+    public Value add(Value o) {
+        if (o instanceof FormattedTextValue)
+        {
+            Text mergedText = ((BaseText) text).shallowCopy().append(((FormattedTextValue) o).getText());
+            return new FormattedTextValue(mergedText);
+        }
+        else
+        {
+            Text mergedText = ((BaseText) text).shallowCopy().append(o.getString());
+            return new FormattedTextValue(mergedText);
+        }
+    }
+
     public String serialize()
     {
         return Text.Serializer.toJson(text);
     }
+
     public static FormattedTextValue deserialize(String serialized)
     {
         return new FormattedTextValue(Text.Serializer.fromJson(serialized));

--- a/src/main/java/carpet/script/value/FormattedTextValue.java
+++ b/src/main/java/carpet/script/value/FormattedTextValue.java
@@ -3,6 +3,7 @@ package carpet.script.value;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.text.BaseText;
+import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 
 public class FormattedTextValue extends StringValue
@@ -12,6 +13,33 @@ public class FormattedTextValue extends StringValue
     {
         super(null);
         this.text = text;
+    }
+
+    public static Value combine(Value left, Value right) {
+        BaseText text;
+        if (left instanceof FormattedTextValue)
+        {
+            text = (BaseText) ((FormattedTextValue) left).getText().shallowCopy();
+        }
+        else
+        {
+            if (left instanceof NullValue)
+                return right;
+            text = new LiteralText(left.getString());
+        }
+        
+        if (right instanceof FormattedTextValue)
+        {
+            text.append(((FormattedTextValue) right).getText().shallowCopy());
+            return new FormattedTextValue(text);
+        }
+        else
+        {
+            if (right instanceof NullValue)
+                return left;
+            text.append(right.getString());
+            return new FormattedTextValue(text);
+        }
     }
 
     @Override
@@ -27,7 +55,7 @@ public class FormattedTextValue extends StringValue
     @Override
     public Value clone()
     {
-        return new FormattedTextValue(text.shallowCopy());
+        return new FormattedTextValue(text);
     }
 
     @Override
@@ -50,16 +78,7 @@ public class FormattedTextValue extends StringValue
 
     @Override
     public Value add(Value o) {
-        if (o instanceof FormattedTextValue)
-        {
-            Text mergedText = ((BaseText) text).shallowCopy().append(((FormattedTextValue) o).getText());
-            return new FormattedTextValue(mergedText);
-        }
-        else
-        {
-            Text mergedText = ((BaseText) text).shallowCopy().append(o.getString());
-            return new FormattedTextValue(mergedText);
-        }
+        return combine(this, o);
     }
 
     public String serialize()

--- a/src/main/java/carpet/script/value/FormattedTextValue.java
+++ b/src/main/java/carpet/script/value/FormattedTextValue.java
@@ -27,7 +27,7 @@ public class FormattedTextValue extends StringValue
     @Override
     public Value clone()
     {
-        return new FormattedTextValue(text);
+        return new FormattedTextValue(text.shallowCopy());
     }
 
     @Override

--- a/src/main/java/carpet/script/value/Value.java
+++ b/src/main/java/carpet/script/value/Value.java
@@ -4,8 +4,6 @@ import carpet.script.exception.InternalExpressionException;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import net.minecraft.nbt.Tag;
-import net.minecraft.text.BaseText;
-import net.minecraft.text.LiteralText;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -83,11 +81,7 @@ public abstract class Value implements Comparable<Value>, Cloneable
         String lstr = this.getString();
         if (o instanceof FormattedTextValue)
         {
-            if (lstr == null)
-                return ((FormattedTextValue) o).clone();
-            BaseText newText = new LiteralText(lstr);
-            newText.append(((FormattedTextValue) o).getText().shallowCopy());
-            return new FormattedTextValue(newText);
+            return FormattedTextValue.combine(this, o);
         }
         if (lstr == null) // null
             return new StringValue(o.getString());

--- a/src/main/java/carpet/script/value/Value.java
+++ b/src/main/java/carpet/script/value/Value.java
@@ -4,6 +4,8 @@ import carpet.script.exception.InternalExpressionException;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import net.minecraft.nbt.Tag;
+import net.minecraft.text.BaseText;
+import net.minecraft.text.LiteralText;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -79,6 +81,14 @@ public abstract class Value implements Comparable<Value>, Cloneable
 
     public Value add(Value o) {
         String lstr = this.getString();
+        if (o instanceof FormattedTextValue)
+        {
+            if (lstr == null)
+                return ((FormattedTextValue) o).clone();
+            BaseText newText = new LiteralText(lstr);
+            newText.append(((FormattedTextValue) o).getText().shallowCopy());
+            return new FormattedTextValue(newText);
+        }
         if (lstr == null) // null
             return new StringValue(o.getString());
         String rstr = o.getString();


### PR DESCRIPTION
Resolves #622.

This makes the addition `+` operator correctly join two formatted text, or a formatted text first and anything else after.

~This however, doesn't allow anything `+` formatted text (reverse order), since that would make the function quite complicated (probably), and required in base `Value`. May do that at some point.~

Ok, after some time (around 20 minutes), I've decided to also add the functionality to the other side, that is: anything `+` formatted text.

```py
format('y Hello ') + format('d World') = format('y Hello ', 'd World')

format('y Hello ') + 'World' = format('y Hello ', 'w World') //# Assuming "w" as default color

format('y Hello ') + 5 = format('y Hello ', 'w 5') //# Assuming "w" as default color

'Hello '+format('d World') = format('w Hello ', 'd World' //# Assuming "w" as default color
```

~Also calls `shallowCopy()` on the `Text` element when cloning, since it's technically mutable.~