### PR TITLE
❄️ Freezing Scarpet ❄️

### DIFF
--- a/src/main/java/carpet/CarpetServer.java
+++ b/src/main/java/carpet/CarpetServer.java
@@ -109,7 +109,7 @@ public class CarpetServer implements ClientModInitializer,DedicatedServerModInit
 
     public static void tick(MinecraftServer server)
     {
-        TickSpeed.tick(server);
+        TickSpeed.tick();
         HUDController.update_hud(server);
         scriptServer.tick();
 

--- a/src/main/java/carpet/commands/TickCommand.java
+++ b/src/main/java/carpet/commands/TickCommand.java
@@ -2,6 +2,7 @@ package carpet.commands;
 
 import carpet.CarpetSettings;
 import carpet.helpers.TickSpeed;
+import carpet.network.ServerNetworkHandler;
 import carpet.settings.SettingsManager;
 import carpet.utils.CarpetProfiler;
 import carpet.utils.Messenger;
@@ -107,6 +108,7 @@ public class TickCommand
             TickSpeed.deepFreeze = false;
             Messenger.m(source, "gi Game runs normally");
         }
+        ServerNetworkHandler.updateTickingStateToConnectedPlayers();
         return 1;
     }
 
@@ -119,6 +121,7 @@ public class TickCommand
     private static int toggleSuperHot(ServerCommandSource source)
     {
         TickSpeed.is_superHot = !TickSpeed.is_superHot;
+        ServerNetworkHandler.updateTickingStateToConnectedPlayers();
         if (TickSpeed.is_superHot)
         {
             Messenger.m(source,"gi Superhot enabled");

--- a/src/main/java/carpet/commands/TickCommand.java
+++ b/src/main/java/carpet/commands/TickCommand.java
@@ -96,19 +96,15 @@ public class TickCommand
 
     private static int toggleFreeze(ServerCommandSource source, boolean isDeep)
     {
-        TickSpeed.is_paused = !TickSpeed.is_paused;
-        if (TickSpeed.is_paused)
+        TickSpeed.setFrozenState(!TickSpeed.isPaused(), isDeep);
+        if (TickSpeed.isPaused())
         {
-            TickSpeed.deepFreeze = isDeep;
             Messenger.m(source, "gi Game is "+(isDeep?"deeply ":"")+"frozen");
-
         }
         else
         {
-            TickSpeed.deepFreeze = false;
             Messenger.m(source, "gi Game runs normally");
         }
-        ServerNetworkHandler.updateTickingStateToConnectedPlayers();
         return 1;
     }
 
@@ -121,10 +117,10 @@ public class TickCommand
     private static int toggleSuperHot(ServerCommandSource source)
     {
         TickSpeed.is_superHot = !TickSpeed.is_superHot;
-        ServerNetworkHandler.updateTickingStateToConnectedPlayers();
+        ServerNetworkHandler.updateSuperHotStateToConnectedPlayers();
         if (TickSpeed.is_superHot)
         {
-            Messenger.m(source,"gi Superhot enabled");
+            Messenger.m(source, "gi Superhot enabled");
         }
         else
         {

--- a/src/main/java/carpet/helpers/TickSpeed.java
+++ b/src/main/java/carpet/helpers/TickSpeed.java
@@ -25,9 +25,41 @@ public class TickSpeed
     public static ServerCommandSource tick_warp_sender = null;
     public static int player_active_timeout = 0;
     public static boolean process_entities = true;
-    public static boolean deepFreeze = false;
-    public static boolean is_paused = false;
+    private static boolean deepFreeze = false;
+    private static boolean is_paused = false;
     public static boolean is_superHot = false;
+
+    /**
+     * @return Whether or not the game is in a frozen state.
+     *         You should normally use {@link #process_entities} instead,
+     *         since that one accounts for tick steps and superhot
+     */
+    public static boolean isPaused() {
+	    return is_paused;
+    }
+
+    /**
+     * This can be used for things that you may not normally want
+     * to freeze, but may need to in some situations.
+     * This should be used with {@link #process_entities} to make sure the 
+     * current tick is actually frozen
+     * @return Whether or not the game is deeply frozen.
+     */
+    public static boolean deeplyFrozen() {
+        return deepFreeze;
+    }
+
+    /**
+     * Used to update the frozen state of the game.
+     * Handles connected clients as well.
+     * @param isPaused Whether or not the game is paused
+     * @param isDeepFreeze Whether or not the game is deeply frozen
+     */
+    public static void setFrozenState(boolean isPaused, boolean isDeepFreeze) {
+        is_paused = isPaused;
+        deepFreeze = isPaused ? isDeepFreeze : false;
+        ServerNetworkHandler.updateFrozenStateToConnectedPlayers();
+    }
 
     /**
      * Functional interface that listens for tickrate changes. This is

--- a/src/main/java/carpet/helpers/TickSpeed.java
+++ b/src/main/java/carpet/helpers/TickSpeed.java
@@ -39,10 +39,11 @@ public class TickSpeed
     }
 
     /**
+     * Whether or not the game is deeply frozen.
      * This can be used for things that you may not normally want
      * to freeze, but may need to in some situations.
-     * This should be used with {@link #process_entities} to make sure the 
-     * current tick is actually frozen
+     * This should be checked with {@link #process_entities} to make sure the 
+     * current tick is actually frozen, not only the game
      * @return Whether or not the game is deeply frozen.
      */
     public static boolean deeplyFrozen() {

--- a/src/main/java/carpet/helpers/TickSpeed.java
+++ b/src/main/java/carpet/helpers/TickSpeed.java
@@ -7,7 +7,6 @@ import java.util.function.BiConsumer;
 import carpet.CarpetServer;
 import carpet.network.ServerNetworkHandler;
 import carpet.utils.Messenger;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -66,6 +65,7 @@ public class TickSpeed
     public static void add_ticks_to_run_in_pause(int ticks)
     {
         player_active_timeout = PLAYER_GRACE+ticks;
+        ServerNetworkHandler.updateTickPlayerActiveTimeoutToConnectedPlayers();
     }
 
     public static BaseText tickrate_advance(ServerPlayerEntity player, int advance, String callback, ServerCommandSource source)
@@ -155,7 +155,7 @@ public class TickSpeed
         }
     }
 
-    public static void tick(MinecraftServer server)
+    public static void tick()
     {
         process_entities = true;
         if (player_active_timeout > 0)

--- a/src/main/java/carpet/mixins/ChunkTicketManager_tickMixin.java
+++ b/src/main/java/carpet/mixins/ChunkTicketManager_tickMixin.java
@@ -18,6 +18,6 @@ public class ChunkTicketManager_tickMixin
     {
         // pausing expiry of tickets
         // that will prevent also chunks from unloading, so require a deep frozen state
-        if (!TickSpeed.process_entities && TickSpeed.deepFreeze) age--;
+        if (!TickSpeed.process_entities && TickSpeed.deeplyFrozen()) age--;
     }
 }

--- a/src/main/java/carpet/mixins/CommandFunctionManager_tickMixin.java
+++ b/src/main/java/carpet/mixins/CommandFunctionManager_tickMixin.java
@@ -1,5 +1,6 @@
 package carpet.mixins;
 
+import carpet.helpers.TickSpeed;
 import carpet.utils.CarpetProfiler;
 import net.minecraft.server.function.CommandFunctionManager;
 import org.spongepowered.asm.mixin.Mixin;
@@ -12,9 +13,11 @@ public class CommandFunctionManager_tickMixin
 {
     CarpetProfiler.ProfilerToken currentSection;
 
-    @Inject(method = "tick", at = @At("HEAD"))
+    @Inject(method = "tick", at = @At("HEAD"), cancellable = true)
     private void beforeDatapacks(CallbackInfo ci)
     {
+    	if (!TickSpeed.process_entities && TickSpeed.deepFreeze) ci.cancel();
+    	else
         currentSection = CarpetProfiler.start_section(null, "Datapacks", CarpetProfiler.TYPE.GENERAL);
     }
 

--- a/src/main/java/carpet/mixins/CommandFunctionManager_tickMixin.java
+++ b/src/main/java/carpet/mixins/CommandFunctionManager_tickMixin.java
@@ -16,7 +16,7 @@ public class CommandFunctionManager_tickMixin
     @Inject(method = "tick", at = @At("HEAD"), cancellable = true)
     private void beforeDatapacks(CallbackInfo ci)
     {
-    	if (!TickSpeed.process_entities && TickSpeed.deepFreeze) ci.cancel();
+    	if (!TickSpeed.process_entities) ci.cancel();
     	else
         currentSection = CarpetProfiler.start_section(null, "Datapacks", CarpetProfiler.TYPE.GENERAL);
     }

--- a/src/main/java/carpet/mixins/MinecraftClientMixin.java
+++ b/src/main/java/carpet/mixins/MinecraftClientMixin.java
@@ -28,7 +28,7 @@ public class MinecraftClientMixin
         if (this.world != null) {
             if (CarpetServer.minecraft_server == null)
                 TickSpeed.tick();
-            if (!TickSpeed.process_entities && TickSpeed.deeplyFrozen())
+            if (!TickSpeed.process_entities)
                 CarpetClient.shapes.renewShapes();
         }
     }

--- a/src/main/java/carpet/mixins/MinecraftClientMixin.java
+++ b/src/main/java/carpet/mixins/MinecraftClientMixin.java
@@ -1,9 +1,13 @@
 package carpet.mixins;
 
+import carpet.CarpetServer;
+import carpet.helpers.TickSpeed;
 import carpet.network.CarpetClient;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.world.ClientWorld;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -11,9 +15,21 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(MinecraftClient.class)
 public class MinecraftClientMixin
 {
+    @Shadow public ClientWorld world;
+    
     @Inject(method = "disconnect(Lnet/minecraft/client/gui/screen/Screen;)V", at = @At("HEAD"))
     private void onCloseGame(Screen screen, CallbackInfo ci)
     {
         CarpetClient.disconnect();
+    }
+    
+    @Inject(at = @At("HEAD"), method = "tick")
+    private void onClientTick(CallbackInfo info) {
+        if (this.world != null) {
+            if (CarpetServer.minecraft_server == null)
+                TickSpeed.tick();
+            if (!TickSpeed.process_entities && TickSpeed.deepFreeze)
+                CarpetClient.shapes.renewShapes();
+        }
     }
 }

--- a/src/main/java/carpet/mixins/MinecraftClientMixin.java
+++ b/src/main/java/carpet/mixins/MinecraftClientMixin.java
@@ -28,7 +28,7 @@ public class MinecraftClientMixin
         if (this.world != null) {
             if (CarpetServer.minecraft_server == null)
                 TickSpeed.tick();
-            if (!TickSpeed.process_entities && TickSpeed.deepFreeze)
+            if (!TickSpeed.process_entities && TickSpeed.deeplyFrozen())
                 CarpetClient.shapes.renewShapes();
         }
     }

--- a/src/main/java/carpet/mixins/MinecraftServer_scarpetMixin.java
+++ b/src/main/java/carpet/mixins/MinecraftServer_scarpetMixin.java
@@ -1,6 +1,7 @@
 package carpet.mixins;
 
 import carpet.fakes.MinecraftServerInterface;
+import carpet.helpers.TickSpeed;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.ServerTask;
 import net.minecraft.server.world.ServerWorld;
@@ -69,6 +70,8 @@ public abstract class MinecraftServer_scarpetMixin extends ReentrantThreadExecut
     ))
     public void tickTasks(BooleanSupplier booleanSupplier_1, CallbackInfo ci)
     {
+        if (!TickSpeed.process_entities && TickSpeed.deepFreeze)
+            return;
         TICK.onTick();
         NETHER_TICK.onTick();
         ENDER_TICK.onTick();

--- a/src/main/java/carpet/mixins/MinecraftServer_scarpetMixin.java
+++ b/src/main/java/carpet/mixins/MinecraftServer_scarpetMixin.java
@@ -70,7 +70,7 @@ public abstract class MinecraftServer_scarpetMixin extends ReentrantThreadExecut
     ))
     public void tickTasks(BooleanSupplier booleanSupplier_1, CallbackInfo ci)
     {
-        if (!TickSpeed.process_entities && TickSpeed.deepFreeze)
+        if (!TickSpeed.process_entities)
             return;
         TICK.onTick();
         NETHER_TICK.onTick();

--- a/src/main/java/carpet/network/ClientNetworkHandler.java
+++ b/src/main/java/carpet/network/ClientNetworkHandler.java
@@ -65,6 +65,13 @@ public class ClientNetworkHandler
             }
         });
         dataHandlers.put("TickRate", (p, t) -> TickSpeed.tickrate(((AbstractNumberTag)t).getFloat(), false));
+        dataHandlers.put("TickingState", (p, t) -> {
+            CompoundTag tickingState = (CompoundTag)t;
+            TickSpeed.is_paused = tickingState.getBoolean("is_paused");
+            TickSpeed.deepFreeze = tickingState.getBoolean("deepFreeze");
+            TickSpeed.is_superHot = tickingState.getBoolean("is_superHot");
+        });
+        dataHandlers.put("TickPlayerActiveTimeout", (p, t) -> TickSpeed.player_active_timeout = ((AbstractNumberTag)t).getInt());
         dataHandlers.put("scShape", (p, t) -> { // deprecated
             if (CarpetClient.shapes != null)
                 CarpetClient.shapes.addShape((CompoundTag)t);

--- a/src/main/java/carpet/network/ClientNetworkHandler.java
+++ b/src/main/java/carpet/network/ClientNetworkHandler.java
@@ -9,6 +9,7 @@ import carpet.settings.SettingsManager;
 import io.netty.buffer.Unpooled;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.nbt.AbstractNumberTag;
+import net.minecraft.nbt.ByteTag;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
@@ -67,9 +68,10 @@ public class ClientNetworkHandler
         dataHandlers.put("TickRate", (p, t) -> TickSpeed.tickrate(((AbstractNumberTag)t).getFloat(), false));
         dataHandlers.put("TickingState", (p, t) -> {
             CompoundTag tickingState = (CompoundTag)t;
-            TickSpeed.is_paused = tickingState.getBoolean("is_paused");
-            TickSpeed.deepFreeze = tickingState.getBoolean("deepFreeze");
-            TickSpeed.is_superHot = tickingState.getBoolean("is_superHot");
+            TickSpeed.setFrozenState(tickingState.getBoolean("is_paused"), tickingState.getBoolean("deepFreeze"));
+        });
+        dataHandlers.put("SuperHotState", (p, t) -> {
+            TickSpeed.is_superHot = ((ByteTag) t).equals(ByteTag.ONE);
         });
         dataHandlers.put("TickPlayerActiveTimeout", (p, t) -> TickSpeed.player_active_timeout = ((AbstractNumberTag)t).getInt());
         dataHandlers.put("scShape", (p, t) -> { // deprecated

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -961,7 +961,7 @@ public class CarpetEventServer
 
     public void tick()
     {
-        if (!TickSpeed.process_entities && TickSpeed.deeplyFrozen())
+        if (!TickSpeed.process_entities)
             return;
         Iterator<ScheduledCall> eventIterator = scheduledCalls.iterator();
         List<ScheduledCall> currentCalls = new ArrayList<>();

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -961,7 +961,7 @@ public class CarpetEventServer
 
     public void tick()
     {
-        if (!TickSpeed.process_entities && TickSpeed.deepFreeze)
+        if (!TickSpeed.process_entities && TickSpeed.deeplyFrozen())
             return;
         Iterator<ScheduledCall> eventIterator = scheduledCalls.iterator();
         List<ScheduledCall> currentCalls = new ArrayList<>();

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -2,6 +2,7 @@ package carpet.script;
 
 import carpet.CarpetServer;
 import carpet.CarpetSettings;
+import carpet.helpers.TickSpeed;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.value.BlockValue;
 import carpet.script.value.EntityValue;
@@ -960,6 +961,8 @@ public class CarpetEventServer
 
     public void tick()
     {
+        if (!TickSpeed.process_entities && TickSpeed.deepFreeze)
+            return;
         Iterator<ScheduledCall> eventIterator = scheduledCalls.iterator();
         List<ScheduledCall> currentCalls = new ArrayList<>();
         while(eventIterator.hasNext())

--- a/src/main/java/carpet/script/utils/ShapesRenderer.java
+++ b/src/main/java/carpet/script/utils/ShapesRenderer.java
@@ -167,6 +167,15 @@ public class ShapesRenderer
         }
     }
 
+    public void renewShapes()
+    {
+        synchronized (shapes)
+        {
+            shapes.values().forEach(el -> el.values().forEach(shape -> {
+                shape.expiryTick++;
+            }));
+        }
+    }
 
     public abstract static class RenderedShape<T extends ShapeDispatcher.ExpiringShape>
     {


### PR DESCRIPTION
_And the client_

Actually, the most important (visible) thing added from this PR is freezing the client, but Scarpet is also frozen.

This is the PR that resolves #581 and resolves #398.

### What does it do?

_It adds new data to the Carpet Protocol to sync more features, such as frozen state and deep frozen state with Carpet clients._

Now, to the full PR:

Syncs the `is_paused`, `deepFreeze` and `super_hot` variables from `TickSpeed` with clients. With the next changes, this will allow us to freeze entity rendering, like in singleplayer, and to add client-side frozen features. The `super_hot` variable doesn't really change absolutely anything, but I added it for completeness sake to maybe try to get it working in the future (because AFAIK it does change things in SSP, doesn't it? if not, I'm dumb and that should be reverted).

Since freezes can be stepped forward, whenever the `step` command is ran, that time is also synced to clients to unfreeze the rendering during those ticks. It doesn't look as good as in singleplayer (client tends to process a bit more than server), but it's better than not having it.

As you probably know, those booleans alone don't really change how the world is rendered directly, since that is handled by the `process_entities` variable, that is determined every tick in `TickSpeed`'s `tick()` method. Since it didn't get naturally ticked in the client, there is new mixin functionality in `MinecraftClientMixin` to tick `TickSpeed` without an attached server. That allows us to get the (almost always) correct value for each client tick depending on the frozen state. This will only work 100% (-ish) accurate when the server's tickrate is 20, or when it has `smoothClientAnimations` and tickrate <= 20 (`smoothClientAnimations` affects our client tick source, affecting also shape duration, etc).

One thing is that in order to tick `TickSpeed` from the client, I had to remove the `MinecraftServer` parameter from the `tick` method, which wasn't used anyway. If needed, it can be readded and just pass `null` from client ticks, but that would need checking if that is null before using.

Now, to the Scarpet freezing part.

First, this prevents `EventServer` (schedules) and `tickTasks` (`on_tick` events) from being ticked when the server is under a deep freeze. I personally think tick events shouldn't tick in regular ones either, but reasoning for this below. There is also an added check in the datapack profiler mixin that just cancels the event if there is a deep freeze, since the mixin seems to be in the perfect location (not tested, I've never used any datapacks, but should work).

Since we are freezing schedules and ticks, that would kill shapes, since there would be no way to send new ones, and we don't want that. Therefore we make use of the newly added synced frozen state to extend shapes lifetime while the world is deeply frozen. That prevents shapes to disappear when they can't be renewed by anything else. The way this is done may not be perfect, but I couldn't find an easy way with the current implementation.

This PR works and is technically feature complete, but there are some questions/considerations that I'd like to ask/suggest:

- [x] As stated above, I personally think `__on_tick()` (and derivatives, including datapack's tick) should neither tick in regular freezes. I think that since, even though yes, the server still ticks, to the user it is supposed to be "frozen", therefore for a user it may seem counter-intuitive for them to tick with the game "frozen". This doesn't apply to `schedule()` due to the reasons mentioned in the rfc. There wasn't really any discussion about the tick events, so I just added all of them only in deep freezes. What do you think?
- [x] `TickSpeed`'s frozen state may need setters/getters. Since now those are synced to clients, I think it makes sense to have setters for them that would automatically notify the client, to prevent anyone (e.g. in an extension) from modifying those variables without syncing them. Maybe both regular and deep frozen state in the same function to prevent unnecessary packets/calls. Thoughts?
- Please tell me a better name for `updateTickPlayerActiveTimeoutToConnectedPlayers` (and derivatives). It's extremely long, but is the only way I've found for it to explain what does it mean.
- [x] ~In case `super_hot` doesn't have any kind of interaction with the client (like visible frozenness, etc), please tell me because it should not be synced, and probably `tickingState` could be just `frozenState` or `pauseState`~ SuperHot has been separated from frozen state
- `renewShapes` may need a better name, and also probably a better implementation

I think this is ready for review. Open to change requests, as always. Will do some more testing since I accidentally rebased the branch down while working, but I think I readded all the necessary changes. Sorry for not being more concise in the description.