### PR TITLE
Made entity~'display_name' return a Formatted text

### DIFF
--- a/docs/scarpet/api/Entities.md
+++ b/docs/scarpet/api/Entities.md
@@ -177,7 +177,7 @@ Returns `true` if en entity is standing on firm ground and falling down due to t
 
 ### `query(e, 'name'), query(e, 'display_name'), query(e, 'custom_name'), query(e, 'type')`
 
-String of entity name
+String of entity name or formatted text in the case of `display_name`
 
 <pre>
 query(e,'name')  => Leatherworker

--- a/src/main/java/carpet/script/value/EntityValue.java
+++ b/src/main/java/carpet/script/value/EntityValue.java
@@ -416,7 +416,7 @@ public class EntityValue extends Value
         put("motion_z", (e, a) -> new NumericValue(e.getVelocity().z));
         put("on_ground", (e, a) -> new NumericValue(e.isOnGround()));
         put("name", (e, a) -> new StringValue(e.getName().getString()));
-        put("display_name", (e, a) -> new StringValue(e.getDisplayName().getString()));
+        put("display_name", (e, a) -> new FormattedTextValue(e.getDisplayName()));
         put("command_name", (e, a) -> new StringValue(e.getEntityName()));
         put("custom_name", (e, a) -> e.hasCustomName()?new StringValue(e.getCustomName().getString()):Value.NULL);
         put("type", (e, a) -> new StringValue(nameFromRegistryId(Registry.ENTITY_TYPE.getId(e.getType()))));


### PR DESCRIPTION
`entity~'display_name'` now returns a formatted text value, which includes team colors and stylized prefixes and suffixes.