### PR TITLE
Add `pingPlayerListLimit` setting

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -531,6 +531,14 @@ public class CarpetSettings
     )
     public static int maxEntityCollisions = 0;
 
+    @Rule(
+            desc = "Customizable server list ping (Multiplayer menu) playerlist sample limit, 0 for no limits",
+            options = {"0", "12", "20", "40"},
+            category = CREATIVE,
+            strict = false,
+            validate = Validator.NONNEGATIVE_NUMBER.class
+    )
+    public static int serverListPingPlayerLimit = 0;
     /*
 
     @Rule(

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -532,13 +532,13 @@ public class CarpetSettings
     public static int maxEntityCollisions = 0;
 
     @Rule(
-            desc = "Customizable server list ping (Multiplayer menu) playerlist sample limit, 0 for no limits",
+            desc = "Customizable server list ping (Multiplayer menu) playerlist sample limit",
             options = {"0", "12", "20", "40"},
             category = CREATIVE,
             strict = false,
             validate = Validator.NONNEGATIVE_NUMBER.class
     )
-    public static int serverListPingPlayerLimit = 0;
+    public static int pingPlayerListLimit = 12;
     /*
 
     @Rule(

--- a/src/main/java/carpet/mixins/MinecraftServer_pingPlayerSampleLimit.java
+++ b/src/main/java/carpet/mixins/MinecraftServer_pingPlayerSampleLimit.java
@@ -1,0 +1,19 @@
+package carpet.mixins;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import carpet.CarpetSettings;
+import net.minecraft.server.MinecraftServer;
+
+@Mixin(MinecraftServer.class)
+public abstract class MinecraftServer_pingPlayerSampleLimit
+{
+
+    @ModifyConstant(method = "tick", constant = @Constant(intValue = 12), require = 1, allow = 1)
+	private int modifyPlayerSampleLimit(int value)
+	{
+		return CarpetSettings.pingPlayerListLimit;
+	}
+}

--- a/src/main/java/carpet/mixins/MinecraftServer_pingPlayerSampleLimit.java
+++ b/src/main/java/carpet/mixins/MinecraftServer_pingPlayerSampleLimit.java
@@ -11,7 +11,7 @@ import net.minecraft.server.MinecraftServer;
 public abstract class MinecraftServer_pingPlayerSampleLimit
 {
 
-    @ModifyConstant(method = "tick", constant = @Constant(intValue = 12), require = 1, allow = 1)
+	@ModifyConstant(method = "tick", constant = @Constant(intValue = 12), require = 0, allow = 1)
 	private int modifyPlayerSampleLimit(int value)
 	{
 		return CarpetSettings.pingPlayerListLimit;

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -24,6 +24,7 @@
     "ServerPlayNetworkHandler_interactionUpdatesMixin",
 
     "ServerMetadata_motdMixin",
+    "MinecraftServer_pingPlayerSampleLimit",
 
     "MinecraftServer_coreMixin",
 


### PR DESCRIPTION
The [ServerListPing Protocol](https://wiki.vg/Server_List_Ping) is used by the client when one is in the multiplayer menu. With it, the client is able to retrieve the server's player number, player limit, protocol version, favicon, and MOTD. One feature of this protocol, is the ability to retrieve a "sample" of up to twelve players currently online on the server. This information can be queried not just from the Minecraft client, but also from [external websites](https://mcsrvstat.us/) and [tools](https://andrews54757.github.io/MCObserver/) regardless of server whitelist status.

On the vanilla client, this info is displayed by hovering over the player number info, like so:

<img width="177" alt="Screen Shot 2021-02-08 at 4 58 18 PM" src="https://user-images.githubusercontent.com/13282284/107286650-dd5f9200-6a2e-11eb-9235-d11287d49553.png">

The current behavior poses two problems:
* Due to privacy concerns, not all server operators may want to broadcast player usernames to the public (addendum: disabling query just for this would be sad).
* For servers that make use of the list, the sample limit of twelve makes some players not show on the list when there are more than twelve players.

To solve these problems, I propose a new rule/setting for carpet called `pingPlayerListLimit`. With this rule, server administrators will be able to set the amount of players shown in the sample. For those who want to hide player-lists, they may set it to 0, while those who want to show more may set it to a higher value.

Tests/Examples:

*With `pingPlayerListLimit` set to 20*
<img width="39" alt="Screen Shot 2021-02-08 at 5 09 21 PM" src="https://user-images.githubusercontent.com/13282284/107287841-82c73580-6a30-11eb-9914-ca5327803a7a.png">

*With `pingPlayerListLimit` set to 1*
<img width="173" alt="Screen Shot 2021-02-08 at 5 11 29 PM" src="https://user-images.githubusercontent.com/13282284/107287963-b7d38800-6a30-11eb-998f-11e4923a1a75.png">

*With `pingPlayerListLimit` set to 0* (nothing shows)

<img width="87" alt="Screen Shot 2021-02-08 at 5 12 15 PM" src="https://user-images.githubusercontent.com/13282284/107288030-cf127580-6a30-11eb-8bd9-1c5e11b9e4af.png">

**Note: This PR uses a ModifyConstant which means this feature will break if other mods also modify it. However, I don't think there is another easy way to do it besides this.**
