### PR TITLE
Make command stacktrace mixin not required

### DIFF
--- a/src/main/java/carpet/mixins/CommandManagerMixin.java
+++ b/src/main/java/carpet/mixins/CommandManagerMixin.java
@@ -44,9 +44,11 @@ public abstract class CommandManagerMixin
 
     @SuppressWarnings("UnresolvedMixinReference")
     @Redirect(method = "execute", at = @At(
-            value = "INVOKE",
-            target = "Lorg/apache/logging/log4j/Logger;isDebugEnabled()Z"
-    ))
+                value = "INVOKE",
+                target = "Lorg/apache/logging/log4j/Logger;isDebugEnabled()Z"
+            ),
+        require = 0
+    )
     private boolean doesOutputCommandStackTrace(Logger logger)
     {
         if (CarpetSettings.superSecretSetting)


### PR DESCRIPTION
Allows the command stacktrace mixin to soft fail to allow for better compatibility with with other mods that try to do the same thing. I think it's a good idea to make it optional in Carpet since it's possible that other mods that don't care about Vanilla behaviour will replace it straight up with `true`, therefore not behaving as expected when Carpet is present because of not knowing about secret settings. After all, I guess the command stacktrace, given it being in secret settings, is not the most important thing for end users, and when debugging there probably won't be anything touching it.

Fixes #765 in many situations, though theoretically not in 100% of the cases because of the arbitrary mod loading order (not really tested, but at least in the specific issue case should be fixed).

Would probably be better if applied to the both mods that have the redirect, to allow Mixin to choose which one it wants to fail at.

BTW did you know there's people who think Carpet breaks many mods? It's the first time I read that, didn't know how to react, and the person who claimed those words didn't really explain why.