### PR TITLE
Fix split

### DIFF
--- a/src/main/java/carpet/script/language/DataStructures.java
+++ b/src/main/java/carpet/script/language/DataStructures.java
@@ -57,7 +57,7 @@ public class DataStructures {
             if (lv.size() == 1)
             {
                 hwat = lv.get(0);
-                delimiter = StringValue.EMPTY;
+                delimiter = null;
             }
             else if (lv.size() == 2)
             {

--- a/src/main/java/carpet/script/value/ListValue.java
+++ b/src/main/java/carpet/script/value/ListValue.java
@@ -350,12 +350,17 @@ public class ListValue extends AbstractListValue implements ContainerValueInterf
     @Override
     public Value split(Value delimiter) {
         ListValue result = new ListValue();
+        if (delimiter == null)
+        {
+            this.forEach(item -> result.items.add(of(item)));
+            return result;
+        }
         int startIndex = 0;
         int index = 0;
         for (Value val : this.items)
         {
             index++;
-            if (val.equals(delimiter) || delimiter == null)
+            if (val.equals(delimiter))
             {
                 result.items.add(ListValue.wrap(this.items.subList(startIndex, index-1)));
                 startIndex = index;

--- a/src/main/java/carpet/script/value/ListValue.java
+++ b/src/main/java/carpet/script/value/ListValue.java
@@ -355,7 +355,7 @@ public class ListValue extends AbstractListValue implements ContainerValueInterf
         for (Value val : this.items)
         {
             index++;
-            if (val.equals(delimiter))
+            if (val.equals(delimiter) || delimiter == null)
             {
                 result.items.add(ListValue.wrap(this.items.subList(startIndex, index-1)));
                 startIndex = index;

--- a/src/main/java/carpet/script/value/Value.java
+++ b/src/main/java/carpet/script/value/Value.java
@@ -193,7 +193,11 @@ public abstract class Value implements Comparable<Value>, Cloneable
     
     public Value split(Value delimiter)
     {
-    	try
+        if (delimiter == null)
+        {
+            delimiter = StringValue.EMPTY;
+        }
+        try
         {
             return ListValue.wrap(Arrays.stream(getString().split(delimiter.getString())).map(StringValue::new).collect(Collectors.toList()));
         }


### PR DESCRIPTION
Makes it return a list of lists with a single element each without delimiter, as commented.

~WIP because I haven't tested this yet~. ~Edit: And now that I've tested it it definitely doesn't work yet.~