### PR TITLE
More datapack examples

### DIFF
--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -442,7 +442,10 @@ script run create_datapack('foo',
         }
     }
 })
+</pre>
 
+Custom dimension example:
+<pre>
 script run create_datapack('funky_world',  {
     'data' -> {
         'minecraft' -> {
@@ -465,7 +468,66 @@ script run create_datapack('funky_world',  {
     }
 });
 check_hidden_dimensions();  => ['funky_world']
-        
+</pre>
+
+Loot table example:
+<pre>
+script run create_datapack('silverfishes_drop_gravel', {
+    'data' -> {
+        'minecraft' -> {
+            'loot_tables' -> {
+                'entities' -> {
+                    'silverfish.json' -> {
+                        'type' -> 'minecraft:entity',
+                        'pools' -> [
+                            {
+                                'rolls' -> {
+                                    'min' -> 0,
+                                    'max' -> 1
+                                },
+                                'entries' -> [
+                                    {
+                                        'type' -> 'minecraft:item',
+                                        'name' -> 'minecraft:gravel'
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+});
+</pre>
+
+Recipe example:
+<pre>
+script run create_datapack('craftable_cobwebs', {
+    'data' -> {
+        'scarpet' -> {
+            'recipes' -> {
+                'cobweb.json' -> {
+                    'type' -> 'crafting_shaped',
+                    'pattern' -> [
+                        'SSS',
+                        'SSS',
+                        'SSS'
+                    ],
+                    'key' -> {
+                        'S' -> {
+                            'item' -> 'minecraft:string'
+                        }
+                    },
+                    'result' -> {
+                        'item' -> 'minecraft:cobweb',
+                        'count' -> 1
+                    }
+                }
+            }
+        }
+    }
+});
 </pre>
 
 ### `enable_hidden_dimensions()`

--- a/docs/scarpet/api/BlocksAndWorldAccess.md
+++ b/docs/scarpet/api/BlocksAndWorldAccess.md
@@ -59,7 +59,7 @@ set(0,5,0,'bedrock')  => bedrock
 set(l(0,5,0), 'bedrock')  => bedrock
 set(block(0,5,0), 'bedrock')  => bedrock
 scan(0,5,0,0,0,0,set(_,'bedrock'))  => 1
-set(pos(players()), 'bedrock')  => bedrock
+set(pos(player()), 'bedrock')  => bedrock
 set(0,0,0,'bedrock')  => 0   // or 1 in overworlds generated in 1.8 and before
 scan(0,100,0,20,20,20,set(_,'glass'))
     // filling the area with glass
@@ -255,7 +255,7 @@ and the same can be achieved with `query(entity,'pos')`, but for simplicity `pos
 
 <pre>
 pos(block(0,5,0)) => l(0,5,0)
-pos(players()) => l(12.3, 45.6, 32.05)
+pos(player()) => l(12.3, 45.6, 32.05)
 pos(block('stone')) => Error: Cannot fetch position of an unrealized block
 </pre>
 
@@ -505,7 +505,7 @@ To check if a block is truly loaded, I mean in memory, use `generation_status(x)
 outside of the playable area, just are not used by any of the game mechanic processes.
 
 <pre>
-loaded(pos(players()))  => 1
+loaded(pos(player()))  => 1
 loaded(100000,100,1000000)  => 0
 </pre>
 

--- a/docs/scarpet/language/LoopsAndHigherOrderFunctions.md
+++ b/docs/scarpet/language/LoopsAndHigherOrderFunctions.md
@@ -92,7 +92,7 @@ place of the resulting map element, otherwise current element is skipped.
 
 <pre>
 map(range(10), _*_)  => [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
-map(players('*'), _+' is stoopid') [gnembon is stoopid, herobrine is stoopid]
+map(player('*'), _+' is stoopid') [gnembon is stoopid, herobrine is stoopid]
 </pre>
 
 ### `filter(list,expr(_,_i))`

--- a/docs/scarpet/language/Operators.md
+++ b/docs/scarpet/language/Operators.md
@@ -114,7 +114,7 @@ $      )
 $   );
 $   lvl
 $);
-/script run global_get_enchantment(players(), 'sharpness')
+/script run global_get_enchantment(player(), 'sharpness')
 </pre>
 
 ### `Basic Arithmetic Operators + - * /`


### PR DESCRIPTION
Added in scapet docs an example for recipes and for loot tables.

Fix #795