### PR TITLE
[Suggestion] Allow splitting lists by element value

### DIFF
--- a/docs/scarpet/language/Containers.md
+++ b/docs/scarpet/language/Containers.md
@@ -160,11 +160,19 @@ join('-', 'foo', 'bar')  => foo-bar
 Splits a string under `expr` by `delim` which can be a regular expression. If no delimiter is specified, it splits
 by characters.
 
+If `expr` is a list, it will split the list into multiple sublists by the element (s) which equal `delim`, or which equal the empty string
+in case no delimiter is specified.
+
+Splitting a `null` value will return an empty list.
+
 <pre>
 split('foo') => [f, o, o]
 split('','foo')  => [f, o, o]
 split('.','foo.bar')  => []
 split('\\.','foo.bar')  => [foo, bar]
+split(1,[2,5,1,2,3,1,5,6]) => [[2,5],[2,3],[5,6]]
+split(1,[1,2,3,1,4,5,1] => [[], [2,3], [4,5], []]
+split(null) => []
 </pre>
 
 ### `slice(expr, from, to?)`

--- a/src/main/java/carpet/script/language/DataStructures.java
+++ b/src/main/java/carpet/script/language/DataStructures.java
@@ -14,10 +14,8 @@ import carpet.script.value.StringValue;
 import carpet.script.value.Value;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 public class DataStructures {
@@ -54,30 +52,23 @@ public class DataStructures {
 
         expression.addFunction("split", (lv) ->
         {
-            String delimiter;
-            String hwat;
+            Value delimiter;
+            Value hwat;
             if (lv.size() == 1)
             {
-                hwat = lv.get(0).getString();
-                delimiter = "";
+                hwat = lv.get(0);
+                delimiter = StringValue.EMPTY;
             }
             else if (lv.size() == 2)
             {
-                delimiter = lv.get(0).getString();
-                hwat = lv.get(1).getString();
+                delimiter = lv.get(0);
+                hwat = lv.get(1);
             }
             else
             {
                 throw new InternalExpressionException("'split' takes 1 or 2 arguments");
             }
-            try
-            {
-                return ListValue.wrap(Arrays.stream(hwat.split(delimiter)).map(StringValue::new).collect(Collectors.toList()));
-            }
-            catch (PatternSyntaxException pse)
-            {
-                throw new InternalExpressionException("Incorrect pattern for 'split': "+pse.getMessage());
-            }
+            return hwat.split(delimiter);
         });
 
         expression.addFunction("slice", (lv) ->

--- a/src/main/java/carpet/script/value/ListValue.java
+++ b/src/main/java/carpet/script/value/ListValue.java
@@ -348,6 +348,24 @@ public class ListValue extends AbstractListValue implements ContainerValueInterf
     }
 
     @Override
+    public Value split(Value delimiter) {
+        ListValue result = new ListValue();
+        int startIndex = 0;
+        int index = 0;
+        for (Value val : this.items)
+        {
+            index++;
+            if (val.equals(delimiter))
+            {
+                result.items.add(ListValue.wrap(this.items.subList(startIndex, index-1)));
+                startIndex = index;
+            }
+        }
+        result.items.add(ListValue.wrap(this.items.subList(startIndex, length())));
+        return result;
+    }
+
+    @Override
     public double readDoubleNumber()
     {
         return (double)items.size();

--- a/src/main/java/carpet/script/value/MapValue.java
+++ b/src/main/java/carpet/script/value/MapValue.java
@@ -204,6 +204,11 @@ public class MapValue extends AbstractListValue implements ContainerValueInterfa
     }
 
     @Override
+    public Value split(Value delimiter) {
+    	throw new InternalExpressionException("Cannot split a map value");
+    }
+
+    @Override
     public double readDoubleNumber()
     {
         return (double)map.size();

--- a/src/main/java/carpet/script/value/NullValue.java
+++ b/src/main/java/carpet/script/value/NullValue.java
@@ -1,5 +1,7 @@
 package carpet.script.value;
 
+import java.util.ArrayList;
+
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import net.minecraft.nbt.StringTag;
@@ -61,6 +63,11 @@ public class NullValue extends NumericValue // TODO check nonsingleton code
     {
         if (!force) throw new NBTSerializableValue.IncompatibleTypeException(this);
         return StringTag.of("null");
+    }
+
+    @Override
+    public Value split(Value delimiter) {
+    	return ListValue.wrap(new ArrayList<Value>());
     }
 
     @Override

--- a/src/main/java/carpet/script/value/Value.java
+++ b/src/main/java/carpet/script/value/Value.java
@@ -6,10 +6,12 @@ import com.google.gson.JsonPrimitive;
 import net.minecraft.nbt.Tag;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 
 public abstract class Value implements Comparable<Value>, Cloneable
 {
@@ -188,6 +190,19 @@ public abstract class Value implements Comparable<Value>, Cloneable
         if (from > to) return StringValue.EMPTY;
         return new StringValue(value.substring(from, to));
     }
+    
+    public Value split(Value delimiter)
+    {
+    	try
+        {
+            return ListValue.wrap(Arrays.stream(getString().split(delimiter.getString())).map(StringValue::new).collect(Collectors.toList()));
+        }
+        catch (PatternSyntaxException pse)
+        {
+            throw new InternalExpressionException("Incorrect pattern for 'split': "+pse.getMessage());
+        }
+    }
+    
     public double readDoubleNumber()
     {
         String s = getString();


### PR DESCRIPTION
This PR adds the ability to `split()` to run different functions depending on the value it's trying to split.

By default, it will work as it has done until now, but this PR adds technically three (actually one) new split functions:

- Splitting a list will split it in sublists delimited by the elements which equal the delimiter
- Splitting a `null` value will return an empty list regardless of the delimiter. Until now, it would split the `null` string
- Splitting a map will throw an exception, just like `slice`