### PR TITLE
Allow apps to specify mod version requirements

### DIFF
--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -676,6 +676,7 @@ Available options in the scarpet app space:
  * `server_banned_players` - list of banned player names
  * `server_banned_ips` - list of banned IP addresses
  * `server_dev_environment` - boolean indicating whether this server is in a development environment.
+ * `server_mods` - map with all loaded mods mapped to their versions as strings
  
  System related properties
  * `java_max_memory` - maximum allowed memory accessible by JVM

--- a/docs/scarpet/api/Overview.md
+++ b/docs/scarpet/api/Overview.md
@@ -76,7 +76,7 @@ will warn and prevent such apps from loading with an error message. If `allow_co
       'requires' -> _() -> (
           d = convert_date(unix_time());
           if(d:6 == 5 && d:2 == 13, 
-            'Its Friday, 13th' // Will throw this if Friday 13th, will load else since functions return false by default
+            'Its Friday, 13th' // Will throw this if Friday 13th, will load else since functions return `null` by default
           )
     }
     ```

--- a/docs/scarpet/api/Overview.md
+++ b/docs/scarpet/api/Overview.md
@@ -76,7 +76,7 @@ will warn and prevent such apps from loading with an error message. If `allow_co
       'requires' -> _() -> (
           d = convert_date(unix_time());
           if(d:6 == 5 && d:2 == 13, 
-            'Its Friday, 13th' // Will throw this if Friday 13th, will load else since `if` functions returns `null` by default
+            'Its Friday, 13th' // Will throw this if Friday 13th, will load else since `if` function returns `null` by default
           )
     }
     ```

--- a/docs/scarpet/api/Overview.md
+++ b/docs/scarpet/api/Overview.md
@@ -76,7 +76,7 @@ will warn and prevent such apps from loading with an error message. If `allow_co
       'requires' -> _() -> (
           d = convert_date(unix_time());
           if(d:6 == 5 && d:2 == 13, 
-            'Its Friday, 13th' // Will throw this if Friday 13th, will load else since functions return `null` by default
+            'Its Friday, 13th' // Will throw this if Friday 13th, will load else since `if` functions returns `null` by default
           )
     }
     ```

--- a/docs/scarpet/api/Overview.md
+++ b/docs/scarpet/api/Overview.md
@@ -59,11 +59,15 @@ will warn and prevent such apps from loading with an error message. If `allow_co
 *   `'requires'` - defines either a map of mod dependencies in Fabric's mod.json style, or a function to be executed. If it's a map, it will only
     allow the app to load if all of the mods specified in the map meet the version criteria. If it's a function, it will prevent the app from 
     loading if the function does not execute to `false`, displaying whatever is returned to the user.
+    
+    Available prefixes for the version comparison are `>=`, `<=`, `>`, `<`, `~`, `^` and `=` (default if none specified), based in the spec 
+    at [NPM docs about SemVer ranges](https://docs.npmjs.com/cli/v6/using-npm/semver#ranges)
     ```
     __config() -> {
       'requires' -> {
         'carpet' -> '>=1.4.33', // Will require Carpet with a version >= 1.4.32
-        'minecraft' -> '>=1.16' // Will require Minecraft with a version
+        'minecraft' -> '>=1.16', // Will require Minecraft with a version >= 1.16
+        'chat-up' -> '*' // Will require any version of the chat-up mod
       }
     }
     ```

--- a/docs/scarpet/api/Overview.md
+++ b/docs/scarpet/api/Overview.md
@@ -56,6 +56,26 @@ conflicts and ambiguities between different paths of execution. While ambiguous 
 and they tend to execute correctly, the suggestion support works really poorly in these situations and scarpet
 will warn and prevent such apps from loading with an error message. If `allow_command_conflicts` is specified and 
 `true`, then scarpet will load all provided commands regardless.
+*   `'requires'` - defines either a map of mod dependencies in Fabric's mod.json style, or a function to be executed. If it's a map, it will only
+    allow the app to load if all of the mods specified in the map meet the version criteria. If it's a function, it will prevent the app from 
+    loading if the function does not execute to `false`, displaying whatever is returned to the user.
+    ```
+    __config() -> {
+      'requires' -> {
+        'carpet' -> '>=1.4.33', // Will require Carpet with a version >= 1.4.32
+        'minecraft' -> '>=1.16' // Will require Minecraft with a version
+      }
+    }
+    ```
+    ```
+    __config() -> {
+      'requires' -> _() -> (
+          d = convert_date(unix_time());
+          if(d:6 == 5 && d:2 == 13, 
+            'Its Friday, 13th' // Will throw this if Friday 13th, will load else since functions return false by default
+          )
+    }
+    ```
 *   `'command_permission'` - indicates a custom permission to run the command. It can either be a number indicating 
 permission level (from 1 to 4) or a string value, one of: `'all'` (default), `'ops'` (default opped player with permission level of 2),
 `'server'` - command accessible only through the server console and commandblocks, but not in chat, `'players'` - opposite

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -271,12 +271,6 @@ public class CarpetScriptServer
         //addEvents(source, name);
         String action = reload?"reloaded":"loaded";
         
-        if (!newHost.meetsModVersionRequirements(source))
-        {
-            removeScriptHost(source, name, false, isRuleApp); //already notified
-            return false;
-        }
-        
         Boolean isCommandAdded = newHost.addAppCommands(s -> {
             if (!isRuleApp) Messenger.m(source, s);
         });

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -270,12 +270,20 @@ public class CarpetScriptServer
         }
         //addEvents(source, name);
         String action = reload?"reloaded":"loaded";
+        
+        if (!newHost.meetsModVersionRequirements(source))
+        {
+            removeScriptHost(source, name, false, isRuleApp); //already notified
+            return false;
+        }
+        
         Boolean isCommandAdded = newHost.addAppCommands(s -> {
             if (!isRuleApp) Messenger.m(source, s);
         });
         if (isCommandAdded == null) // error should be dispatched
         {
-            removeScriptHost(source, name, false, false);
+            removeScriptHost(source, name, false, isRuleApp);
+            return false;
         }
         else if (isCommandAdded)
         {

--- a/src/main/java/carpet/script/utils/SystemInfo.java
+++ b/src/main/java/carpet/script/utils/SystemInfo.java
@@ -15,6 +15,7 @@ import carpet.settings.ParsedRule;
 import carpet.settings.SettingsManager;
 import com.sun.management.OperatingSystemMXBean;
 import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.SharedConstants;
 import net.minecraft.util.WorldSavePath;
 import net.minecraft.world.GameRules;
@@ -107,6 +108,12 @@ public class SystemInfo {
             return whitelist;
         });
         put("server_dev_environment", c-> new NumericValue(FabricLoader.getInstance().isDevelopmentEnvironment()));
+        put("server_mods", c -> {
+            Map<Value, Value> ret = new HashMap<>();
+            for (ModContainer mod : FabricLoader.getInstance().getAllMods())
+                ret.put(new StringValue(mod.getMetadata().getName()), new StringValue(mod.getMetadata().getVersion().getFriendlyString()));
+            return MapValue.wrap(ret);
+        });
 
         put("java_max_memory", c -> new NumericValue(Runtime.getRuntime().maxMemory()));
         put("java_allocated_memory", c -> new NumericValue(Runtime.getRuntime().totalMemory()));


### PR DESCRIPTION
Note: Doesn't have docs since I'm not really sure where to specify this/I was too lazy to check (at least yet, feel free to add them).

Resolves #644.

Allows Scarpet apps to specify dependencies on mods, including specific mod versions (using a `>=` comparison).

Syntax is basically the following:

```py
__config() -> {
    'requires' -> {
        'carpet' -> '1.2.3',
        'minecraft' -> '1.16',
        'java' -> 11,
        'carpet-extra' -> '*',
        ...
    },
    ...
};
```

That means: `Carpet at least 1.2.3, Minecraft at least 1.16, Java at least 11, any Carpet Extra version`.

This basically supports requiring any arbitrary mod to be present, since it uses FLoader's (not FAPI) APIs to get whether the mod is present and what version is it running, plus parsing the requirement as a semantic version and comparing it properly.

Therefore:
- If a specific version is specified, it will require the mod of _at least_ that version to be present
- If an `*` is specified, it will allow _any_ version of the mod as long as it is present
- Currently, there's no other checks. I was going to use version dependency checking logic in FLoader, but it seems that isn't part of the public API, so it may change in a future (unlikely, but not using it just in case)

My opinion to possible Whys:
- Why allowing any mod? App may depend on specific blocks, fluids, entities, functionalities, not only as a complement
- Why not making sure requirement is Carpet when checking dev env? Extensions may use a dev env and require themselves
- Why did you add a `return false` somewhere around the code that isn't related to this? I saw it, had to fix it. Though removing apps in the loading sequence may need to pop the profiler.
- Why not moving Ghoulboy's branch just mentioned in the discussion? That made me remember I also had this locally, which was mostly finished, just stopped cause I wasn't sure if I should have added the operators manually.

Questions:
- Should it be in `readConfig()` instead? In such case, should it throw from there instead of return false in case arguments are correct since else it would read "failed to read config"?
- Should the major or equal version comparison require a prefix in case I/anyone feels like adding more at some point?
- Does the name of the function make sense?