### PR TITLE
Chain an exception's constructor

### DIFF
--- a/src/main/java/carpet/script/exception/ExpressionException.java
+++ b/src/main/java/carpet/script/exception/ExpressionException.java
@@ -7,6 +7,7 @@ import carpet.script.Tokenizer;
 import carpet.script.value.FunctionValue;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -26,10 +27,7 @@ public class ExpressionException extends RuntimeException implements ResolvedExc
 
     public ExpressionException(Context c, Expression e, Tokenizer.Token t, String message)
     {
-        super("Error");
-        lazyMessage = () -> makeMessage(c, e, t, message);
-        token = t;
-        context = c;
+        this(c, e, t, message, Collections.emptyList());
     }
     public ExpressionException(Context c, Expression e, Tokenizer.Token t, String message, List<FunctionValue> stack)
     {


### PR DESCRIPTION
Makes `ExpressionException`'s second smallest constructor call the next with default params instead of filling the thing itself.

Would also love to get rid of the independence (or) of one of the other two, didn't do because of the two options I had:
- Drop the one with the Supplier: It is currently only used when instantiating processed throw statements to (I guess) make them not call `getString()` on construction (since they can still be caught). Can it be that expensive?
- Make the non-supplier constructor create a supplier with the passed message. Would keep the supplier for throwables and would still make all constructors rely on one after all.
- (new) Making the last constructor's supplier be the lazyMessage supplier and making the non-supplier version and the throwable create it. 

Motivation: Makes registering exceptions externally simpler, and removes a bit of code duplication here too.