### PR TITLE
Use latest ServerPlayerEntity after respawn

### DIFF
--- a/src/main/java/carpet/mixins/PlayerManager_scarpetEventsMixin.java
+++ b/src/main/java/carpet/mixins/PlayerManager_scarpetEventsMixin.java
@@ -12,9 +12,9 @@ import static carpet.script.CarpetEventServer.Event.PLAYER_RESPAWNS;
 @Mixin(PlayerManager.class)
 public class PlayerManager_scarpetEventsMixin
 {
-    @Inject(method = "respawnPlayer", at = @At("HEAD"))
+    @Inject(method = "respawnPlayer", at = @At("TAIL"))
     private void onRespawn(ServerPlayerEntity player, boolean olive, CallbackInfoReturnable<ServerPlayerEntity> cir)
     {
-        PLAYER_RESPAWNS.onPlayerEvent(player);
+        PLAYER_RESPAWNS.onPlayerEvent(cir.getReturnValue());
     }
 }


### PR DESCRIPTION
Fixes #633.

This happens because the `ServerPlayerEntity` that is passed to the event is destroyed during the function the mixin is in, therefore inventory (and other data) ends up being incorrect. The new SPE is generated at around line 465 of `PlayerManager` (yarn).

Therefore this PR changes the target to `TAIL` and passes the newly generated `ServerPlayerEntity` to the Scarpet event instead of the old one.

With this, the code in #633 works properly.