### PR TITLE
Fixed slice() returning empty string when referring to last character 

### DIFF
--- a/docs/scarpet/language/Containers.md
+++ b/docs/scarpet/language/Containers.md
@@ -187,10 +187,10 @@ other parts. In that case consecutive calls to `slice` will refer to index `0` t
 cannot go back nor track where they are in the sequence (see examples).
 
 <pre>
-slice([0,1,2,3,4,5], 1, 3)  => [1, 2, 3]
+slice([0,1,2,3,4,5], 1, 3)  => [1, 2]
 slice('foobar', 0, 1)  => 'f'
 slice('foobar', 3)  => 'bar'
-slice(range(10), 3, 5)  => [3, 4, 5]
+slice(range(10), 3, 5)  => [3, 4]
 slice(range(10), 5)  => [5, 6, 7, 8, 9]
 r = range(100); [slice(r, 5, 7), slice(r, 1, 3)]  => [[5, 6], [8, 9]]
 </pre>

--- a/src/main/java/carpet/script/value/ListValue.java
+++ b/src/main/java/carpet/script/value/ListValue.java
@@ -341,7 +341,7 @@ public class ListValue extends AbstractListValue implements ContainerValueInterf
         int from = normalizeIndex(fromDesc, size);
         if (toDesc == null)
             return new ListValue((Collection<? extends Value>) getItems().subList(from, size));
-        int to = normalizeIndex(toDesc, size);
+        int to = normalizeIndex(toDesc, size+1);
         if (from > to)
             return ListValue.of();
         return new ListValue((Collection<? extends Value>) getItems().subList(from, to));

--- a/src/main/java/carpet/script/value/Value.java
+++ b/src/main/java/carpet/script/value/Value.java
@@ -186,7 +186,7 @@ public abstract class Value implements Comparable<Value>, Cloneable
         int size = value.length();
         int from = ListValue.normalizeIndex(fromDesc, size);
         if (toDesc == null) return new StringValue(value.substring(from));
-        int to = ListValue.normalizeIndex(toDesc, size);
+        int to = ListValue.normalizeIndex(toDesc, size+1);
         if (from > to) return StringValue.EMPTY;
         return new StringValue(value.substring(from, to));
     }


### PR DESCRIPTION
This fixes an issue with slice() which made it return empty strings when the upper bound was one more than the index of the last character, which should be usable for the upper bound since its non inclusive.

| Code                       | Before | Now      |
|----------------------------|--------|----------|
| `slice('abcd',3,4)`        | `''`   | `'d'`    |
| `slice('abcd',1,4)`        | `''`   | `'bcd'`  |
| `slice(split('abcd'),2,4)` | `[]`   | `[c, d]` |

Also fixed two examples of `slice()` in the docs where the upper bound was included for the example