### PR TITLE
Added renewableDeepslate

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -723,6 +723,12 @@ public class CarpetSettings
     )
     public static boolean renewableBlackstone = false;
 
+    @Rule(
+            desc = "Lava and water generate deepslate and cobbled deepslate instead below y0",
+            category = FEATURE
+    )
+    public static boolean renewableDeepslate = false;
+
     @Rule(desc = "fixes block placement rotation issue when player rotates quickly while placing blocks", category = BUGFIX)
     public static boolean placementRotationFix = false;
 

--- a/src/main/java/carpet/mixins/FluidBlock_renewableDeepslateMixin.java
+++ b/src/main/java/carpet/mixins/FluidBlock_renewableDeepslateMixin.java
@@ -20,7 +20,7 @@ public abstract class FluidBlock_renewableDeepslateMixin {
 
     @Inject(method = "receiveNeighborFluids", at = @At(value = "INVOKE",target = "Lnet/minecraft/fluid/FluidState;isStill()Z"), cancellable = true)
     private void receiveFluidToDeepslate(World world, BlockPos pos, BlockState state, CallbackInfoReturnable<Boolean> cir) {
-        if(CarpetSettings.renewableDeepslate && !world.getFluidState(pos).isStill() && pos.getY() < 0 ) {
+        if(CarpetSettings.renewableDeepslate && !world.getFluidState(pos).isStill() && pos.getY() < 0 && world.getRegistryKey() == World.OVERWORLD ) {
             world.setBlockState(pos, Blocks.COBBLED_DEEPSLATE.getDefaultState());
             this.playExtinguishSound(world, pos);
             cir.setReturnValue(false);

--- a/src/main/java/carpet/mixins/FluidBlock_renewableDeepslateMixin.java
+++ b/src/main/java/carpet/mixins/FluidBlock_renewableDeepslateMixin.java
@@ -1,0 +1,30 @@
+package carpet.mixins;
+
+import carpet.CarpetSettings;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.FluidBlock;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(FluidBlock.class)
+public abstract class FluidBlock_renewableDeepslateMixin {
+
+    @Shadow protected abstract void playExtinguishSound(WorldAccess world, BlockPos pos);
+
+    @Inject(method = "receiveNeighborFluids", at = @At(value = "INVOKE",target = "Lnet/minecraft/fluid/FluidState;isStill()Z"), cancellable = true)
+    private void receiveFluidToDeepslate(World world, BlockPos pos, BlockState state, CallbackInfoReturnable<Boolean> cir) {
+        if(CarpetSettings.renewableDeepslate && pos.getY() < 0) {
+            world.setBlockState(pos, Blocks.COBBLED_DEEPSLATE.getDefaultState());
+            this.playExtinguishSound(world, pos);
+            cir.setReturnValue(false);
+            cir.cancel();
+        }
+    }
+}

--- a/src/main/java/carpet/mixins/FluidBlock_renewableDeepslateMixin.java
+++ b/src/main/java/carpet/mixins/FluidBlock_renewableDeepslateMixin.java
@@ -20,7 +20,7 @@ public abstract class FluidBlock_renewableDeepslateMixin {
 
     @Inject(method = "receiveNeighborFluids", at = @At(value = "INVOKE",target = "Lnet/minecraft/fluid/FluidState;isStill()Z"), cancellable = true)
     private void receiveFluidToDeepslate(World world, BlockPos pos, BlockState state, CallbackInfoReturnable<Boolean> cir) {
-        if(CarpetSettings.renewableDeepslate && !world.getFluidState(pos).isStill() && pos.getY() < 0 && world.) {
+        if(CarpetSettings.renewableDeepslate && !world.getFluidState(pos).isStill() && pos.getY() < 0 ) {
             world.setBlockState(pos, Blocks.COBBLED_DEEPSLATE.getDefaultState());
             this.playExtinguishSound(world, pos);
             cir.setReturnValue(false);

--- a/src/main/java/carpet/mixins/FluidBlock_renewableDeepslateMixin.java
+++ b/src/main/java/carpet/mixins/FluidBlock_renewableDeepslateMixin.java
@@ -20,7 +20,7 @@ public abstract class FluidBlock_renewableDeepslateMixin {
 
     @Inject(method = "receiveNeighborFluids", at = @At(value = "INVOKE",target = "Lnet/minecraft/fluid/FluidState;isStill()Z"), cancellable = true)
     private void receiveFluidToDeepslate(World world, BlockPos pos, BlockState state, CallbackInfoReturnable<Boolean> cir) {
-        if(CarpetSettings.renewableDeepslate && pos.getY() < 0) {
+        if(CarpetSettings.renewableDeepslate && !world.getFluidState(pos).isStill() && pos.getY() < 0 && world.) {
             world.setBlockState(pos, Blocks.COBBLED_DEEPSLATE.getDefaultState());
             this.playExtinguishSound(world, pos);
             cir.setReturnValue(false);

--- a/src/main/java/carpet/mixins/LavaFluid_renewableDeepslateMixin.java
+++ b/src/main/java/carpet/mixins/LavaFluid_renewableDeepslateMixin.java
@@ -1,0 +1,29 @@
+package carpet.mixins;
+
+import carpet.CarpetSettings;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.LavaFluid;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.WorldAccess;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(LavaFluid.class)
+public abstract class LavaFluid_renewableDeepslateMixin {
+    @Shadow protected abstract void playExtinguishEvent(WorldAccess world, BlockPos pos);
+
+    @Inject(method = "flow", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;getDefaultState()Lnet/minecraft/block/BlockState;"), cancellable = true)
+    private void generateDeepslate(WorldAccess world, BlockPos pos, BlockState state, Direction direction, FluidState fluidState, CallbackInfo ci) {
+        if(CarpetSettings.renewableDeepslate && pos.getY() < 0) {
+            world.setBlockState(pos, Blocks.DEEPSLATE.getDefaultState(), 3);
+            this.playExtinguishEvent(world, pos);
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/carpet/mixins/LavaFluid_renewableDeepslateMixin.java
+++ b/src/main/java/carpet/mixins/LavaFluid_renewableDeepslateMixin.java
@@ -7,6 +7,7 @@ import net.minecraft.fluid.FluidState;
 import net.minecraft.fluid.LavaFluid;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;

--- a/src/main/java/carpet/mixins/LavaFluid_renewableDeepslateMixin.java
+++ b/src/main/java/carpet/mixins/LavaFluid_renewableDeepslateMixin.java
@@ -20,7 +20,7 @@ public abstract class LavaFluid_renewableDeepslateMixin {
 
     @Inject(method = "flow", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;getDefaultState()Lnet/minecraft/block/BlockState;"), cancellable = true)
     private void generateDeepslate(WorldAccess world, BlockPos pos, BlockState state, Direction direction, FluidState fluidState, CallbackInfo ci) {
-        if(CarpetSettings.renewableDeepslate && pos.getY() < 0) {
+        if(CarpetSettings.renewableDeepslate && pos.getY() < 0 && ((World)world).getRegistryKey() == World.OVERWORLD) {
             world.setBlockState(pos, Blocks.DEEPSLATE.getDefaultState(), 3);
             this.playExtinguishEvent(world, pos);
             ci.cancel();

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -86,6 +86,8 @@
     "CoralBlockMixin",
     "CoralFeatureMixin",
     "FluidBlock_renewableBlackstoneMixin",
+    "FluidBlock_renewableDeepslateMixin",
+    "LavaFluid_renewableDeepslateMixin",
     "StructureFeatureMixin",
     "World_scarpetPlopMixin",
     "ChunkRegion_scarpetPlopMixin",


### PR DESCRIPTION
Fixes #767 

Adds new rule `renewableDeepslate`
Instead of stone and cobblestone, deepslate and cobbled deepslate will generate from water and lava below y-level 0.

Wasn't sure if i should combine the `FluidBlock_renewableDeepslateMixin` with the already existing `FluidBlock_renewableBlackstonMixin`, or leave them seperate since they are different rules. If they should be combined, what name would the mixin get?