### PR TITLE
Struct block protocol

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -799,10 +799,12 @@ public class CarpetSettings
     )
     public static boolean cleanLogs = false;
 
+    public static final int VANILLA_STRUCTURE_BLOCK_LIMIT = 48;
+
     public static class StructureBlockLimitValidator extends Validator<Integer> {
 
         @Override public Integer validate(ServerCommandSource source, ParsedRule<Integer> currentRule, Integer newValue, String string) {
-            return (newValue >= 48) ? newValue : null;
+            return (newValue >= VANILLA_STRUCTURE_BLOCK_LIMIT) ? newValue : null;
         }
 
         @Override
@@ -823,7 +825,7 @@ public class CarpetSettings
             validate = StructureBlockLimitValidator.class,
             strict = false
     )
-    public static int structureBlockLimit = 48;
+    public static int structureBlockLimit = VANILLA_STRUCTURE_BLOCK_LIMIT;
 
     public static class StructureBlockIgnoredValidator extends Validator<String> {
 

--- a/src/main/java/carpet/mixins/StructureBlockScreen_structureBlockLimitMixin.java
+++ b/src/main/java/carpet/mixins/StructureBlockScreen_structureBlockLimitMixin.java
@@ -16,9 +16,9 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 @Mixin(StructureBlockScreen.class)
 public abstract class StructureBlockScreen_structureBlockLimitMixin
 {
-	@Shadow @Final private StructureBlockBlockEntity structureBlock;
+    @Shadow @Final private StructureBlockBlockEntity structureBlock;
 
-	@Inject(method = "method_2516", at = @At(value = "TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
+    @Inject(method = "method_2516", at = @At(value = "TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
     private void sendCarpetStructureBlockPacket(StructureBlockBlockEntity.Action action, CallbackInfoReturnable<Boolean> cir, BlockPos blockPos, BlockPos blockPos2)
     {
         if (CarpetSettings.structureBlockLimit != CarpetSettings.VANILLA_STRUCTURE_BLOCK_LIMIT)

--- a/src/main/java/carpet/mixins/StructureBlockScreen_structureBlockLimitMixin.java
+++ b/src/main/java/carpet/mixins/StructureBlockScreen_structureBlockLimitMixin.java
@@ -1,7 +1,6 @@
 package carpet.mixins;
 
 import carpet.CarpetSettings;
-import carpet.network.CarpetClient;
 import carpet.network.ClientNetworkHandler;
 import net.minecraft.block.entity.StructureBlockBlockEntity;
 import net.minecraft.client.gui.screen.ingame.StructureBlockScreen;
@@ -22,7 +21,7 @@ public abstract class StructureBlockScreen_structureBlockLimitMixin
 	@Inject(method = "method_2516", at = @At(value = "TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
     private void sendCarpetStructureBlockPacket(StructureBlockBlockEntity.Action action, CallbackInfoReturnable<Boolean> cir, BlockPos blockPos, BlockPos blockPos2)
     {
-        if (CarpetClient.isCarpet() && CarpetSettings.structureBlockLimit != CarpetSettings.VANILLA_STRUCTURE_BLOCK_LIMIT)
+        if (CarpetSettings.structureBlockLimit != CarpetSettings.VANILLA_STRUCTURE_BLOCK_LIMIT)
         {
             ClientNetworkHandler.sendCarpetStructureBlockPacket(this.structureBlock.getPos(), blockPos, blockPos2);
         }

--- a/src/main/java/carpet/mixins/StructureBlockScreen_structureBlockLimitMixin.java
+++ b/src/main/java/carpet/mixins/StructureBlockScreen_structureBlockLimitMixin.java
@@ -1,5 +1,6 @@
 package carpet.mixins;
 
+import carpet.CarpetSettings;
 import carpet.network.CarpetClient;
 import carpet.network.ClientNetworkHandler;
 import net.minecraft.block.entity.StructureBlockBlockEntity;
@@ -21,7 +22,7 @@ public abstract class StructureBlockScreen_structureBlockLimitMixin
 	@Inject(method = "method_2516", at = @At(value = "TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
     private void sendCarpetStructureBlockPacket(StructureBlockBlockEntity.Action action, CallbackInfoReturnable<Boolean> cir, BlockPos blockPos, BlockPos blockPos2)
     {
-        if (CarpetClient.isCarpet())
+        if (CarpetClient.isCarpet() && CarpetSettings.structureBlockLimit != CarpetSettings.VANILLA_STRUCTURE_BLOCK_LIMIT)
         {
             ClientNetworkHandler.sendCarpetStructureBlockPacket(this.structureBlock.getPos(), blockPos, blockPos2);
         }

--- a/src/main/java/carpet/mixins/StructureBlockScreen_structureBlockLimitMixin.java
+++ b/src/main/java/carpet/mixins/StructureBlockScreen_structureBlockLimitMixin.java
@@ -1,0 +1,29 @@
+package carpet.mixins;
+
+import carpet.network.CarpetClient;
+import carpet.network.ClientNetworkHandler;
+import net.minecraft.block.entity.StructureBlockBlockEntity;
+import net.minecraft.client.gui.screen.ingame.StructureBlockScreen;
+import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(StructureBlockScreen.class)
+public abstract class StructureBlockScreen_structureBlockLimitMixin
+{
+	@Shadow @Final private StructureBlockBlockEntity structureBlock;
+
+	@Inject(method = "method_2516", at = @At(value = "TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
+    private void sendCarpetStructureBlockPacket(StructureBlockBlockEntity.Action action, CallbackInfoReturnable<Boolean> cir, BlockPos blockPos, BlockPos blockPos2)
+    {
+        if (CarpetClient.isCarpet())
+        {
+            ClientNetworkHandler.sendCarpetStructureBlockPacket(this.structureBlock.getPos(), blockPos, blockPos2);
+        }
+    }
+}

--- a/src/main/java/carpet/mixins/UpdateStructureBlockC2SPacketMixin.java
+++ b/src/main/java/carpet/mixins/UpdateStructureBlockC2SPacketMixin.java
@@ -26,6 +26,7 @@ public class UpdateStructureBlockC2SPacketMixin {
     )
     private void structureBlockLimitsRead(PacketByteBuf buf, CallbackInfo ci) {
         // fabric-carpet client 1.4.25 ~ 1.4.26 compatibility
+        // TODO remove at some point with a major MC release as not important
         if (buf.readableBytes() == 6*4) {
             // This will throw an exception if carpet is not installed on client
             offset = new BlockPos(MathHelper.clamp(buf.readInt(), -CarpetSettings.structureBlockLimit, CarpetSettings.structureBlockLimit), MathHelper.clamp(buf.readInt(), -CarpetSettings.structureBlockLimit, CarpetSettings.structureBlockLimit), MathHelper.clamp(buf.readInt(), -CarpetSettings.structureBlockLimit, CarpetSettings.structureBlockLimit));

--- a/src/main/java/carpet/mixins/UpdateStructureBlockC2SPacketMixin.java
+++ b/src/main/java/carpet/mixins/UpdateStructureBlockC2SPacketMixin.java
@@ -23,23 +23,11 @@ public class UpdateStructureBlockC2SPacketMixin {
             at = @At("TAIL")
     )
     private void structureBlockLimitsRead(PacketByteBuf buf, CallbackInfo ci) {
+        // fabric-carpet client 1.4.25 ~ 1.4.26 compatibility
         if (buf.readableBytes() > 0) {
             // This will throw an exception if carpet is not installed on client
             offset = new BlockPos(MathHelper.clamp(buf.readInt(), -CarpetSettings.structureBlockLimit, CarpetSettings.structureBlockLimit), MathHelper.clamp(buf.readInt(), -CarpetSettings.structureBlockLimit, CarpetSettings.structureBlockLimit), MathHelper.clamp(buf.readInt(), -CarpetSettings.structureBlockLimit, CarpetSettings.structureBlockLimit));
             size = new BlockPos(MathHelper.clamp(buf.readInt(), 0, CarpetSettings.structureBlockLimit), MathHelper.clamp(buf.readInt(), 0, CarpetSettings.structureBlockLimit), MathHelper.clamp(buf.readInt(), 0, CarpetSettings.structureBlockLimit));
         }
-    }
-
-    @Inject(
-            method = "write",
-            at = @At("TAIL")
-    )
-    private void structureBlockLimitsWrite(PacketByteBuf buf, CallbackInfo ci) {
-        buf.writeInt(this.offset.getX());
-        buf.writeInt(this.offset.getY());
-        buf.writeInt(this.offset.getZ());
-        buf.writeInt(this.size.getX());
-        buf.writeInt(this.size.getY());
-        buf.writeInt(this.size.getZ());
     }
 }

--- a/src/main/java/carpet/network/CarpetClient.java
+++ b/src/main/java/carpet/network/CarpetClient.java
@@ -16,6 +16,7 @@ public class CarpetClient
     public static final int HI = 69;
     public static final int HELLO = 420;
     public static final int DATA = 1;
+    public static final int STRUCTURE_BLOCK = 2;
     public static ShapesRenderer shapes = null;
 
     private static ClientPlayerEntity clientPlayer = null;

--- a/src/main/java/carpet/network/ClientNetworkHandler.java
+++ b/src/main/java/carpet/network/ClientNetworkHandler.java
@@ -15,6 +15,7 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
+import net.minecraft.util.math.BlockPos;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -150,6 +151,22 @@ public class ClientNetworkHandler
         CarpetClient.getPlayer().networkHandler.sendPacket(new CustomPayloadC2SPacket(
                 CarpetClient.CARPET_CHANNEL,
                 (new PacketByteBuf(Unpooled.buffer())).writeVarInt(CarpetClient.DATA).writeCompoundTag(outer)
+        ));
+    }
+
+    public static void sendCarpetStructureBlockPacket(BlockPos pos, BlockPos offset, BlockPos size)
+    {
+        CarpetClient.getPlayer().networkHandler.sendPacket(new CustomPayloadC2SPacket(
+                CarpetClient.CARPET_CHANNEL,
+                (new PacketByteBuf(Unpooled.buffer())).
+                        writeVarInt(CarpetClient.STRUCTURE_BLOCK).
+                        writeBlockPos(pos).
+                        writeVarInt(offset.getX()).
+                        writeVarInt(offset.getY()).
+                        writeVarInt(offset.getZ()).
+                        writeVarInt(size.getX()).
+                        writeVarInt(size.getY()).
+                        writeVarInt(size.getZ())
         ));
     }
 }

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -211,7 +211,9 @@
     "WorldRenderer_scarpetRenderMixin",
 
     "SoundEngineInt_cleanLogsMixin",
-    "SoundSystem_cleanLogsMixin"
+    "SoundSystem_cleanLogsMixin",
+
+    "StructureBlockScreen_structureBlockLimitMixin"
   ],
   "server": [
   ],


### PR DESCRIPTION
A workaround for issue #712

As I suggested in https://github.com/gnembon/fabric-carpet/pull/718#issuecomment-779800171, using a custom carpet packet instead of extending the vanilla structure block packet provides better compatibility to other mods / tools.

## Changes

- Added a `VANILLA_STRUCTURE_BLOCK_LIMIT` field in `CarpetSettings` for rule modified check
- Added a new Carpet packet id `STRUCTURE_BLOCK` with value `2` for structure block update
- Added sending / handling logic towards the carpet structure block update packet
- Added `StructureBlockScreen_structureBlockLimitMixin`, to let the client send a carpet structure block update packet to the server, only if the server is carpet and the value of the rule `structureBlockLimit` has been modified
- Removed the int field writing in `UpdateStructureBlockC2SPacketMixin`, since its funtionalities have been implemented by the  carpet structure block update packet. The `structureBlockLimitsRead` method is reserved for compatibility with client with fabric carpet 1.4.25 ~ 1.4.26

Fixed #712

## Some tests

Already tested the compatibilities with the following setups:

- new client single player
- new client -> new server
- new client -> 1.4.26 server
- new client -> fabric server without mod
- 1.4.26 client -> new server

Where "new" means a client / server with this PR

## Protentional notvanilla

Since the structure block is written twice when the client updates the structure block (one by vanilla packet and one by carpet packet), there might be some extra `getBlockState` and `updateListeners` that will occur

But these extra operations only occur when the carpet rule is modified by the user, and structure blocks are always used in creative servers, so it's fine I guess