### PR TITLE
Remove jcenter from settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'


### PR DESCRIPTION
JCenter is:
- Shutting down on 1st May
- Not required for anything
- Already removed from the example mod
- "Should have never been there in the first place" - modmuss50

See also: FabricMC/fabric-example-mod#78