### PR TITLE
Make mixins not be required by default

### DIFF
--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -216,8 +216,5 @@
     "SoundSystem_cleanLogsMixin"
   ],
   "server": [
-  ],
-  "injectors": {
-    "defaultRequire": 1
-  }
+  ]
 }


### PR DESCRIPTION
This improves compatibility with other mods, as those mods can override carpet's mixins when necessary.