### PR TITLE
Make `player_list` take arguments one at a time and make it compatible with loggers

### DIFF
--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -265,7 +265,7 @@ Example usages:
   // not a problem in apps
 </pre>
 
-### `display_title(players, type, title?, fadeInTicks?, stayTicks?, fadeOutTicks),`
+### `display_title(players, type, text?, fadeInTicks?, stayTicks?, fadeOutTicks),`
 
 Sends the player (or players if `players` is a list) a title of a specific type, with optionally some times.
  * `players` is either an online player or a list of players. When sending a single player, it will throw if the player is invalid or offline.
@@ -277,13 +277,12 @@ Sends the player (or players if `players` is a list) a title of a specific type,
    Executing with those will set the times to the specified ones.
    Note that `actionbar` type doesn't support changing times (vanilla bug, see [MC-106167](https://bugs.mojang.com/browse/MC-106167)).
 
-### `display_title(players, 'player_list')`
-### `display_title(players, 'player_list', footer)`
-### `display_title(players, 'player_list', header, footer)`
+### `display_title(players, 'player_list_header', text)`
+### `display_title(players, 'player_list_footer', text)`
 
-Changes the header and footer of the player list.
-When no `header` and `footer` is specified, they will be reset.
-Keep in mind this would interfere with carpet's loggers, so if you are using this, you need to keep them off.
+Changes the header or footer of the player list for the specified targets.
+If `text` is `null` or an empty string it will remove the header or footer for the specified targets.
+In case the player has Carpet loggers running, the footer specified by Scarpet will appear above the loggers.
 
 ### `logger(msg), logger(type, msg)`
 

--- a/src/main/java/carpet/CarpetServer.java
+++ b/src/main/java/carpet/CarpetServer.java
@@ -112,7 +112,7 @@ public class CarpetServer implements ClientModInitializer,DedicatedServerModInit
     public static void tick(MinecraftServer server)
     {
         TickSpeed.tick();
-        HUDController.update_hud(server);
+        HUDController.update_hud(server, false);
         scriptServer.tick();
 
         //in case something happens
@@ -180,6 +180,7 @@ public class CarpetServer implements ClientModInitializer,DedicatedServerModInit
             currentCommandDispatcher = null;
 
             LoggerRegistry.stopLoggers();
+            HUDController.resetScarpetHUDs();
             extensions.forEach(e -> e.onServerClosed(server));
             minecraft_server = null;
         }

--- a/src/main/java/carpet/logging/HUDController.java
+++ b/src/main/java/carpet/logging/HUDController.java
@@ -39,6 +39,15 @@ public class HUDController
     }
 
     public static Map<PlayerEntity, List<BaseText>> player_huds = new HashMap<>();
+    
+    public static final Map<PlayerEntity, BaseText> scarpet_headers = new HashMap<>();
+    
+    public static final Map<PlayerEntity, BaseText> scarpet_footers = new HashMap<>();
+
+    public static void resetScarpetHUDs() {
+        scarpet_headers.clear();
+        scarpet_footers.clear();
+    }
 
     public static void addMessage(PlayerEntity player, BaseText hudMessage)
     {
@@ -61,12 +70,14 @@ public class HUDController
     }
 
 
-    public static void update_hud(MinecraftServer server)
+    public static void update_hud(MinecraftServer server, boolean force)
     {
-        if(server.getTicks() % 20 != 0 || CarpetServer.minecraft_server == null)
+        if ((server.getTicks() % 20 != 0 && !force) || CarpetServer.minecraft_server == null)
             return;
 
         player_huds.clear();
+
+        scarpet_footers.forEach((p, m) -> addMessage(p, m));
 
         if (LoggerRegistry.__tps)
             LoggerRegistry.getLogger("tps").log(()-> send_tps_display(server));
@@ -101,7 +112,7 @@ public class HUDController
         for (PlayerEntity player: player_huds.keySet())
         {
             PlayerListHeaderS2CPacket packet = new PlayerListHeaderS2CPacket();
-            ((PlayerListHeaderS2CPacketMixin)packet).setHeader(new LiteralText(""));
+            ((PlayerListHeaderS2CPacketMixin)packet).setHeader(scarpet_headers.getOrDefault(player, new LiteralText("")));
             ((PlayerListHeaderS2CPacketMixin)packet).setFooter(Messenger.c(player_huds.get(player).toArray(new Object[0])));
             ((ServerPlayerEntity)player).networkHandler.sendPacket(packet);
         }


### PR DESCRIPTION
Implements (and GH keyword) Closes #818.

This PR changes the `display_title()` signature for things in the `player_list` to `display_title(targets, position, text)`, making it the same as the other `display_title()` arguments.

Not only that, it also changes the internals so that those headers and footers are stored in `HUDController` instead of just being sent once. HUDController will then make sure that those values are sent to the client even if it's sending other loggers at the same time.

Current behaviour is to display the Scarpet footer above loggers, can easily be changed by moving the call it has in `HUDController#updateHud`.

`CarpetServer` will reset the Scarpet headers and footers when the world changes, but they will be stored for the player while the server is running (if SPE keeps same hashcode and equals after relog will also keep them after relog, else it won't).

Also adds a `force` boolean parameter to `HUDController#updateHud` so Scarpet headers and footers can be updated instantly when the function is called.

Old versions are not deprecated since they have not been released yet and my idea would be to get them before release.