### PR TITLE
Fixed null acting as a string with matching operator (~) and split()

### DIFF
--- a/src/main/java/carpet/script/language/DataStructures.java
+++ b/src/main/java/carpet/script/language/DataStructures.java
@@ -9,7 +9,6 @@ import carpet.script.value.LContainerValue;
 import carpet.script.value.LazyListValue;
 import carpet.script.value.ListValue;
 import carpet.script.value.MapValue;
-import carpet.script.value.NullValue;
 import carpet.script.value.NumericValue;
 import carpet.script.value.StringValue;
 import carpet.script.value.Value;
@@ -59,13 +58,13 @@ public class DataStructures {
             String hwat;
             if (lv.size() == 1)
             {
-                if(lv.get(0) instanceof NullValue) return new ListValue(new ArrayList<>());
+                if(lv.get(0).isNull()) return new ListValue(new ArrayList<>());
                 hwat = lv.get(0).getString();
                 delimiter = "";
             }
             else if (lv.size() == 2)
             {
-                if(lv.get(1) instanceof NullValue) return new ListValue(new ArrayList<>());
+                if(lv.get(1).isNull()) return new ListValue(new ArrayList<>());
                 delimiter = lv.get(0).getString();
                 hwat = lv.get(1).getString();
             }

--- a/src/main/java/carpet/script/language/DataStructures.java
+++ b/src/main/java/carpet/script/language/DataStructures.java
@@ -9,6 +9,7 @@ import carpet.script.value.LContainerValue;
 import carpet.script.value.LazyListValue;
 import carpet.script.value.ListValue;
 import carpet.script.value.MapValue;
+import carpet.script.value.NullValue;
 import carpet.script.value.NumericValue;
 import carpet.script.value.StringValue;
 import carpet.script.value.Value;
@@ -58,11 +59,13 @@ public class DataStructures {
             String hwat;
             if (lv.size() == 1)
             {
+                if(lv.get(0) instanceof NullValue) return new ListValue(new ArrayList<>());
                 hwat = lv.get(0).getString();
                 delimiter = "";
             }
             else if (lv.size() == 2)
             {
+                if(lv.get(1) instanceof NullValue) return new ListValue(new ArrayList<>());
                 delimiter = lv.get(0).getString();
                 hwat = lv.get(1).getString();
             }

--- a/src/main/java/carpet/script/language/DataStructures.java
+++ b/src/main/java/carpet/script/language/DataStructures.java
@@ -58,13 +58,11 @@ public class DataStructures {
             String hwat;
             if (lv.size() == 1)
             {
-                if(lv.get(0).isNull()) return new ListValue(new ArrayList<>());
                 hwat = lv.get(0).getString();
                 delimiter = "";
             }
             else if (lv.size() == 2)
             {
-                if(lv.get(1).isNull()) return new ListValue(new ArrayList<>());
                 delimiter = lv.get(0).getString();
                 hwat = lv.get(1).getString();
             }

--- a/src/main/java/carpet/script/value/NullValue.java
+++ b/src/main/java/carpet/script/value/NullValue.java
@@ -45,6 +45,11 @@ public class NullValue extends NumericValue // TODO check nonsingleton code
     }
 
     @Override
+    public Value in(Value value) {
+        return Value.NULL;
+    }
+
+    @Override
     public String getTypeString()
     {
         return "null";


### PR DESCRIPTION
Fixes an issue where `null~'string'` is searching for a substring in the actual string version of `null`, which meant that:
`null~'nu'` -> `'nu'`
`null~'l'` -> `'l'`
`null~'null'` -> `'null'`
`null~'hello'` -> `null`
Pretty sure this is not inteded, `null` represents _nothing_, and _nothing_ should not contain anything