### PR TITLE
Exception handling features

### DIFF
--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -11,6 +11,8 @@ optional `mixer`. Default values for `volume`, `pitch` and `mixer` are `1.0`, `1
 Valid mixer options are `master`, `music`, `record`, `weather`, `block`, `hostile`,`neutral`, `player`, `ambient`
 and `voice`. `pos` can be either a block, triple of coords, or a list of thee numbers. Uses the same options as a
  corresponding `playsound` command.
+ 
+Throws `unknown_sound` if sound doesn't exist.
 
 ## Particles
 
@@ -21,18 +23,23 @@ of 0, and to all players nearby, but these options can be changed via optional a
 command on details on those options. Valid particle names are 
 for example `'angry_villager', 'item diamond', 'block stone', 'dust 0.8 0.1 0.1 4'`.
 
+Throws `unknown_particle` if particle doesn't exist.
+
 ### `particle_line(name, pos, pos2, density?, player?)`
 
 Renders a line of particles from point `pos` to `pos2` with supplied density (defaults to 1), which indicates how far 
 apart you would want particles to appear, so `0.1` means one every 10cm. If a player (or player name) is supplied, only
 that player will receive particles.
 
+Throws `unknown_particle` if particle doesn't exist.
 
 ### `particle_box(name, pos, pos2, density?, player?)`
 ### `particle_rect` (deprecated)
 
 Renders a cuboid of particles between points `pos` and `pos2` with supplied density. If a player (or player name) is 
 supplied, only that player will receive particles.
+
+Throws `unknown_particle` if particle doesn't exist.
 
 ## Markers
 
@@ -320,6 +327,10 @@ record to the file. Since files are closed after each write, sending multiple li
 write is beneficial for writing speed. To send multiple packs of data, either provide them flat or as a list in the
 third argument.
 
+Throws:
+- `nbt_read_exception`: When failed to read NBT file
+- `json_read_exception`: When failed to read JSON file. The `_msg` variable will contain details about the problem
+
 <pre>
 write_file('foo', 'shared_text, ['one', 'two']);
 write_file('foo', 'shared_text', 'three\n', 'four\n');
@@ -370,6 +381,8 @@ specific data directory is under `world/scripts/foo.data/bar/../baz.nbt`, and sh
 `world/scripts/shared/bar/../baz.nbt`.
 
 You can use app data to save non-vanilla information separately from the world and other scripts.
+
+Throws `nbt_read_exception` if failed to read app data.
 
 ### `store_app_data(tag)`
 
@@ -447,6 +460,8 @@ Returns current dimension that the script runs in.
 Evaluates the expression `expr` with different dimension execution context. `smth` can be an entity, 
 world-localized block, so not `block('stone')`, or a string representing a dimension like:
  `'nether'`, `'the_nether'`, `'end'` or `'overworld'`, etc.
+ 
+Throws `unknown_dimension` if given a dimension as a String and it can't be found.
  
 ### `view_distance()`
 Returns the view distance of the server.

--- a/docs/scarpet/api/BlocksAndWorldAccess.md
+++ b/docs/scarpet/api/BlocksAndWorldAccess.md
@@ -21,6 +21,8 @@ when it was used. Block values passed in various places like `scan` functions, e
 its properties are needed. This means that if the block at the location changes before its queried in the program this 
 might result in getting the later state, which might not be desired. Consider the following example:
 
+Throws `unknown_block` if block from `state` doesn't exist.
+
 <pre>set(10,10,10,'stone');
 scan(10,10,10,0,0,0, b = _);
 set(10,10,10,'air');
@@ -49,6 +51,8 @@ destination block is the same the `set` operation is skipped, otherwise is execu
 properties that the original source block may have contained.
 
 The returned value is either the block state that has been set, or `false` if block setting was skipped, or failed
+
+Throws `unknown_block` if `block` doesn't exist.
 
 <pre>
 set(0,5,0,'bedrock')  => bedrock
@@ -128,6 +132,8 @@ but doesn't open chests / containers, so have no effect on interactive blocks, l
 Returns true if placement/use was 
 successful, false otherwise.
 
+Throws `unknown_item` if `item` doesn't exist
+
 <pre>
 place_item('stone',x,y,z) // places a stone block on x,y,z block
 place_item('piston,x,y,z,'down') // places a piston facing down
@@ -146,6 +152,8 @@ If type is `null`, POI at position is removed. In any case, previous POI is also
 Interestingly, `unemployed`, and `nitwit` are not used in the game, meaning, they could be used as permanent spatial 
 markers for scarpet apps. `meeting` is the only one with increased max occupancy of 32.
 
+Throws `unknown_poi_type` if POI type doesn't exist 
+
 ### `set_biome(pos, biome_name, update=true)`
 
 Changes the biome at that block position. if update is specified and false, then chunk will not be refreshed
@@ -155,6 +163,8 @@ Setting a biome is now (as of 1.16) dimension specific. In the overworld and the
 is only effective if you set it at y=0, and affects the entire column of. In the nether - you have to use the
 specific Y coordinate of the biome you want to change, and it affects roughly 4x4x4 area (give or take some random
 noise).
+
+Throws `unknown_biome` if biome doesn't exist.
 
 ### `update(pos)`
 
@@ -179,6 +189,8 @@ Without item context it returns `false` if failed to destroy the block and `true
 In item context, `true` means that breaking item has no nbt to use, `null` indicating that the tool should be 
 considered broken in process, and `nbt` type value, for a resulting NBT tag on a hypothetical tool. Its up to the 
 programmer to use that nbt to apply it where it belong
+
+Throws `unknown_item` if `tool` doesn't exist.
 
 Here is a sample code that can be used to mine blocks using items in player inventory, without using player context 
 for mining. Obviously, in this case the use of `harvest` would be much more applicable:
@@ -271,6 +283,8 @@ back in state definition in various applications where block properties are requ
 
 `block_state` can also accept block names as input, returning block's default state.
 
+Throws `unknown_block` if `block` comes from a String and doesn't exist.
+
 <pre>
 set(x,y,z,'iron_trapdoor','half','top'); block_state(x,y,z)  => {waterlogged: false, half: top, open: false, ...}
 set(x,y,z,'iron_trapdoor','half','top'); block_state(x,y,z,'half')  => top
@@ -290,6 +304,8 @@ Returns list of all blocks. If tag is provided, returns list of blocks that belo
 Without arguments, returns list of available tags, with block supplied (either by coordinates, or via block name), returns lost
 of tags the block belongs to, and if a tag is specified, returns `null` if tag is invalid, `false` if this block doesn't belong 
 to this tag, and `true` if the block belongs to the tag.
+
+Throws `unknown_block` if `block` comes from a String and doesn't exist
 
 ### `block_data(pos)`
 
@@ -347,6 +363,8 @@ and values < 0, below sea level.
 * `'scale'`: float value indicating how flat is the terrain.
 * `'features'`: list of features that generate in the biome, grouped by generation steps
 * `'structures'`: list of structures that generate in the biome.
+
+Throws `unknown_block` if `block` comes from a String and doesn't exist. 
 
 ### `solid(pos)`
 
@@ -716,6 +734,7 @@ If structure is not specified, it will return a set of structure names that are 
 as keys, and same type of map values as with a single structure call. An empty set or an empty map would indicate that nothing
 should be generated there.
 
+Throws `unknown_structure` if structure doesn't exist.
 
 ### `structures(pos), structures(pos, structure_name)`
 
@@ -748,6 +767,8 @@ structure starts.
 
 Requires a `Structure Variant` or `Standard Structure` name (see above). If standard name is used, the variant of the 
 structure may depend on the biome, otherwise the default structure for this type will be generated.
+
+Throws `unknown_structure` if structure doesn't exist.
 
 ### `plop(pos, what)`
 

--- a/docs/scarpet/api/Inventories.md
+++ b/docs/scarpet/api/Inventories.md
@@ -28,13 +28,15 @@ an inventory, all API functions typically do nothing and return null.
 
 Most items returned are in the form of a triple of item name, count, and nbt or the extra data associated with an item. 
 
-### item_list(tag?)
+### `item_list(tag?)`
 
 With no arguments, returns a list of all items in the game. With an item tag provided, list items matching the tag, or `null` if tag is not valid.
 
-### item_tags(item, tag?)
+### `item_tags(item, tag?)`
 
 Returns list of tags the item belongs to, or, if tag is provided, `true` if an item maches the tag, `false` if it doesn't and `null` if that's not a valid tag
+
+Throws `unknown_item` if item doesn't exist.
 
 ### `stack_limit(item)`
 
@@ -42,6 +44,8 @@ Returns number indicating what is the stack limit for the item. Its typically 1 
 or 64 - rest. It is recommended to consult this, as other inventory API functions ignore normal stack limits, and 
 it is up to the programmer to keep it at bay. As of 1.13, game checks for negative numbers and setting an item to 
 negative is the same as empty.
+
+Throws `unknown_item` if item doesn't exist.
 
 <pre>
 stack_limit('wooden_axe') => 1
@@ -52,6 +56,8 @@ stack_limit('stone') => 64
 ### `item_category(item)`
 
 Returns the string representing the category of a given item, like `building_blocks`, `combat`, or `tools`.
+
+Throws `unknown_item` if item doesn't exist.
 
 <pre>
 item_category('wooden_axe') => tools
@@ -174,6 +180,8 @@ while( (slot = inventory_find(p, 'diamond', slot)) != null, 41, drop_item(p, slo
     // spits all diamonds from player inventory wherever they are
 inventory_drop(x,y,z, 0) => 64 // removed and spawned in the world a full stack of items
 </pre>
+
+Throws `unknown_item` if item doesn't exist.
 
 ### `inventory_remove(inventory, item, amount?)`
 

--- a/docs/scarpet/api/Scoreboard.md
+++ b/docs/scarpet/api/Scoreboard.md
@@ -14,6 +14,8 @@ Adds a new objective to scoreboard. If `criterion` is not specified, assumes `'d
 If the objective already exists, changes the criterion of that objective and returns `false`. If the criterion was not specified but the objective already exists, returns the current criterion.
 If the objective was added, returns `true`. If nothing is affected, returns `null`
 
+Throws `unknown_criterion` if criterion doesn't exist.
+
 <pre>
 scoreboard_add('counter')
 scoreboard_add('lvl','level')

--- a/docs/scarpet/language/FunctionsAndControlFlow.md
+++ b/docs/scarpet/language/FunctionsAndControlFlow.md
@@ -286,6 +286,8 @@ You can specify the `parent` to be either an already existing exception from the
 will not inherit from `user_defined_exception`, or specify a custom one, in which case your exception will inherit from
 `exception` > `user_defined_exception` > `parent` > `id`.
 
+If you don't want your exception to be handled, you can use `error` as the `parent` to throw an error which cannot be handled.
+
 Deprecated usage: `throw()` (without id): Specify at least the id of your exception
 
 ### `if(cond, expr, cond?, expr?, ..., default?)`

--- a/docs/scarpet/language/FunctionsAndControlFlow.md
+++ b/docs/scarpet/language/FunctionsAndControlFlow.md
@@ -234,26 +234,27 @@ returns everywhere, but it would often lead to a messy code.
 
 It terminates entire program passing `expr` as the result of the program execution, or null if omitted.
 
-### `try(expr, id_filter?, catch_expr(_, _msg)?, id_filter2?, catch_expr2(_, _msg), ...)`
+### `try(expr, id_filter, catch_expr(_, _msg), id_filter2?, catch_expr2(_, _msg), ...)`
 
 `try` function evaluates expression, and continues further unless an exception is thrown anywhere inside `expr`, 
 it being produced by `throw` or a catchable exception being thrown by Carpet. In that case the `catch_expr` is evaluated with 
-`_` set to the id of the exception and `_msg` set to the exception message. If an `id_filter` is present, only exceptions
-with an id equal to that value will be caught, and any other exception will continue up the stack. You can specify multiple filters
+`_` set to the id of the exception and `_msg` set to the exception message. Only exceptions with their or their parent's id(recursively) equal 
+to a provided `id_filter` will be caught, and any other exception will continue up the stack. You can specify multiple filters
 and their respective `catch_expr` to be able to catch different exceptions within the same code. When an exception occurs, the script 
 will try to find an equality with every provided filter in order. Therefore, even if the caught exception matches multiple filters, only 
 the first matching block will be executed. It is recommended to filter the exceptions to catch to be able to distinguish from an exception 
 that is known that may happen from one that shouldn't.
 
-This mechanic accepts skipping catch expression - then try returns `null`. This mechanism allows to terminate large 
-portion of a convoluted call stack and continue program  execution.
-
-A `try` block will not only catch any exception whose id match the `id_filter`, but also any exception that has a parent with
-their id being that one, recursively.
+This mechanism allows to terminate large portion of a convoluted call stack and continue program  execution.
 
 The `try` function allows you to catch some Scarpet exceptions for those cases when trying to get things like items,
 blocks, biomes or dimensions from registries, that may have been modified by datapacks, resourcepacks or other mods, or when an error that
 is out of the scope of the programmer occurs, such as problems when reading files.
+
+Deprecated usages:
+- `try(expr)`: Filter the exception you are looking for, and provide something as the `catch_expr` (use `null` if you have nothing to provide).
+                 Example replacement: `try(expr, 'exception', null)`
+- `try(expr, catch_expr)`: Filter the exception you are looking for.
 
 In this documentation, those are documented in at least most of the functions that throw them, and the current exception
 hierarchy is the following:
@@ -274,7 +275,7 @@ hierarchy is the following:
   - `user_defined_exception`: This is the parent for any exception thrown by the below `throw` function, except for those that explicitly declare
                                     their parent to be one of the above
 
-### `throw(id?, message?, parent?)`
+### `throw(id, message?, parent?)`
 
 Throws an exception that can be caught in a `try` block (see above). If ran without arguments, it will pass `null`
 as the value to the `catch_expr`. `message` is the message to show to chat or console in case the `throw` is 
@@ -283,7 +284,9 @@ unhandled.
 By default, the parent of any exception thrown by this function is `user_defined_exception`.
 You can specify the `parent` to be either an already existing exception from the list above, in which case your exception
 will not inherit from `user_defined_exception`, or specify a custom one, in which case your exception will inherit from
-`exception` > `user_defined_exception` > `parent` > `id`
+`exception` > `user_defined_exception` > `parent` > `id`.
+
+Deprecated usage: `throw()` (without id): Specify at least the id of your exception
 
 ### `if(cond, expr, cond?, expr?, ..., default?)`
 

--- a/docs/scarpet/language/FunctionsAndControlFlow.md
+++ b/docs/scarpet/language/FunctionsAndControlFlow.md
@@ -234,13 +234,17 @@ returns everywhere, but it would often lead to a messy code.
 
 It terminates entire program passing `expr` as the result of the program execution, or null if omitted.
 
-### `try(expr, id_filter?, catch_expr(_, _msg)?)`
+### `try(expr, id_filter?, catch_expr(_, _msg)?, id_filter2?, catch_expr2(_, _msg), ...)`
 
 `try` function evaluates expression, and continues further unless an exception is thrown anywhere inside `expr`, 
 it being produced by `throw` or a catchable exception being thrown by Carpet. In that case the `catch_expr` is evaluated with 
 `_` set to the id of the exception and `_msg` set to the exception message. If an `id_filter` is present, only exceptions
-with an id equal to that value will be caught, and any other exception will continue up the stack. It is recommended to filter
-the exceptions to catch to be able to distinguish from an exception that is known that may happen from one that shouldn't.
+with an id equal to that value will be caught, and any other exception will continue up the stack. You can specify multiple filters
+and their respective `catch_expr` to be able to catch different exceptions within the same code. When an exception occurs, the script 
+will try to find an equality with every provided filter in order. Therefore, even if the caught exception matches multiple filters, only 
+the first matching block will be executed. It is recommended to filter the exceptions to catch to be able to distinguish from an exception 
+that is known that may happen from one that shouldn't.
+
 This mechanic accepts skipping catch expression - then try returns `null`. This mechanism allows to terminate large 
 portion of a convoluted call stack and continue program  execution.
 

--- a/docs/scarpet/language/FunctionsAndControlFlow.md
+++ b/docs/scarpet/language/FunctionsAndControlFlow.md
@@ -234,15 +234,41 @@ returns everywhere, but it would often lead to a messy code.
 
 It terminates entire program passing `expr` as the result of the program execution, or null if omitted.
 
-### `try(expr, catch_expr(_)?) ... throw(value?)`
+### `try(expr, id_filter?, catch_expr(_, _msg)?)`
 
-`try` function evaluates expression, and continues further unless `throw` function is called anywhere 
-inside `expr`. In that case the `catch_expr` is evaluates with `_` set to the argument `throw` was called with. 
-This mechanic accepts skipping thrown value - it throws null instead, and catch expression - then try returns 
-null as well This mechanism allows to terminate large portion of a convoluted call stack and continue program 
-execution. There is only one level of exceptions currently in carpet, so if the inner function also defines 
-the `try` catchment area, it will received the exception first, but it can technically rethrow the value its 
-getting for the outer scope. Unhandled throw acts like an exit statement.
+`try` function evaluates expression, and continues further unless an exception is thrown anywhere inside `expr`, 
+it being produced by `throw` or a catchable exception is thrown by Carpet. In that case the `catch_expr` is evaluated with 
+`_` set to the id of the exception and `_msg` set to the exception message. If `id_filter` is present, only exceptions
+with an id equal to that value will be catched, and any other exception will continue up the stack. It is recommended to filter
+the exceptions to catch to be able to distinguish from an exception that is known that may happen from one that shouldn't.
+This mechanic accepts skipping catch expression - then try returns `null`. This mechanism allows to terminate large 
+portion of a convoluted call stack and continue program  execution. There is only one level of exceptions currently in carpet, 
+so if the inner function also defines the `try` catchment area, it will received the exception first, but it can technically 
+rethrow the value its getting for the outer scope.
+
+The `try` function allows you to catch some Scarpet exceptions for those cases when trying to get things like items,
+blocks, biomes or dimensions from registries, that may have been modified by resourcepacks or mods, or when an error that
+is out of the scope of the programmer occurs, like problems when reading a file.
+
+In this documentation, those are documented in at least most of the functions that throw them, and the current list of exceptions
+is the following:
+- `unknown_item`: Happens when a specified item doesn't exist
+- `unknown_block`: Happens when a specified block doesn't exist
+- `unknown_biome`: Happens when a specified biome doesn't exist
+- `unknown_sound`: Happens when a specified sound doesn't exist
+- `unknown_particle`: Happens when a specified particle doesn't exist
+- `unknown_poi_type`: Happens when a specified POI type doesn't exist
+- `unknown_dimension`: Happens when a specified dimension doesn't exist
+- `unknown_structure`: Happens when a specified structure doesn't exist
+- `unknown_criterion`: Happens when a specified scoreboard criterion doesn't exist
+- `nbt_read_exception`: Happens when there is an exception while reading an NBT file
+- `json_read_exception`: Happens when there is an exception while reading a JSON file
+
+### `throw(id?, message?)`
+
+Throws an exception that can be catched in a `try` block (see above). If ran without arguments, it will pass `null`
+as the value to the `catch_expr`. `message` is the message to show to chat or console in case the `throw` is 
+unhandled.
 
 ### `if(cond, expr, cond?, expr?, ..., default?)`
 

--- a/src/main/java/carpet/script/Expression.java
+++ b/src/main/java/carpet/script/Expression.java
@@ -19,7 +19,6 @@ import carpet.script.exception.ExpressionException;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.exception.ResolvedException;
 import carpet.script.exception.ReturnStatement;
-import carpet.script.exception.ThrowStatement;
 import carpet.script.language.Arithmetic;
 import carpet.script.language.ControlFlow;
 import carpet.script.language.DataStructures;
@@ -232,7 +231,7 @@ public class Expression
         if (exc instanceof ExitStatement)
             return exc;
         if (exc instanceof InternalExpressionException)
-            return new ExpressionException(c, e, token, exc.getMessage(), ((InternalExpressionException) exc).stack);
+            return ((InternalExpressionException) exc).promote(c, e, token);
         if (exc instanceof ArithmeticException)
             return new ExpressionException(c, e, token, "Your math is wrong, "+exc.getMessage());
         if (exc instanceof ResolvedException)
@@ -624,9 +623,9 @@ public class Expression
         {
             return exprProvider.get().evalValue(c, expectedType);
         }
-        catch (ContinueStatement | BreakStatement | ReturnStatement | ThrowStatement exc)
+        catch (ContinueStatement | BreakStatement | ReturnStatement exc)
         {
-            throw new ExpressionException(c, this, "Control flow functions, like continue, break, throw or return, should only be used in loops, try blocks, and functions respectively.");
+            throw new ExpressionException(c, this, "Control flow functions, like continue, break or return, should only be used in loops, and functions respectively.");
         }
         catch (ExitStatement exit)
         {

--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -20,6 +20,7 @@ import carpet.script.argument.Vector3Argument;
 import carpet.script.exception.ExitStatement;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.exception.ThrowStatement;
+import carpet.script.exception.Throwables;
 import carpet.script.utils.FixedCommandSource;
 import carpet.script.utils.ScarpetJsonDeserializer;
 import carpet.script.utils.ShapeDispatcher;
@@ -132,7 +133,7 @@ public class Auxiliary {
             Identifier soundName = new Identifier(lv.get(0).evalValue(c).getString());
             Vector3Argument locator = Vector3Argument.findIn(cc, lv, 1);
             if (Registry.SOUND_EVENT.get(soundName) == null)
-                throw new ThrowStatement("No such sound: "+soundName.getPath(), ThrowStatement.UNKNOWN_SOUND);
+                throw new ThrowStatement("No such sound: "+soundName.getPath(), Throwables.UNKNOWN_SOUND);
             float volume = 1.0F;
             float pitch = 1.0F;
             SoundCategory mixer = SoundCategory.MASTER;
@@ -828,7 +829,7 @@ public class Auxiliary {
                     state = ((CarpetScriptHost) c.host).readFileTag(fdesc.getLeft(), fdesc.getRight());
                 } catch (CrashException e)
                 {
-                    throw new ThrowStatement("Couldn't read NBT data", ThrowStatement.NBT_READ_EXCEPTION); 
+                    throw new ThrowStatement("Couldn't read NBT data", Throwables.NBT_READ); 
                 }
 
                 if (state == null) return LazyValue.NULL;
@@ -846,7 +847,7 @@ public class Auxiliary {
                     Throwable exc = e;
                     if(e.getCause() != null)
                         exc = e.getCause();
-                    throw new ThrowStatement("Failed to read JSON file: "+exc.getMessage(), ThrowStatement.JSON_READ_EXCEPTION);
+                    throw new ThrowStatement("Failed to read JSON file: "+exc.getMessage(), Throwables.JSON_READ);
                 }
                 Value parsedJson = gson.fromJson(json, Value.class);
                 if (parsedJson == null)
@@ -940,7 +941,7 @@ public class Auxiliary {
                 state = ((CarpetScriptHost)((CarpetContext)c).host).readFileTag(file, shared);
             } catch (CrashException e)
             {
-                throw new ThrowStatement("Failed to read App data", ThrowStatement.NBT_READ_EXCEPTION);
+                throw new ThrowStatement("Failed to read App data", Throwables.NBT_READ);
             }
             if (state == null)
                 return (cc, tt) -> Value.NULL;

--- a/src/main/java/carpet/script/api/Inventories.java
+++ b/src/main/java/carpet/script/api/Inventories.java
@@ -7,6 +7,7 @@ import carpet.script.Expression;
 import carpet.script.LazyValue;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.exception.ThrowStatement;
+import carpet.script.exception.Throwables;
 import carpet.script.value.ListValue;
 import carpet.script.value.NBTSerializableValue;
 import carpet.script.value.NullValue;
@@ -192,7 +193,7 @@ public class Inventories {
             String itemStr = lv.get(0).evalValue(c).getString();
             Item item;
             Identifier id = new Identifier(itemStr);
-            item = Registry.ITEM.getOrEmpty(id).orElseThrow(() -> new ThrowStatement("Incorrect item: "+itemStr, ThrowStatement.UNKNOWN_ITEM));
+            item = Registry.ITEM.getOrEmpty(id).orElseThrow(() -> new ThrowStatement("Incorrect item: "+itemStr, Throwables.UNKNOWN_ITEM));
 
             if (!item.hasRecipeRemainder()) return LazyValue.NULL;
             Value ret = new StringValue(NBTSerializableValue.nameFromRegistryId(Registry.ITEM.getId(item.getRecipeRemainder())));

--- a/src/main/java/carpet/script/api/Inventories.java
+++ b/src/main/java/carpet/script/api/Inventories.java
@@ -6,6 +6,7 @@ import carpet.script.CarpetContext;
 import carpet.script.Expression;
 import carpet.script.LazyValue;
 import carpet.script.exception.InternalExpressionException;
+import carpet.script.exception.ThrowStatement;
 import carpet.script.value.ListValue;
 import carpet.script.value.NBTSerializableValue;
 import carpet.script.value.NullValue;
@@ -119,14 +120,7 @@ public class Inventories {
                 }
             }
             List<Recipe<?>> recipes;
-            try
-            {
-                recipes = ((RecipeManagerInterface) cc.s.getMinecraftServer().getRecipeManager()).getAllMatching(type, new Identifier(recipeName));
-            }
-            catch (InvalidIdentifierException ignored)
-            {
-                return LazyValue.NULL;
-            }
+            recipes = ((RecipeManagerInterface) cc.s.getMinecraftServer().getRecipeManager()).getAllMatching(type, new Identifier(recipeName));
             if (recipes.isEmpty())
                 return LazyValue.NULL;
             List<Value> recipesOutput = new ArrayList<>();
@@ -197,17 +191,9 @@ public class Inventories {
         {
             String itemStr = lv.get(0).evalValue(c).getString();
             Item item;
-            try
-            {
-                Identifier id = new Identifier(itemStr);
-                item = Registry.ITEM.get(id);
-                if (item == Items.AIR && !id.getPath().equalsIgnoreCase("air"))
-                    throw new InvalidIdentifierException("boo");
-            }
-            catch (InvalidIdentifierException ignored)
-            {
-                throw new InternalExpressionException("Incorrect item: "+itemStr);
-            }
+            Identifier id = new Identifier(itemStr);
+            item = Registry.ITEM.getOrEmpty(id).orElseThrow(() -> new ThrowStatement("Incorrect item: "+itemStr, ThrowStatement.UNKNOWN_ITEM));
+
             if (!item.hasRecipeRemainder()) return LazyValue.NULL;
             Value ret = new StringValue(NBTSerializableValue.nameFromRegistryId(Registry.ITEM.getId(item.getRecipeRemainder())));
             return (_c, _t ) -> ret;

--- a/src/main/java/carpet/script/api/Scoreboards.java
+++ b/src/main/java/carpet/script/api/Scoreboards.java
@@ -6,6 +6,7 @@ import carpet.script.CarpetContext;
 import carpet.script.Expression;
 import carpet.script.LazyValue;
 import carpet.script.exception.InternalExpressionException;
+import carpet.script.exception.ThrowStatement;
 import carpet.script.value.EntityValue;
 import carpet.script.value.ListValue;
 import carpet.script.value.NullValue;
@@ -131,7 +132,7 @@ public class Scoreboards {
                 criterion = ScoreboardCriterion.createStatCriterion(critetionName).orElse(null);
                 if (criterion==null)
                 {
-                    throw new InternalExpressionException("Unknown scoreboard criterion: "+critetionName);
+                    throw new ThrowStatement("Unknown scoreboard criterion: "+critetionName, ThrowStatement.UNKNOWN_CRITERION);
                 }
             }
 

--- a/src/main/java/carpet/script/api/Scoreboards.java
+++ b/src/main/java/carpet/script/api/Scoreboards.java
@@ -7,6 +7,7 @@ import carpet.script.Expression;
 import carpet.script.LazyValue;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.exception.ThrowStatement;
+import carpet.script.exception.Throwables;
 import carpet.script.value.EntityValue;
 import carpet.script.value.ListValue;
 import carpet.script.value.NullValue;
@@ -132,7 +133,7 @@ public class Scoreboards {
                 criterion = ScoreboardCriterion.createStatCriterion(critetionName).orElse(null);
                 if (criterion==null)
                 {
-                    throw new ThrowStatement("Unknown scoreboard criterion: "+critetionName, ThrowStatement.UNKNOWN_CRITERION);
+                    throw new ThrowStatement("Unknown scoreboard criterion: "+critetionName, Throwables.UNKNOWN_CRITERION);
                 }
             }
 

--- a/src/main/java/carpet/script/api/WorldAccess.java
+++ b/src/main/java/carpet/script/api/WorldAccess.java
@@ -19,6 +19,7 @@ import carpet.script.LazyValue;
 import carpet.script.argument.BlockArgument;
 import carpet.script.argument.Vector3Argument;
 import carpet.script.exception.InternalExpressionException;
+import carpet.script.exception.ThrowStatement;
 import carpet.script.utils.BiomeInfo;
 import carpet.script.utils.WorldTools;
 import carpet.script.value.BlockValue;
@@ -336,8 +337,8 @@ public class WorldAccess {
                 String poiType = lv.get(locator.offset+1).evalValue(c).getString().toLowerCase(Locale.ROOT);
                 if (!"any".equals(poiType))
                 {
-                    PointOfInterestType type =  Registry.POINT_OF_INTEREST_TYPE.get(new Identifier(poiType));
-                    if (type == PointOfInterestType.UNEMPLOYED && !"unemployed".equals(poiType)) return LazyValue.NULL;
+                    PointOfInterestType type =  Registry.POINT_OF_INTEREST_TYPE.getOrEmpty(new Identifier(poiType))
+                            .orElseThrow(() -> new ThrowStatement("Unknown POI type", ThrowStatement.UNKNOWN_POI_TYPE));
                     condition = (tt) -> tt == type;
                 }
                 if (locator.offset + 2 < lv.size())
@@ -391,9 +392,8 @@ public class WorldAccess {
                 return LazyValue.FALSE;
             }
             String poiTypeString = poi.getString().toLowerCase(Locale.ROOT);
-            PointOfInterestType type =  Registry.POINT_OF_INTEREST_TYPE.get(new Identifier(poiTypeString));
-            // solving lack of null with defaulted registries
-            if (type == PointOfInterestType.UNEMPLOYED && !"unemployed".equals(poiTypeString)) throw new InternalExpressionException("Unknown POI type: "+poiTypeString);
+            PointOfInterestType type =  Registry.POINT_OF_INTEREST_TYPE.getOrEmpty(new Identifier(poiTypeString))
+            		.orElseThrow(() -> new ThrowStatement("Unknown POI type: "+poiTypeString, ThrowStatement.UNKNOWN_POI_TYPE));
             int occupancy = 0;
             if (locator.offset + 1 < lv.size())
             {
@@ -872,9 +872,8 @@ public class WorldAccess {
                 {
                     playerBreak = true;
                     String itemString = val.getString();
-                    item = Registry.ITEM.get(new Identifier(itemString));
-                    if (item == Items.AIR && !itemString.equals("air"))
-                        throw new InternalExpressionException("Incorrect item: " + itemString);
+                    item = Registry.ITEM.getOrEmpty(new Identifier(itemString))
+                            .orElseThrow(() -> new ThrowStatement("Incorrect item: " + itemString, ThrowStatement.UNKNOWN_ITEM));
                 }
             }
             CompoundTag tag = null;
@@ -1180,9 +1179,8 @@ public class WorldAccess {
                 throw new InternalExpressionException("'set_biome' needs a biome name as an argument");
             String biomeName = lv.get(locator.offset+0).evalValue(c).getString();
             // from locatebiome command code
-            Biome biome = cc.s.getMinecraftServer().getRegistryManager().get(Registry.BIOME_KEY).get(new Identifier(biomeName));
-            if (biome == null)
-                throw new InternalExpressionException("Unknown biome: "+biomeName);
+            Biome biome = cc.s.getMinecraftServer().getRegistryManager().get(Registry.BIOME_KEY).getOrEmpty(new Identifier(biomeName))
+                .orElseThrow(() -> new ThrowStatement("Unknown biome: "+biomeName, ThrowStatement.UNKNOWN_BIOME));
             boolean doImmediateUpdate = true;
             if (lv.size() > locator.offset+1)
             {
@@ -1251,8 +1249,8 @@ public class WorldAccess {
                 if (!(requested instanceof NullValue))
                 {
                     String reqString = requested.getString();
-                    structure = Registry.STRUCTURE_FEATURE.get(new Identifier(reqString));
-                    if (structure == null) throw new InternalExpressionException("Unknown structure: " + reqString);
+                    structure = Registry.STRUCTURE_FEATURE.getOrEmpty(new Identifier(reqString))
+                            .orElseThrow(() -> new ThrowStatement("Unknown structure: " + reqString, ThrowStatement.UNKNOWN_STRUCTURE));
                 }
                 if (lv.size() > locator.offset+1)
                 {
@@ -1332,7 +1330,7 @@ public class WorldAccess {
                 throw new InternalExpressionException("'set_structure requires at least position and a structure name");
             String structureName = lv.get(locator.offset).evalValue(c).getString().toLowerCase(Locale.ROOT);
             ConfiguredStructureFeature<?, ?> configuredStructure = FeatureGenerator.resolveConfiguredStructure(structureName, world, pos);
-            if (configuredStructure == null) throw new InternalExpressionException("Unknown structure: "+structureName);
+            if (configuredStructure == null) throw new ThrowStatement("Unknown structure: "+structureName, ThrowStatement.UNKNOWN_STRUCTURE);
             // good 'ol pointer
             Value[] result = new Value[]{Value.NULL};
             // technically a world modification. Even if we could let it slide, we will still park it

--- a/src/main/java/carpet/script/api/WorldAccess.java
+++ b/src/main/java/carpet/script/api/WorldAccess.java
@@ -20,6 +20,7 @@ import carpet.script.argument.BlockArgument;
 import carpet.script.argument.Vector3Argument;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.exception.ThrowStatement;
+import carpet.script.exception.Throwables;
 import carpet.script.utils.BiomeInfo;
 import carpet.script.utils.WorldTools;
 import carpet.script.value.BlockValue;
@@ -338,7 +339,7 @@ public class WorldAccess {
                 if (!"any".equals(poiType))
                 {
                     PointOfInterestType type =  Registry.POINT_OF_INTEREST_TYPE.getOrEmpty(new Identifier(poiType))
-                            .orElseThrow(() -> new ThrowStatement("Unknown POI type", ThrowStatement.UNKNOWN_POI_TYPE));
+                            .orElseThrow(() -> new ThrowStatement("Unknown POI type", Throwables.UNKNOWN_POI_TYPE));
                     condition = (tt) -> tt == type;
                 }
                 if (locator.offset + 2 < lv.size())
@@ -393,7 +394,7 @@ public class WorldAccess {
             }
             String poiTypeString = poi.getString().toLowerCase(Locale.ROOT);
             PointOfInterestType type =  Registry.POINT_OF_INTEREST_TYPE.getOrEmpty(new Identifier(poiTypeString))
-            		.orElseThrow(() -> new ThrowStatement("Unknown POI type: "+poiTypeString, ThrowStatement.UNKNOWN_POI_TYPE));
+            		.orElseThrow(() -> new ThrowStatement("Unknown POI type: "+poiTypeString, Throwables.UNKNOWN_POI_TYPE));
             int occupancy = 0;
             if (locator.offset + 1 < lv.size())
             {
@@ -873,7 +874,7 @@ public class WorldAccess {
                     playerBreak = true;
                     String itemString = val.getString();
                     item = Registry.ITEM.getOrEmpty(new Identifier(itemString))
-                            .orElseThrow(() -> new ThrowStatement("Incorrect item: " + itemString, ThrowStatement.UNKNOWN_ITEM));
+                            .orElseThrow(() -> new ThrowStatement("Incorrect item: " + itemString, Throwables.UNKNOWN_ITEM));
                 }
             }
             CompoundTag tag = null;
@@ -1180,7 +1181,7 @@ public class WorldAccess {
             String biomeName = lv.get(locator.offset+0).evalValue(c).getString();
             // from locatebiome command code
             Biome biome = cc.s.getMinecraftServer().getRegistryManager().get(Registry.BIOME_KEY).getOrEmpty(new Identifier(biomeName))
-                .orElseThrow(() -> new ThrowStatement("Unknown biome: "+biomeName, ThrowStatement.UNKNOWN_BIOME));
+                .orElseThrow(() -> new ThrowStatement("Unknown biome: "+biomeName, Throwables.UNKNOWN_BIOME));
             boolean doImmediateUpdate = true;
             if (lv.size() > locator.offset+1)
             {
@@ -1250,7 +1251,7 @@ public class WorldAccess {
                 {
                     String reqString = requested.getString();
                     structure = Registry.STRUCTURE_FEATURE.getOrEmpty(new Identifier(reqString))
-                            .orElseThrow(() -> new ThrowStatement("Unknown structure: " + reqString, ThrowStatement.UNKNOWN_STRUCTURE));
+                            .orElseThrow(() -> new ThrowStatement("Unknown structure: " + reqString, Throwables.UNKNOWN_STRUCTURE));
                 }
                 if (lv.size() > locator.offset+1)
                 {
@@ -1330,7 +1331,7 @@ public class WorldAccess {
                 throw new InternalExpressionException("'set_structure requires at least position and a structure name");
             String structureName = lv.get(locator.offset).evalValue(c).getString().toLowerCase(Locale.ROOT);
             ConfiguredStructureFeature<?, ?> configuredStructure = FeatureGenerator.resolveConfiguredStructure(structureName, world, pos);
-            if (configuredStructure == null) throw new ThrowStatement("Unknown structure: "+structureName, ThrowStatement.UNKNOWN_STRUCTURE);
+            if (configuredStructure == null) throw new ThrowStatement("Unknown structure: "+structureName, Throwables.UNKNOWN_STRUCTURE);
             // good 'ol pointer
             Value[] result = new Value[]{Value.NULL};
             // technically a world modification. Even if we could let it slide, we will still park it

--- a/src/main/java/carpet/script/exception/InternalExpressionException.java
+++ b/src/main/java/carpet/script/exception/InternalExpressionException.java
@@ -1,5 +1,8 @@
 package carpet.script.exception;
 
+import carpet.script.Context;
+import carpet.script.Expression;
+import carpet.script.Tokenizer;
 import carpet.script.value.FunctionValue;
 
 import java.util.ArrayList;
@@ -12,5 +15,21 @@ public class InternalExpressionException extends RuntimeException
     public InternalExpressionException(String message)
     {
         super(message);
+    }
+    
+    /**
+     * <p>Promotes this simple exception into one with context and extra information.
+     * 
+     * <p>Provides a cleaner way of handling similar exceptions, in this case
+     * {@link InternalExpressionException} and {@link ThrowStatement} 
+     * @param c Context
+     * @param e Expression
+     * @param token Token
+     * @return The new {@link ExpressionException} (or {@link ProcessedThrowStatement}),
+     *         depending on the implementation.
+     */
+    public ExpressionException promote(Context c, Expression e, Tokenizer.Token token)
+    {
+        return new ExpressionException(c, e, token, getMessage(), stack);
     }
 }

--- a/src/main/java/carpet/script/exception/ProcessedThrowStatement.java
+++ b/src/main/java/carpet/script/exception/ProcessedThrowStatement.java
@@ -6,15 +6,14 @@ import carpet.script.Context;
 import carpet.script.Expression;
 import carpet.script.Tokenizer.Token;
 import carpet.script.value.FunctionValue;
-import carpet.script.value.Value;
 
 public class ProcessedThrowStatement extends ExpressionException {
-    public final Value exceptionName;
+    public final Throwables.Exception exception;
     public final String message;
     
-    public ProcessedThrowStatement(Context c, Expression e, Token token, String message, List<FunctionValue> stack, Value exceptionName) {
+    public ProcessedThrowStatement(Context c, Expression e, Token token, String message, List<FunctionValue> stack, Throwables.Exception exception) {
         super(c, e, token, "Unhandled exception: "+message, stack);
-        this.exceptionName = exceptionName;
+        this.exception = exception;
         this.message = message;
     }
 }

--- a/src/main/java/carpet/script/exception/ProcessedThrowStatement.java
+++ b/src/main/java/carpet/script/exception/ProcessedThrowStatement.java
@@ -1,0 +1,20 @@
+package carpet.script.exception;
+
+import java.util.List;
+
+import carpet.script.Context;
+import carpet.script.Expression;
+import carpet.script.Tokenizer.Token;
+import carpet.script.value.FunctionValue;
+import carpet.script.value.Value;
+
+public class ProcessedThrowStatement extends ExpressionException {
+    public final Value exceptionName;
+    public final String message;
+    
+    public ProcessedThrowStatement(Context c, Expression e, Token token, String message, List<FunctionValue> stack, Value exceptionName) {
+        super(c, e, token, "Unhandled exception: "+message, stack);
+        this.exceptionName = exceptionName;
+        this.message = message;
+    }
+}

--- a/src/main/java/carpet/script/exception/ThrowStatement.java
+++ b/src/main/java/carpet/script/exception/ThrowStatement.java
@@ -39,9 +39,10 @@ public class ThrowStatement extends InternalExpressionException
      * Conveniently creates a value from the {@code value} String
      * to be used easily in Java code
      * @param message The message to display when not handled
-     * @param value A String that will be converted 
-     *              to a value to pass to {@code catch}
-     *              blocks
+     * @param exception An {@link Exception} containing the inheritance data
+     *                  for this exception. When throwing from Java,
+     *                  those exceptions should be pre-registered and used
+     *                  instead of creating new ones each time.
      * @param parent This exception's data
      */
     public ThrowStatement(String message, Exception exception)

--- a/src/main/java/carpet/script/exception/ThrowStatement.java
+++ b/src/main/java/carpet/script/exception/ThrowStatement.java
@@ -3,47 +3,35 @@ package carpet.script.exception;
 import carpet.script.Context;
 import carpet.script.Expression;
 import carpet.script.Tokenizer.Token;
-import carpet.script.value.StringValue;
 import carpet.script.value.Value;
+
+import static carpet.script.exception.Throwables.Exception;
 
 public class ThrowStatement extends InternalExpressionException
 {
-    public static final String UNKNOWN_ITEM        = "unknown_item";
-    public static final String UNKNOWN_BLOCK       = "unknown_block";
-    public static final String UNKNOWN_BIOME       = "unknown_biome";
-    public static final String UNKNOWN_SOUND       = "unknown_sound";
-    public static final String UNKNOWN_PARTICLE    = "unknown_particle";
-    public static final String UNKNOWN_POI_TYPE    = "unknown_poi_type";
-    public static final String UNKNOWN_DIMENSION   = "unknown_dimension";
-    public static final String UNKNOWN_STRUCTURE   = "unknown_structure";
-    public static final String UNKNOWN_CRITERION   = "unknown_criterion";
-    public static final String NBT_READ_EXCEPTION  = "nbt_read_exception";
-    public static final String JSON_READ_EXCEPTION = "json_read_exception";
-    public final Value retval;
+    private final Exception exception;
     /**
      * Creates a throw exception from a value.
      * That value will also be used as the message.<br>
-     * To use when throwing from Scarpet's {@code throw}
+     * To be used when throwing from Scarpet's {@code throw} function with a single argument
      * @param value The value to pass
      */
     public ThrowStatement(Value value)
     {
-        super(value.getString());
-        retval = value;
+        this(value, value, Value.NULL);
     }
     
     /**
-     * Creates a throw exception from a value, and 
-     * assigns it a specified message.<br>
-     * To use when throwing from Scarpet's {@code throw}
-     * function
+     * Creates a throw exception from a value, and assigns it a specified message.
+     * <p>To be used when throwing from Scarpet's {@code throw} function
      * @param message The message to display if uncaught
      * @param value The value to pass
+     * @param parent A parent's name
      */
-    public ThrowStatement(String message, Value value)
+    public ThrowStatement(Value message, Value value, Value parent)
     {
-        super(message);
-        retval = value;
+        super(message.getString());
+        exception = new Exception(value, parent);
     }
 
     /**
@@ -54,15 +42,16 @@ public class ThrowStatement extends InternalExpressionException
      * @param value A String that will be converted 
      *              to a value to pass to {@code catch}
      *              blocks
+     * @param parent This exception's data
      */
-    public ThrowStatement(String message, String value)
+    public ThrowStatement(String message, Exception exception)
     {
         super(message);
-        retval = new StringValue(value);
+        this.exception = exception;
     }
     
     @Override
     public ExpressionException promote(Context c, Expression e, Token token) {
-        return new ProcessedThrowStatement(c, e, token, getMessage(), stack, retval);
+        return new ProcessedThrowStatement(c, e, token, getMessage(), stack, exception);
     }
 }

--- a/src/main/java/carpet/script/exception/ThrowStatement.java
+++ b/src/main/java/carpet/script/exception/ThrowStatement.java
@@ -1,11 +1,68 @@
 package carpet.script.exception;
 
+import carpet.script.Context;
+import carpet.script.Expression;
+import carpet.script.Tokenizer.Token;
+import carpet.script.value.StringValue;
 import carpet.script.value.Value;
 
-public class ThrowStatement extends ExitStatement
+public class ThrowStatement extends InternalExpressionException
 {
+    public static final String UNKNOWN_ITEM        = "unknown_item";
+    public static final String UNKNOWN_BLOCK       = "unknown_block";
+    public static final String UNKNOWN_BIOME       = "unknown_biome";
+    public static final String UNKNOWN_SOUND       = "unknown_sound";
+    public static final String UNKNOWN_PARTICLE    = "unknown_particle";
+    public static final String UNKNOWN_POI_TYPE    = "unknown_poi_type";
+    public static final String UNKNOWN_DIMENSION   = "unknown_dimension";
+    public static final String UNKNOWN_STRUCTURE   = "unknown_structure";
+    public static final String UNKNOWN_CRITERION   = "unknown_criterion";
+    public static final String NBT_READ_EXCEPTION  = "nbt_read_exception";
+    public static final String JSON_READ_EXCEPTION = "json_read_exception";
+    public final Value retval;
+    /**
+     * Creates a throw exception from a value.
+     * That value will also be used as the message.<br>
+     * To use when throwing from Scarpet's {@code throw}
+     * @param value The value to pass
+     */
     public ThrowStatement(Value value)
     {
-        super(value);
+        super(value.getString());
+        retval = value;
+    }
+    
+    /**
+     * Creates a throw exception from a value, and 
+     * assigns it a specified message.<br>
+     * To use when throwing from Scarpet's {@code throw}
+     * function
+     * @param message The message to display if uncaught
+     * @param value The value to pass
+     */
+    public ThrowStatement(String message, Value value)
+    {
+        super(message);
+        retval = value;
+    }
+
+    /**
+     * Creates a throw exception.<br>
+     * Conveniently creates a value from the {@code value} String
+     * to be used easily in Java code
+     * @param message The message to display when not handled
+     * @param value A String that will be converted 
+     *              to a value to pass to {@code catch}
+     *              blocks
+     */
+    public ThrowStatement(String message, String value)
+    {
+        super(message);
+        retval = new StringValue(value);
+    }
+    
+    @Override
+    public ExpressionException promote(Context c, Expression e, Token token) {
+        return new ProcessedThrowStatement(c, e, token, getMessage(), stack, retval);
     }
 }

--- a/src/main/java/carpet/script/exception/Throwables.java
+++ b/src/main/java/carpet/script/exception/Throwables.java
@@ -12,10 +12,10 @@ import carpet.script.value.Value;
  * methods to check whether filters are compatible with those.
  * 
  * Exceptions here cannot be thrown as an actual {@link Throwable}, they are just part of the metadata for
- * {@link ThrowStatement}
+ * {@link ThrowStatement} and {@link ProcessedThrowStatement}
  */
 public class Throwables {
-    private static final Map<Value, Exception> byValue = new HashMap<>();
+    protected static final Map<Value, Exception> byValue = new HashMap<>();
     public static final Exception EXCEPTION               = register("exception", null);
     public static final Exception   VALUE_EXCEPTION       = register("value_exception", EXCEPTION);
     public static final Exception     UNKNOWN_ITEM        = register("unknown_item", VALUE_EXCEPTION);
@@ -39,11 +39,11 @@ public class Throwables {
      * Creates an exception and registers it to be used as parent for
      * user defined exceptions in Scarpet's throw function.
      * <p>Scarpet exceptions should, in general, have a top-level parent being {@link Throwables#EXCEPTION} 
-     * @param name The name for the exception. Will be converted into a {@link StringValue}
+     * @param value The value for the exception as a {@link String}. Will be converted into a {@link StringValue}
      * @param parent The parent of the exception being created, or <code>null</code> if top-level
      * @return The created exception
      */
-    protected static Exception register(String value, Exception parent)
+    public static Exception register(String value, Exception parent)
     {
         Exception exc = new Exception(value, parent);
         byValue.put(exc.getValue(), exc);
@@ -65,14 +65,14 @@ public class Throwables {
          * <p>Parent will default to {@link Throwables#USER_DEFINED} if provided
          * parentValue meets Value#isNull, else it will create a new {@link Exception},
          * with its parent being {@link Throwables#USER_DEFINED}.
-         * @param name The name/id of the exception
-         * @param parentValue An optional Value matching the name of a parent exception.
-         *               <br>Accepts a {@link NullValue}, but not a <code>null</code>
+         * @param value The {@link Value} of the exception
+         * @param parentValue An optional {@link Value} matching the name of a parent exception.
+         *               <br>Accepts a {@link NullValue}, but not a {@code null}
          */
         public Exception(Value value, Value parentValue)
         {
             if (byValue.containsKey(value))
-                throw new InternalExpressionException("Exception id can't be the same as existing exception. Use it as parent instead");
+                throw new InternalExpressionException("Exception value can't be the same as existing exception. Use it as parent instead");
             this.value = value;
             if (!parentValue.isNull())
             {
@@ -87,7 +87,7 @@ public class Throwables {
          * Creates a new exception.
          * <p>Not suitable for creating exceptions that can't be caught.
          * Use an {@link InternalExpressionException} for that
-         * @param name The exception's name/id
+         * @param value The exception's value as a {@link String}
          * @param parent The parent exception, or <code>null</code> if no parent is available
          */
         protected Exception(String value, Exception parent)
@@ -100,7 +100,7 @@ public class Throwables {
         /**
          * Checks whether the given filter matches an instance of this exception, including checking equality
          * with itself and possible parents.
-         * @param filter The value to check against
+         * @param filter The {@link Value} to check against
          * @return Whether or not the given value matches this exception's hierarchy
          */
         public boolean isInstance(Value filter) {

--- a/src/main/java/carpet/script/exception/Throwables.java
+++ b/src/main/java/carpet/script/exception/Throwables.java
@@ -65,6 +65,8 @@ public class Throwables {
          * <p>Parent will default to {@link Throwables#USER_DEFINED} if provided
          * parentValue meets Value#isNull, else it will create a new {@link Exception},
          * with its parent being {@link Throwables#USER_DEFINED}.
+         * <p>If passed parent matches {@link Throwables#ERROR}, it will create an error
+         * exception, which cannot be caught.
          * @param value The {@link Value} of the exception
          * @param parentValue An optional {@link Value} matching the name of a parent exception.
          *               <br>Accepts a {@link NullValue}, but not a {@code null}
@@ -98,7 +100,7 @@ public class Throwables {
         }
         
         /**
-         * Checks whether the given filter matches an instance of this exception, including checking equality
+         * Checks whether the given filter matches an instance of this exception, by checking equality
          * with itself and possible parents.
          * @param filter The {@link Value} to check against
          * @return Whether or not the given value matches this exception's hierarchy

--- a/src/main/java/carpet/script/exception/Throwables.java
+++ b/src/main/java/carpet/script/exception/Throwables.java
@@ -1,0 +1,127 @@
+package carpet.script.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import carpet.script.value.NullValue;
+import carpet.script.value.StringValue;
+import carpet.script.value.Value;
+
+/**
+ * This class contains default Scarpet catchable exception's ids, as well as their inheritance and 
+ * methods to check whether filters are compatible with those.
+ * 
+ * Exceptions here cannot be thrown as an actual {@link Throwable}, they are just part of the metadata for
+ * {@link ThrowStatement}
+ */
+public class Throwables {
+    private static final Map<Value, Exception> byValue = new HashMap<>();
+    public static final Exception EXCEPTION               = register("exception", null);
+    public static final Exception   VALUE_EXCEPTION       = register("value_exception", EXCEPTION);
+    public static final Exception     UNKNOWN_ITEM        = register("unknown_item", VALUE_EXCEPTION);
+    public static final Exception     UNKNOWN_BLOCK       = register("unknown_block", VALUE_EXCEPTION);
+    public static final Exception     UNKNOWN_BIOME       = register("unknown_biome", VALUE_EXCEPTION);
+    public static final Exception     UNKNOWN_SOUND       = register("unknown_sound", VALUE_EXCEPTION);
+    public static final Exception     UNKNOWN_PARTICLE    = register("unknown_particle", VALUE_EXCEPTION);
+    public static final Exception     UNKNOWN_POI_TYPE    = register("unknown_poi_type", VALUE_EXCEPTION);
+    public static final Exception     UNKNOWN_DIMENSION   = register("unknown_dimension", VALUE_EXCEPTION);
+    public static final Exception     UNKNOWN_STRUCTURE   = register("unknown_structure", VALUE_EXCEPTION);
+    public static final Exception     UNKNOWN_CRITERION   = register("unknown_criterion", VALUE_EXCEPTION);
+    public static final Exception   FILE_READ_EXCEPTION   = register("file_read_exception", EXCEPTION);
+    public static final Exception     NBT_READ            = register("nbt_read_exception", FILE_READ_EXCEPTION);
+    public static final Exception     JSON_READ           = register("json_read_exception", FILE_READ_EXCEPTION);
+    public static final Exception   USER_DEFINED          = register("user_defined_exception", EXCEPTION);
+    protected static final Exception ERROR                = register("error", null);
+    
+    private Throwables() {}
+    
+    /**
+     * Creates an exception and registers it to be used as parent for
+     * user defined exceptions in Scarpet's throw function.
+     * <p>Scarpet exceptions should, in general, have a top-level parent being {@link Throwables#EXCEPTION} 
+     * @param name The name for the exception. Will be converted into a {@link StringValue}
+     * @param parent The parent of the exception being created, or <code>null</code> if top-level
+     * @return The created exception
+     */
+    protected static Exception register(String value, Exception parent)
+    {
+        Exception exc = new Exception(value, parent);
+        byValue.put(exc.getValue(), exc);
+        return exc;
+    }
+    
+    /**
+     * The data of a {@link ThrowStatement} exception. Supports creating with inheritance and
+     * checking whether a filter is compatible with them.
+     */
+    public static class Exception {
+        private final Value value;
+        private final Exception parent;
+        private final boolean isError;
+        
+        /**
+         * Creates a new exception, with an optional parent.
+         * <p>To be used in Scarpet's throw command
+         * <p>Parent will default to {@link Throwables#USER_DEFINED} if provided
+         * parentValue meets Value#isNull, else it will create a new {@link Exception},
+         * with its parent being {@link Throwables#USER_DEFINED}.
+         * @param name The name/id of the exception
+         * @param parentValue An optional Value matching the name of a parent exception.
+         *               <br>Accepts a {@link NullValue}, but not a <code>null</code>
+         */
+        public Exception(Value value, Value parentValue)
+        {
+            if (byValue.containsKey(value))
+                throw new InternalExpressionException("Exception id can't be the same as existing exception. Use it as parent instead");
+            this.value = value;
+            if (!parentValue.isNull())
+            {
+                Exception possibleParent = byValue.get(parentValue);
+                parent = possibleParent == null ? new Exception(parentValue, Value.NULL) : possibleParent;
+            } else
+                parent = USER_DEFINED;
+            isError = this.parent == ERROR;
+        }
+        
+        /**
+         * Creates a new exception.
+         * <p>Not suitable for creating exceptions that can't be caught.
+         * Use an {@link InternalExpressionException} for that
+         * @param name The exception's name/id
+         * @param parent The parent exception, or <code>null</code> if no parent is available
+         */
+        protected Exception(String value, Exception parent)
+        {
+            this.value = StringValue.of(value);
+            this.parent = parent;
+            this.isError = false;
+        }
+        
+        /**
+         * Checks whether the given filter matches an instance of this exception, including checking equality
+         * with itself and possible parents.
+         * @param filter The value to check against
+         * @return Whether or not the given value matches this exception's hierarchy
+         */
+        public boolean isInstance(Value filter) {
+            return getValue().equals(filter) || (parent != null && parent.isInstance(filter));
+        }
+        
+        /**
+         * Returns the {@link Value} provided when creating this exception
+         * @return The {@link Value} of this exception
+         */
+        public Value getValue() {
+            return value;
+        }
+        
+        /**
+         * Returns whether this exception has been defined as an error.
+         * <p> Error exceptions cannot be caught in Scarpet
+         * @return Whether this exception has been defined as an error
+         */
+        public boolean isError() {
+            return isError;
+        }
+    }
+}

--- a/src/main/java/carpet/script/utils/ShapeDispatcher.java
+++ b/src/main/java/carpet/script/utils/ShapeDispatcher.java
@@ -4,6 +4,7 @@ import carpet.CarpetSettings;
 import carpet.network.ServerNetworkHandler;
 import carpet.script.CarpetContext;
 import carpet.script.exception.InternalExpressionException;
+import carpet.script.exception.ThrowStatement;
 import carpet.script.language.Sys;
 import carpet.script.value.BlockValue;
 import carpet.script.value.EntityValue;
@@ -156,7 +157,7 @@ public class ShapeDispatcher
         }
         catch (CommandSyntaxException e)
         {
-            throw new InternalExpressionException("No such particle: "+name);
+            throw new ThrowStatement("No such particle: "+name, ThrowStatement.UNKNOWN_PARTICLE);
         }
         particleCache.put(name, particle);
         return particle;

--- a/src/main/java/carpet/script/utils/ShapeDispatcher.java
+++ b/src/main/java/carpet/script/utils/ShapeDispatcher.java
@@ -5,6 +5,7 @@ import carpet.network.ServerNetworkHandler;
 import carpet.script.CarpetContext;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.exception.ThrowStatement;
+import carpet.script.exception.Throwables;
 import carpet.script.language.Sys;
 import carpet.script.value.BlockValue;
 import carpet.script.value.EntityValue;
@@ -157,7 +158,7 @@ public class ShapeDispatcher
         }
         catch (CommandSyntaxException e)
         {
-            throw new ThrowStatement("No such particle: "+name, ThrowStatement.UNKNOWN_PARTICLE);
+            throw new ThrowStatement("No such particle: "+name, Throwables.UNKNOWN_PARTICLE);
         }
         particleCache.put(name, particle);
         return particle;

--- a/src/main/java/carpet/script/value/BlockValue.java
+++ b/src/main/java/carpet/script/value/BlockValue.java
@@ -2,6 +2,8 @@ package carpet.script.value;
 
 import carpet.script.CarpetContext;
 import carpet.script.exception.InternalExpressionException;
+import carpet.script.exception.ThrowStatement;
+
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.block.BlockState;
@@ -73,7 +75,7 @@ public class BlockValue extends Value
         catch (CommandSyntaxException ignored)
         {
         }
-        throw new InternalExpressionException("Cannot parse block: "+str);
+        throw new ThrowStatement("Cannot parse block: "+str, ThrowStatement.UNKNOWN_BLOCK);
     }
 
     public static BlockPos locateBlockPos(CarpetContext c, int xpos, int ypos, int zpos)

--- a/src/main/java/carpet/script/value/BlockValue.java
+++ b/src/main/java/carpet/script/value/BlockValue.java
@@ -3,6 +3,7 @@ package carpet.script.value;
 import carpet.script.CarpetContext;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.exception.ThrowStatement;
+import carpet.script.exception.Throwables;
 
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -75,7 +76,7 @@ public class BlockValue extends Value
         catch (CommandSyntaxException ignored)
         {
         }
-        throw new ThrowStatement("Cannot parse block: "+str, ThrowStatement.UNKNOWN_BLOCK);
+        throw new ThrowStatement("Cannot parse block: "+str, Throwables.UNKNOWN_BLOCK);
     }
 
     public static BlockPos locateBlockPos(CarpetContext c, int xpos, int ypos, int zpos)

--- a/src/main/java/carpet/script/value/FunctionValue.java
+++ b/src/main/java/carpet/script/value/FunctionValue.java
@@ -215,7 +215,6 @@ public class FunctionValue extends Value implements Fluff.ILazyFunction
 
         }
         Value retVal;
-        boolean rethrow = false;
         try
         {
             retVal = body.evalValue(newFrame, type); // todo not sure if we need to propagete type / consider boolean context in defined functions - answer seems ye
@@ -227,15 +226,6 @@ public class FunctionValue extends Value implements Fluff.ILazyFunction
         catch (ReturnStatement returnStatement)
         {
             retVal = returnStatement.retval;
-        }
-        catch (ThrowStatement throwStatement) // might not be really necessary
-        {
-            retVal = throwStatement.retval;
-            rethrow = true;
-        }
-        if (rethrow)
-        {
-            throw new ThrowStatement(retVal);
         }
         Value otherRetVal = retVal;
         return (cc, tt) -> otherRetVal;

--- a/src/main/java/carpet/script/value/NBTSerializableValue.java
+++ b/src/main/java/carpet/script/value/NBTSerializableValue.java
@@ -5,6 +5,7 @@ import carpet.script.CarpetContext;
 import carpet.script.LazyValue;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.exception.ThrowStatement;
+import carpet.script.exception.Throwables;
 import carpet.script.utils.EquipmentInventory;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -298,7 +299,7 @@ public class NBTSerializableValue extends Value implements ContainerValueInterfa
         }
         catch (CommandSyntaxException e)
         {
-            throw new ThrowStatement("Incorrect item: "+itemString, ThrowStatement.UNKNOWN_ITEM);
+            throw new ThrowStatement("Incorrect item: "+itemString, Throwables.UNKNOWN_ITEM);
         }
     }
 

--- a/src/main/java/carpet/script/value/NBTSerializableValue.java
+++ b/src/main/java/carpet/script/value/NBTSerializableValue.java
@@ -4,6 +4,7 @@ import carpet.fakes.InventoryBearerInterface;
 import carpet.script.CarpetContext;
 import carpet.script.LazyValue;
 import carpet.script.exception.InternalExpressionException;
+import carpet.script.exception.ThrowStatement;
 import carpet.script.utils.EquipmentInventory;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -297,7 +298,7 @@ public class NBTSerializableValue extends Value implements ContainerValueInterfa
         }
         catch (CommandSyntaxException e)
         {
-            throw new InternalExpressionException("Incorrect item: "+itemString);
+            throw new ThrowStatement("Incorrect item: "+itemString, ThrowStatement.UNKNOWN_ITEM);
         }
     }
 

--- a/src/main/java/carpet/script/value/ValueConversions.java
+++ b/src/main/java/carpet/script/value/ValueConversions.java
@@ -2,6 +2,7 @@ package carpet.script.value;
 
 import carpet.fakes.BlockPredicateInterface;
 import carpet.script.exception.InternalExpressionException;
+import carpet.script.exception.ThrowStatement;
 import carpet.utils.BlockInfo;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.MaterialColor;
@@ -158,7 +159,7 @@ public class ValueConversions
                         }
                     }
                     if (dim == null)
-                        throw new InternalExpressionException("Incorrect dimension string: "+dimString);
+                        throw new ThrowStatement("Incorrect dimension string: "+dimString, ThrowStatement.UNKNOWN_DIMENSION);
                     return server.getWorld(dim);
             }
         }

--- a/src/main/java/carpet/script/value/ValueConversions.java
+++ b/src/main/java/carpet/script/value/ValueConversions.java
@@ -3,6 +3,7 @@ package carpet.script.value;
 import carpet.fakes.BlockPredicateInterface;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.exception.ThrowStatement;
+import carpet.script.exception.Throwables;
 import carpet.utils.BlockInfo;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.MaterialColor;
@@ -159,7 +160,7 @@ public class ValueConversions
                         }
                     }
                     if (dim == null)
-                        throw new ThrowStatement("Incorrect dimension string: "+dimString, ThrowStatement.UNKNOWN_DIMENSION);
+                        throw new ThrowStatement("Incorrect dimension string: "+dimString, Throwables.UNKNOWN_DIMENSION);
                     return server.getWorld(dim);
             }
         }


### PR DESCRIPTION
Since mods (or even resource/data/whatever packs) can add many things that Scarpet can opt to read, and just returning `null` may not be ideal in many cases, this PR allows some, specified exceptions to be caught. Not every exception is catchable, mostly to prevent people just wrapping everything in a big `try` block. At the same time this PR it also overhauls the current exception system a bit.

What's that overhaul?

Now exceptions have two different values: Their "id" and their message. The id is something that should be kind-of general, in order to allow apps to easily filter exceptions in the code. The message is, well, the message that will be shown in the stacktrace when being unhandled. The id is present in the old `_` variable, and in order to make the message useful, it is passed as `_msg` (feel free to ask for a name change).

Not only that, exception handlers now can (and are encouraged to) filter what exceptions to catch by specifying the second parameter of `try` as the id to match before processing the `try` block. While something similar could be achieved in code by just throwing a new one with the same id and message, filtering them there allows the stacktrace (if needed) to point to the original location that threw it.

How does it work?

First of all, this PR converts the `ThrowStatement` into a subclass of `InternalExpressionException` instead of `ExitStatement`. I don't think the subclass is really needed, but I left it just in case there was something somewhere I didn't see, since I suppose that should prevent code relying on IEEs getting broken with the new catchable ones.

Now, in order for those to have stacktrace and all that info, they need to get converted into some sort of `ExpressionException` in `handleCodeException()`. Therefore, the new exception type `ProcessedThrowException` is a subclass of `ExpressionException` that also keeps the Scarpet information. This is the exception type that will be caught in the `try` blocks, therefore `throw` needs to be a `lazyFunction` (no idea why, else it wouldn't be caught if on the same block and line marking would be wrong), making it be always ready to be caught by `try`.

Note that in order to prevent the "stacktrace" to be shown even when being caught, the message of `ExpressionException` is now lazy. Long story short: It has been a pain to try to locate where were exceptions finally handled, when found I lost it once, and after that just found that would add an extra complexity (passing context, token, etc to `CarpetExpressionException`. Basically at construction, a supplier is created with what would be the message and a dummy message is passed to the `RuntimeException`. Then it overrides `getMessage()` to call the supplier.

This PR also contains a lot (if not all) of the functions that (I think) should be catchable for reasons like distributing and mod/datapack/anything not being present, optional compatibility with some of those, etc.
It also changes some of them to "cleaner" code (using optionals in DefaultedRegistries instead of `v = Registry.BLOCKS.get(id); if(v == Blocks.AIR && id != 'air') throw`).
Also unhandles an exception that shouldn't have ever been handled (`InvalidIdentifierException`), since that is thrown when the identifier (the string like `minecraft:air`) is invalid due to disallowed characters, etc, not when whatever is being searched isn't found.

Exception ids are currently being used from fields in the `ThrowStatement` class in order to make sure all of them are the same for related exceptions.

Docs are updated too.

This works, but may need a bit more testing to make sure nothing is broken. 