### PR TITLE
Fix rules-to-wiki and generalize some code for extension's equivalents

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -159,7 +159,7 @@ jobs:
             "id": "carpet",
             "version": "1.4.11",
             "entrypoints": {
-              "preLaunch": [ "carpet.utils.RulePrinter" ]
+              "server": [ "carpet.utils.RulePrinter" ]
             }
            }' > fabric.mod.json
           cd ../../../

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -159,8 +159,8 @@ jobs:
             "id": "carpet",
             "version": "1.4.11",
             "entrypoints": {
-              "server": [ "carpet.utils.RulePrinter" ],
-              "preLaunch": [ "carpet.utils.RulePrinter" ]
+              "server": [ "carpet.utils.CarpetRulePrinter" ],
+              "preLaunch": [ "carpet.utils.CarpetRulePrinter" ]
             }
            }' > fabric.mod.json
           cd ../../../

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -159,7 +159,8 @@ jobs:
             "id": "carpet",
             "version": "1.4.11",
             "entrypoints": {
-              "server": [ "carpet.utils.RulePrinter" ]
+              "server": [ "carpet.utils.RulePrinter" ],
+              "preLaunch": [ "carpet.utils.RulePrinter" ]
             }
            }' > fabric.mod.json
           cd ../../../

--- a/src/main/java/carpet/utils/CarpetRulePrinter.java
+++ b/src/main/java/carpet/utils/CarpetRulePrinter.java
@@ -13,8 +13,8 @@ import java.lang.System;
  * It is here so it can be managed by the IDE
  *
  */
-public class RulePrinter implements DedicatedServerModInitializer, PreLaunchEntrypoint {
-    private static final PrintStream OLD_OUT = System.out;
+public class CarpetRulePrinter implements DedicatedServerModInitializer, PreLaunchEntrypoint {
+    public static final PrintStream OLD_OUT = System.out;
 
     @Override
     public void onInitializeServer() {

--- a/src/main/java/carpet/utils/RulePrinter.java
+++ b/src/main/java/carpet/utils/RulePrinter.java
@@ -1,20 +1,18 @@
 package carpet.utils;
 
 import carpet.CarpetServer;
-import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+import net.fabricmc.api.DedicatedServerModInitializer;
 import java.lang.System;
 /**
  * Runs only from GitHub Actions to generate the wiki
  * page with all Carpet rules on it.
  * It is here so it can be managed by the IDE
- * 
- * @author altrisi
  *
  */
-public class RulePrinter implements PreLaunchEntrypoint {
+public class RulePrinter implements DedicatedServerModInitializer {
 
     @Override
-    public void onPreLaunch() {
+    public void onInitializeServer() {
         CarpetServer.onGameStarted();
         CarpetServer.settingsManager.printAllRulesToLog(null);
         System.exit(0);

--- a/src/main/java/carpet/utils/RulePrinter.java
+++ b/src/main/java/carpet/utils/RulePrinter.java
@@ -2,19 +2,32 @@ package carpet.utils;
 
 import carpet.CarpetServer;
 import net.fabricmc.api.DedicatedServerModInitializer;
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+import java.io.PrintStream;
 import java.lang.System;
+
 /**
  * Runs only from GitHub Actions to generate the wiki
  * page with all Carpet rules on it.
  * It is here so it can be managed by the IDE
  *
  */
-public class RulePrinter implements DedicatedServerModInitializer {
+public class RulePrinter implements DedicatedServerModInitializer, PreLaunchEntrypoint {
+    private static final PrintStream OLD_OUT = System.out;
 
     @Override
     public void onInitializeServer() {
+        // Minecraft (or whatever) changes the System.out to have prefixes,
+    	// our simple parser doesn't like that. So we change it back
+        System.setOut(OLD_OUT);
         CarpetServer.onGameStarted();
         CarpetServer.settingsManager.printAllRulesToLog(null);
         System.exit(0);
+    }
+    
+    @Override
+    public void onPreLaunch() {
+        // Just initializes our OLD_OUT by nooping the class
     }
 }


### PR DESCRIPTION
Move it later, when the game is ready to be touched.

It previously was in pre-launch because Carpet didn't really touch the game at `onGameStarted`, now it references `Blocks` statically so it basically initializes that and makes a chain reaction until it hits a NPE. This means it'll have to wait for DFU and will take a bit more time, but it should be fine (it's been quite fast on the testrun at https://github.com/altrisi/fabric-carpet/actions/runs/537672403.