### PR TITLE
Extra handling of null values (split, non-order-dependant only)

### DIFF
--- a/src/main/java/carpet/script/value/NullValue.java
+++ b/src/main/java/carpet/script/value/NullValue.java
@@ -41,6 +41,21 @@ public class NullValue extends NumericValue // TODO check nonsingleton code
     }
 
     @Override
+    public Value slice(long fromDesc, Long toDesc) {
+        return Value.NULL;
+    }
+
+    @Override
+    public NumericValue opposite() {
+        return Value.NULL;
+    }
+
+    @Override
+    public int length() {
+        return 0;
+    }
+
+    @Override
     public int compareTo(Value o)
     {
         return  o instanceof NullValue ? 0 : -1;


### PR DESCRIPTION
This is a split of #676, adding only the ones that don't depend on the order of the operator (plus a new one).

That includes `slice()`, the one I consider the most useful of them.

| Function        | Before  | After  |
|-----------------|---------|--------|
| `slice(null,1)` | `'ull'` | `null` |
| `length(null)` | 1   | 0 |
| `-null`         | 0       | `null` |

