### PR TITLE
Remove limitation of rule apps of having the minimum permission level set to the rule's value

### DIFF
--- a/src/main/java/carpet/commands/ScriptCommand.java
+++ b/src/main/java/carpet/commands/ScriptCommand.java
@@ -246,13 +246,13 @@ public class ScriptCommand
                         suggests( (cc, bb) -> suggestMatching(CarpetServer.scriptServer.listAvailableModules(true),bb)).
                         executes((cc) ->
                         {
-                            boolean success = CarpetServer.scriptServer.addScriptHost(cc.getSource(), StringArgumentType.getString(cc, "app"), null, true, false, false);
+                            boolean success = CarpetServer.scriptServer.addScriptHost(cc.getSource(), StringArgumentType.getString(cc, "app"), true, false, false);
                             return success?1:0;
                         }).
                         then(literal("global").
                                 executes((cc) ->
                                 {
-                                    boolean success = CarpetServer.scriptServer.addScriptHost(cc.getSource(), StringArgumentType.getString(cc, "app"), null, false, false, false);
+                                    boolean success = CarpetServer.scriptServer.addScriptHost(cc.getSource(), StringArgumentType.getString(cc, "app"), false, false, false);
                                     return success?1:0;
                                 }
                                 )

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -109,7 +109,7 @@ public class CarpetScriptServer
         tickStart = 0L;
         stopAll = false;
         holyMoly = server.getCommandManager().getDispatcher().getRoot().getChildren().stream().map(CommandNode::getName).collect(Collectors.toSet());
-        globalHost = CarpetScriptHost.create(this, null, false, null, p -> true, false);
+        globalHost = CarpetScriptHost.create(this, null, false, null, false);
     }
 
     public void initializeForWorld()
@@ -124,7 +124,7 @@ public class CarpetScriptServer
         {
             for (String moduleName: listAvailableModules(false))
             {
-                addScriptHost(server.getCommandSource(), moduleName, null, true, true, false);
+                addScriptHost(server.getCommandSource(), moduleName, true, true, false);
             }
         }
         CarpetEventServer.Event.START.onTick();
@@ -222,11 +222,9 @@ public class CarpetScriptServer
         return modules.get(name);
     }
 
-    public boolean addScriptHost(ServerCommandSource source, String name, Function<ServerCommandSource, Boolean> commandValidator,
-                                 boolean perPlayer, boolean autoload, boolean isRuleApp)
+    public boolean addScriptHost(ServerCommandSource source, String name, boolean perPlayer, boolean autoload, boolean isRuleApp)
     {
         CarpetProfiler.ProfilerToken currentSection = CarpetProfiler.start_section(null, "Scarpet load", CarpetProfiler.TYPE.GENERAL);
-        if (commandValidator == null) commandValidator = p -> true;
         long start = System.nanoTime();
         name = name.toLowerCase(Locale.ROOT);
         boolean reload = false;
@@ -242,7 +240,7 @@ public class CarpetScriptServer
             Messenger.m(source, "r Failed to add "+name+" app");
             return false;
         }
-        CarpetScriptHost newHost = CarpetScriptHost.create(this, module, perPlayer, source, commandValidator, isRuleApp);
+        CarpetScriptHost newHost = CarpetScriptHost.create(this, module, perPlayer, source, isRuleApp);
         if (newHost == null)
         {
             Messenger.m(source, "r Failed to add "+name+" app");
@@ -456,7 +454,6 @@ public class CarpetScriptServer
         private TransferData(CarpetScriptHost host)
         {
             perUser = host.perUser;
-            commandValidator = host.commandValidator;
             isRuleApp = host.isRuleApp;
         }
     }
@@ -468,7 +465,7 @@ public class CarpetScriptServer
         apps.keySet().forEach(s -> removeScriptHost(server.getCommandSource(), s, false, false));
         CarpetEventServer.Event.clearAllBuiltinEvents();
         init();
-        apps.forEach((s, data) -> addScriptHost(server.getCommandSource(), s,data.commandValidator, data.perUser,false, data.isRuleApp));
+        apps.forEach((s, data) -> addScriptHost(server.getCommandSource(), s,data.perUser,false, data.isRuleApp));
     }
 
     public void reAddCommands()

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -193,7 +193,7 @@ public class SettingsManager
         {
             if (rule.getBoolValue() || (rule.type == String.class && !rule.get().equals("false")))
             {
-                CarpetServer.scriptServer.addScriptHost(source, rule.scarpetApp, s -> canUseCommand(s, rule.get()), false, false, true);
+                CarpetServer.scriptServer.addScriptHost(source, rule.scarpetApp, false, false, true);
             } else {
                 CarpetServer.scriptServer.removeScriptHost(source, rule.scarpetApp, false, true);
             }


### PR DESCRIPTION
Supersedes #799. 

Since apps can now provide their own command usage validator, this PR removes the limitation that rule apps have to only be able to be ran with the permissions specified in their rule's field.

Why? For instance, an app may only want to remove commands based on different criteria, plus currently if the app isn't set to a valid permission level (e.g. the app isn't only a command but has some extra features configured in the rule) it will just return that it can't ever be executed, when the app probably could decide whether it can actually be executed (SettingsManager#canUseCommand returns false by default if object doesn't meet any criteria, which makes sense, but doesn't work as expected for this). Also it's spread through half of the code, though that part may be wanted to be kept in order to allow extra command validators from code other than this, in which case this PR should be closed and the field restriction just be killed directly.

BTW I'd personally use a predicate there in such case, though that's more a matter of taste.