### PR TITLE
Incorrect bug report for lightningKillsDropsFix

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -860,7 +860,7 @@ public class CarpetSettings
 
     @Rule(
             desc = "Lightning kills the items that drop when lightning kills an entity",
-            extra = {"Setting to true will prevent lightning from killing drops", "Fixes (https://bugs.mojang.com/browse/MC-206922)."},
+            extra = {"Setting to true will prevent lightning from killing drops", "Fixes [MC-206922](https://bugs.mojang.com/browse/MC-206922)."},
             category = {BUGFIX}
     )
     public static boolean lightningKillsDropsFix = false;

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -860,7 +860,7 @@ public class CarpetSettings
 
     @Rule(
             desc = "Lightning kills the items that drop when lightning kills an entity",
-            extra = {"Setting to true will prevent lightning from killing drops", "Fixes (https://bugs.mojang.com/browse/MC-195640)."},
+            extra = {"Setting to true will prevent lightning from killing drops", "Fixes (https://bugs.mojang.com/browse/MC-206922)."},
             category = {BUGFIX}
     )
     public static boolean lightningKillsDropsFix = false;


### PR DESCRIPTION
[MC-195640](https://bugs.mojang.com/browse/MC-195640) is "Suspicious stew inedible with full hunger", which doesn't seem right for the rule 'lightningKillsDropsFix'. The carpet rule fixes [MC-206922](https://bugs.mojang.com/browse/MC-206922) (Items dropped by mobs that were killed by lightning instantly disappear).