### PR TITLE
Fix NbtIo crash when loading appdata

### DIFF
--- a/src/main/java/carpet/script/bundled/FileModule.java
+++ b/src/main/java/carpet/script/bundled/FileModule.java
@@ -76,9 +76,14 @@ public class FileModule extends Module
         }
         catch (IOException e)
         {
-            try
+            // Copy of NbtIo.read(File) because that's now client-side only
+            if (!file.exists())
             {
-                return NbtIo.read(file);
+                return null;
+            }
+            try (DataInputStream in = new DataInputStream(new FileInputStream(file)))
+            {
+                return NbtIo.read(in);
             }
             catch (IOException ioException)
             {


### PR DESCRIPTION
Fixes #674.

It seems ~in recent versions (snapshots)~ NbtIo.read(File) is only present in the client side, so it basically crashes the dedicated server.

This PR is more like a workaround than a full fix, that basically mimics the behaviour of that method and calls other functions that are present in both sides. Obviously finding a proper method to call instead may be desirable, but that at least works for now.

This didn't strike before because that function is only called as a fallback for simple tags, which isn't so common.

Edit: This actually also happens in the 1.16 version, thus changed the base. The branch name is therefore misleading, but was to prevent opening another PR.