### PR TITLE
Optimizing scoreboard API with scoreboard_property

### DIFF
--- a/docs/scarpet/api/Scoreboard.md
+++ b/docs/scarpet/api/Scoreboard.md
@@ -20,8 +20,6 @@ scoreboard_add('lvl','level')
 
 ### `scoreboard_remove(objective)` `scoreboard_remove(objective, key)`
 
-NOTE: This function is deprecated, use `scoreboard(objective, key, null)` and `scoreboard_property(objective, 'remove')` instead.
-
 Removes an entire objective, or an entry in the scoreboard associated with the key. 
 Returns `true` if objective has existed and has been removed, or previous
 value of the scoreboard if players score is removed. Returns `null` if objective didn't exist, or a key was missing
@@ -40,7 +38,6 @@ Reads a property of an `objective` or sets it to a `value` if specified. Availab
 * `display_name` (Formatted text supported)
 * `display_slot`: When reading, returns list of slots, when modifying, displays the objective in the specified slot
 * `rendertype`: Either `'integer'` or `'hearts'`, defaults to `'integer'` if invalid value specified
-* `remove`: Removes the objective, specifying a `value` doesn't matter
 
 # Team
 

--- a/docs/scarpet/api/Scoreboard.md
+++ b/docs/scarpet/api/Scoreboard.md
@@ -6,13 +6,12 @@ Displays or modifies individual scoreboard values. With no arguments, returns th
 With specified `objective`, lists all keys (players) associated with current objective, or `null` if objective does not exist.
 With specified `objective` and
 `key`, returns current value of the objective for a given player (key). With additional `value` sets a new scoreboard
- value, returning previous value associated with the `key`.
+ value, returning previous value associated with the `key`. If the `value` is null, resets the scoreboard value.
  
 ### `scoreboard_add(objective, criterion?)`
 
 Adds a new objective to scoreboard. If `criterion` is not specified, assumes `'dummy'`.
-If the objective already exists, changes the criterion of that objective and returns `false`. If the criterion was not specified but the objective already exists, returns the current criterion.
-If the objective was added, returns `true`. If nothing is affected, returns `null`
+Returns `true` if the objective was created, or `null` if an objective with the specified name already exists.
 
 <pre>
 scoreboard_add('counter')
@@ -20,6 +19,8 @@ scoreboard_add('lvl','level')
 </pre>
 
 ### `scoreboard_remove(objective)` `scoreboard_remove(objective, key)`
+
+NOTE: This function is deprecated, use `scoreboard(objective, key, null)` and `scoreboard_property(objective, 'remove')` instead.
 
 Removes an entire objective, or an entry in the scoreboard associated with the key. 
 Returns `true` if objective has existed and has been removed, or previous
@@ -30,6 +31,16 @@ for the objective.
 
 Sets display location for a specified `objective`. If `objective` is `null`, then display is cleared. If objective is invalid,
 returns `null`.
+
+### `scoreboard_property(objective, property)` `scoreboard_property(objective, property, value)`
+
+Reads a property of an `objective` or sets it to a `value` if specified. Available properties are:
+
+* `criterion`
+* `display_name` (Formatted text supported)
+* `display_slot`: When reading, returns list of slots, when modifying, displays the objective in the specified slot
+* `rendertype`: Either `'integer'` or `'hearts'`, defaults to `'integer'` if invalid value specified
+* `remove`: Removes the objective, specifying a `value` doesn't matter
 
 # Team
 

--- a/docs/scarpet/api/Scoreboard.md
+++ b/docs/scarpet/api/Scoreboard.md
@@ -36,8 +36,8 @@ Reads a property of an `objective` or sets it to a `value` if specified. Availab
 
 * `criterion`
 * `display_name` (Formatted text supported)
-* `display_slot`: When reading, returns list of slots, when modifying, displays the objective in the specified slot
-* `rendertype`: Either `'integer'` or `'hearts'`, defaults to `'integer'` if invalid value specified
+* `display_slot`: When reading, returns a list of slots this objective is displayed in, when modifying, displays the objective in the specified slot
+* `render_type`: Either `'integer'` or `'hearts'`, defaults to `'integer'` if invalid value specified
 
 # Team
 

--- a/docs/scarpet/resources/editors/idea/2.txt
+++ b/docs/scarpet/resources/editors/idea/2.txt
@@ -94,8 +94,8 @@ scan
 schedule
 scoreboard
 scoreboard_add
-scoreboard_remove
 scoreboard_display
+scoreboard_property
 tag_matches
 team_add
 team_leave

--- a/docs/scarpet/resources/editors/idea/2.txt
+++ b/docs/scarpet/resources/editors/idea/2.txt
@@ -94,6 +94,7 @@ scan
 schedule
 scoreboard
 scoreboard_add
+scoreboard_remove
 scoreboard_display
 scoreboard_property
 tag_matches

--- a/docs/scarpet/resources/editors/npp/scarpet.xml
+++ b/docs/scarpet/resources/editors/npp/scarpet.xml
@@ -62,7 +62,7 @@
 
                 display_title
 
-                scoreboard scoreboard_add scoreboard_display scoreboard_remove
+                scoreboard scoreboard_add scoreboard_display scoreboard_property
 
                 team_add team_list team_remove team_leave team_property
 

--- a/docs/scarpet/resources/editors/npp/scarpet.xml
+++ b/docs/scarpet/resources/editors/npp/scarpet.xml
@@ -62,7 +62,7 @@
 
                 display_title
 
-                scoreboard scoreboard_add scoreboard_display scoreboard_property
+                scoreboard scoreboard_add scoreboard_remove scoreboard_display scoreboard_property
 
                 team_add team_list team_remove team_leave team_property
 

--- a/docs/scarpet/resources/editors/npp/scarpet.xml
+++ b/docs/scarpet/resources/editors/npp/scarpet.xml
@@ -62,7 +62,7 @@
 
                 display_title
 
-                scoreboard scoreboard_add scoreboard_remove scoreboard_display
+                scoreboard scoreboard_add scoreboard_display scoreboard_remove
 
                 team_add team_list team_remove team_leave team_property
 

--- a/src/main/java/carpet/script/api/Scoreboards.java
+++ b/src/main/java/carpet/script/api/Scoreboards.java
@@ -104,7 +104,6 @@ public class Scoreboards {
 
         expression.addLazyFunction("scoreboard_remove", -1, (c, t, lv)->
         {
-            c.host.issueDeprecation("scoreboard_remove");
             if (lv.size()==0) throw new InternalExpressionException("'scoreboard_remove' requires at least one parameter");
             CarpetContext cc = (CarpetContext)c;
             Scoreboard scoreboard =  cc.s.getMinecraftServer().getScoreboard();

--- a/src/main/java/carpet/script/api/Scoreboards.java
+++ b/src/main/java/carpet/script/api/Scoreboards.java
@@ -240,7 +240,7 @@ public class Scoreboards {
                         }
                     }
                     return (_c, _t) -> ListValue.wrap(slots);
-                case "rendertype":
+                case "render_type":
                     if(modify) {
                         ScoreboardCriterion.RenderType renderType = ScoreboardCriterion.RenderType.getType(setValue.getString().toLowerCase());
                         if(objective.getRenderType().equals(renderType)) return LazyValue.FALSE;

--- a/src/main/java/carpet/script/api/Scoreboards.java
+++ b/src/main/java/carpet/script/api/Scoreboards.java
@@ -165,28 +165,6 @@ public class Scoreboards {
             return LazyValue.TRUE;
         });
 
-        expression.addLazyFunction("scoreboard_remove", -1, (c, t, lv)->
-        {
-            if (lv.size()==0) throw new InternalExpressionException("'scoreboard_remove' requires at least one parameter");
-            CarpetContext cc = (CarpetContext)c;
-            Scoreboard scoreboard =  cc.s.getMinecraftServer().getScoreboard();
-            String objectiveName = lv.get(0).evalValue(c).getString();
-            ScoreboardObjective objective = scoreboard.getObjective(objectiveName);
-            if (objective == null)
-                return LazyValue.FALSE;
-            if (lv.size() == 1)
-            {
-                scoreboard.removeObjective(objective);
-                return LazyValue.TRUE;
-            }
-            String key = getScoreboardKeyFromValue(lv.get(1).evalValue(c));
-            if (!scoreboard.playerHasObjective(key, objective)) return LazyValue.NULL;
-            ScoreboardPlayerScore scoreboardPlayerScore = scoreboard.getPlayerScore(key, objective);
-            Value previous = new NumericValue(scoreboardPlayerScore.getScore());
-            scoreboard.resetPlayerScore(key, objective);
-            return (c_, t_) -> previous;
-        });
-
         expression.addLazyFunction("scoreboard_property", -1, (c, t, lv) ->
         {
             if(lv.size() < 2) throw new InternalExpressionException("'scoreboard_property' requires at least two parameters");

--- a/src/main/java/carpet/script/api/Scoreboards.java
+++ b/src/main/java/carpet/script/api/Scoreboards.java
@@ -165,6 +165,28 @@ public class Scoreboards {
             return LazyValue.TRUE;
         });
 
+        expression.addLazyFunction("scoreboard_remove", -1, (c, t, lv)->
+        {
+            if (lv.size()==0) throw new InternalExpressionException("'scoreboard_remove' requires at least one parameter");
+            CarpetContext cc = (CarpetContext)c;
+            Scoreboard scoreboard =  cc.s.getMinecraftServer().getScoreboard();
+            String objectiveName = lv.get(0).evalValue(c).getString();
+            ScoreboardObjective objective = scoreboard.getObjective(objectiveName);
+            if (objective == null)
+                return LazyValue.FALSE;
+            if (lv.size() == 1)
+            {
+                scoreboard.removeObjective(objective);
+                return LazyValue.TRUE;
+            }
+            String key = getScoreboardKeyFromValue(lv.get(1).evalValue(c));
+            if (!scoreboard.playerHasObjective(key, objective)) return LazyValue.NULL;
+            ScoreboardPlayerScore scoreboardPlayerScore = scoreboard.getPlayerScore(key, objective);
+            Value previous = new NumericValue(scoreboardPlayerScore.getScore());
+            scoreboard.resetPlayerScore(key, objective);
+            return (c_, t_) -> previous;
+        });
+
         expression.addLazyFunction("scoreboard_property", -1, (c, t, lv) ->
         {
             if(lv.size() < 2) throw new InternalExpressionException("'scoreboard_property' requires at least two parameters");
@@ -226,9 +248,6 @@ public class Scoreboards {
                         return LazyValue.TRUE;
                     }
                     return (_c, _t) -> StringValue.of(objective.getRenderType().getName());
-                case "remove":
-                    scoreboard.removeObjective(objective);
-                    return LazyValue.TRUE;
                 default:
                     throw new InternalExpressionException("scoreboard property '" + property + "' is not a valid property");
             }

--- a/src/main/java/carpet/script/api/Scoreboards.java
+++ b/src/main/java/carpet/script/api/Scoreboards.java
@@ -33,6 +33,8 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.InvalidIdentifierException;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public class Scoreboards {
@@ -77,20 +79,32 @@ public class Scoreboards {
                 Value ret = ListValue.wrap(scoreboard.getAllPlayerScores(objective).stream().map(s -> new StringValue(s.getPlayerName())).collect(Collectors.toList()));
                 return (_c, _t) -> ret;
             }
+
             String key = getScoreboardKeyFromValue(lv.get(1).evalValue(c));
-            if (!scoreboard.playerHasObjective(key, objective) && lv.size()==2)
+            if(lv.size()==2) {
+                if(scoreboard.playerHasObjective(key, objective)) {
+                    return (_c,_t) -> NumericValue.of(scoreboard.getPlayerScore(key,objective).getScore());
+                }
                 return LazyValue.NULL;
-            ScoreboardPlayerScore scoreboardPlayerScore = scoreboard.getPlayerScore(key, objective);
-            Value retval = new NumericValue(scoreboardPlayerScore.getScore());
-            if (lv.size() > 2)
-            {
-                scoreboardPlayerScore.setScore(NumericValue.asNumber(lv.get(2).evalValue(c)).getInt());
             }
-            return (_c, _t) -> retval;
+
+            Value value = lv.get(2).evalValue(c);
+            if(value.isNull()) {
+                ScoreboardPlayerScore score = scoreboard.getPlayerScore(key, objective);
+                scoreboard.resetPlayerScore(key,objective);
+                return (_c,_t) -> NumericValue.of(score.getScore());
+            }
+            if (value instanceof NumericValue) {
+                ScoreboardPlayerScore score = scoreboard.getPlayerScore(key, objective);
+                score.setScore(NumericValue.asNumber(value).getInt());
+                return (_c,_t) -> NumericValue.of(score.getScore());
+            }
+            throw new InternalExpressionException("'scoreboard' requires a number or null as the third parameter");
         });
 
         expression.addLazyFunction("scoreboard_remove", -1, (c, t, lv)->
         {
+            c.host.issueDeprecation("scoreboard_remove");
             if (lv.size()==0) throw new InternalExpressionException("'scoreboard_remove' requires at least one parameter");
             CarpetContext cc = (CarpetContext)c;
             Scoreboard scoreboard =  cc.s.getMinecraftServer().getScoreboard();
@@ -137,6 +151,7 @@ public class Scoreboards {
 
             ScoreboardObjective objective = scoreboard.getObjective(objectiveName);
             if (objective != null) {
+                c.host.issueDeprecation("reading or modifying an objective's criterion with scoreboard_add");
                 if(lv.size() == 1) return (_c, _t) -> StringValue.of(objective.getCriterion().getName());
                 if(objective.getCriterion().equals(criterion) || lv.size() == 1) return LazyValue.NULL;
                 ((Scoreboard_scarpetMixin)scoreboard).getObjectivesByCriterion().get(objective.getCriterion()).remove(objective);
@@ -148,6 +163,75 @@ public class Scoreboards {
 
             scoreboard.addObjective(objectiveName, criterion, new LiteralText(objectiveName), criterion.getCriterionType());
             return LazyValue.TRUE;
+        });
+
+        expression.addLazyFunction("scoreboard_property", -1, (c, t, lv) ->
+        {
+            if(lv.size() < 2) throw new InternalExpressionException("'scoreboard_property' requires at least two parameters");
+            CarpetContext cc = (CarpetContext)c;
+            Scoreboard scoreboard =  cc.s.getMinecraftServer().getScoreboard();
+            ScoreboardObjective objective = scoreboard.getObjective(lv.get(0).evalValue(c).getString());
+            if(objective == null) return LazyValue.NULL;
+
+            boolean modify = lv.size() > 2;
+            Value setValue = null;
+            if(modify) {
+                setValue = lv.get(2).evalValue(c);
+            }
+            String property = lv.get(1).evalValue(c).getString();
+            switch (property) {
+                case "criterion":
+                    if(modify) {
+                        ScoreboardCriterion criterion = ScoreboardCriterion.createStatCriterion(setValue.getString()).orElse(null);
+                        if (criterion==null) throw new InternalExpressionException("Unknown scoreboard criterion: "+ setValue.getString());
+                        if(objective.getCriterion().equals(criterion) || lv.size() == 1) return LazyValue.FALSE;
+                        ((Scoreboard_scarpetMixin)scoreboard).getObjectivesByCriterion().get(objective.getCriterion()).remove(objective);
+                        ((ScoreboardObjective_scarpetMixin) objective).setCriterion(criterion);
+                        (((Scoreboard_scarpetMixin)scoreboard).getObjectivesByCriterion().computeIfAbsent(criterion, (criterion1) -> Lists.newArrayList())).add(objective);
+                        scoreboard.updateObjective(objective);
+                        return LazyValue.TRUE;
+                    }
+                    return (_c, _t) -> StringValue.of(objective.getCriterion().getName());
+                case "display_name":
+                    if(modify) {
+                        Text text = (setValue instanceof FormattedTextValue)?((FormattedTextValue) setValue).getText():new LiteralText(setValue.getString());
+                        objective.setDisplayName(text);
+                        return LazyValue.TRUE;
+                    }
+                    return (_c, _t) -> new FormattedTextValue(objective.getDisplayName());
+                case "display_slot":
+                    if(modify) {
+                        int slotId = Scoreboard.getDisplaySlotId(setValue.getString());
+                        if(slotId == -1) throw new InternalExpressionException("Unknown scoreboard display slot: " + setValue.getString());
+                        if(objective.equals(scoreboard.getObjectiveForSlot(slotId))) {
+                            return LazyValue.FALSE;
+                        }
+                        scoreboard.setObjectiveSlot(slotId,objective);
+                        return LazyValue.TRUE;
+                    }
+
+                    List<Value> slots = new ArrayList<>();
+                    for(int i = 0; i < 19; i++) {
+                        if (scoreboard.getObjectiveForSlot(i) == objective) {
+                            String slotName = Scoreboard.getDisplaySlotName(i);
+                            slots.add(StringValue.of(slotName));
+                        }
+                    }
+                    return (_c, _t) -> ListValue.wrap(slots);
+                case "rendertype":
+                    if(modify) {
+                        ScoreboardCriterion.RenderType renderType = ScoreboardCriterion.RenderType.getType(setValue.getString().toLowerCase());
+                        if(objective.getRenderType().equals(renderType)) return LazyValue.FALSE;
+                        objective.setRenderType(renderType);
+                        return LazyValue.TRUE;
+                    }
+                    return (_c, _t) -> StringValue.of(objective.getRenderType().getName());
+                case "remove":
+                    scoreboard.removeObjective(objective);
+                    return LazyValue.TRUE;
+                default:
+                    throw new InternalExpressionException("scoreboard property '" + property + "' is not a valid property");
+            }
         });
 
         expression.addLazyFunction("scoreboard_display", 2, (c, t, lv) ->
@@ -408,7 +492,7 @@ public class Scoreboards {
                     team.setSuffix(suffix);
                     break;
                 default:
-                    throw new InternalExpressionException("team property " + propertyVal.getString() + " is not a valid property");
+                    throw new InternalExpressionException("team property '" + propertyVal.getString() + "' is not a valid property");
             }
             return LazyValue.TRUE;
         });


### PR DESCRIPTION
Fixes #731 
Resolves #672 

Adding `scoreboard_property` to change and read various properties of scoreboard objectives:

`scoreboard_property(objective, property)`
`scoreboard_property(objective, property, value)`

* `criterion`
* `display_name` (Formatted text supported)
* `display_slot`: When reading, returns list of slots, when modifying, displays the objective in the specified slot
* `rendertype`: Either `'integer'` or `'hearts'`, defaults to `'integer'` if invalid value specified
* `remove`: Removes the objective, specifying a `value` doesn't matter

This deprecates the part of `scoreboard_add` which allowed changing scoreboard criterions. 

The `scoreboard_remove` function is also deprecated. The two parts of `scoreboard_remove` were:

* Removing an objective. This is now done with `scoreboard_property(objective,'remove')`.
* Resetting a score. This PR also adds resetting a score with `scoreboard(objective, key, null)`.