### PR TITLE
Fix `run()` with a locked SettingsManager

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -417,6 +417,7 @@ public class CarpetSettings
             if (source != null && !source.hasPermissionLevel(permissionLevel))
                 return null;
             CarpetSettings.runPermissionLevel = permissionLevel;
+            CarpetServer.settingsManager.notifyPlayersCommandsChanged();
             return newValue;
         }
         @Override

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -423,9 +423,11 @@ public class CarpetSettings
             desc = "Enables restrictions for arbitrary code execution with scarpet",
             extra = {
                     "Users that don't have this permission level",
-                    "won't be able to load apps or /script run"
+                    "won't be able to load apps or /script run.",
+                    "Also apps will only be able to run() commands",
+                    "up to that permission level."
             },
-            category = {COMMAND, SCARPET},
+            category = {SCARPET},
             validate = ModulePermissionLevel.class
     )
     public static String commandScriptACE = "ops";

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -413,22 +413,25 @@ public class CarpetSettings
 
     private static class ModulePermissionLevel extends Validator<String> {
         @Override public String validate(ServerCommandSource source, ParsedRule<String> currentRule, String newValue, String string) {
-            CarpetSettings.runPermissionLevel = SettingsManager.getCommandLevel(newValue);
+            int permissionLevel = SettingsManager.getCommandLevel(newValue);
+            if (source != null && !source.hasPermissionLevel(permissionLevel))
+                return null;
+            CarpetSettings.runPermissionLevel = permissionLevel;
             return newValue;
         }
         @Override
-        public String description() { return "Also controls permission level of commands executed via `run()`";}
+        public String description() { return "When changing the rule, you must at least have the permission level you are trying to give it";}
     }
     @Rule(
             desc = "Enables restrictions for arbitrary code execution with scarpet",
             extra = {
                     "Users that don't have this permission level",
                     "won't be able to load apps or /script run.",
-                    "Also apps will only be able to run() commands",
-                    "up to that permission level."
+                    "It is also the permission level apps will",
+                    "have when running commands with run()"
             },
             category = {SCARPET},
-            validate = ModulePermissionLevel.class
+            validate = {Validator._COMMAND_LEVEL_VALIDATOR.class, ModulePermissionLevel.class}
     )
     public static String commandScriptACE = "ops";
 


### PR DESCRIPTION
This is a "suggestion" since it could be considered a workaround, and may not be the preferred method to do this.

This basically removes the `COMMAND` category from `commandScriptACE` to prevent app malfunction in a locked SettingsManager, since every `COMMAND` rule is disabled unless explicitly stated, making apps run commands with permission level `0`.

I think it shouldn't be a problem to not turn it down, since apps can already do most of the things commands are doing with native functions, and command level 2 isn't giving them anything that could make things go wrong.

Doing that also fixes a small documentation mismatch, since else it said that it had an accompanying command.

Resolves #734, fixes gnembon/scarpet#180 and closes gnembon/scarpet#183.

At the same time I fixed the bug I commented you in Discord.

Probably candidate to squashing, given I made 3 commits for such a simple change.