### PR TITLE
Make `get()` always return a list if requested item ends with `[]`

### DIFF
--- a/src/main/java/carpet/script/value/NBTSerializableValue.java
+++ b/src/main/java/carpet/script/value/NBTSerializableValue.java
@@ -569,13 +569,14 @@ public class NBTSerializableValue extends Value implements ContainerValueInterfa
     @Override
     public Value get(Value value)
     {
-        NbtPathArgumentType.NbtPath path = cachePath(value.getString());
+        String valString = value.getString();
+        NbtPathArgumentType.NbtPath path = cachePath(valString);
         try
         {
             List<Tag> tags = path.get(getTag());
             if (tags.size()==0)
                 return Value.NULL;
-            if (tags.size()==1)
+            if (tags.size()==1 && !valString.endsWith("[]"))
                 return NBTSerializableValue.decodeTag(tags.get(0));
             return ListValue.wrap(tags.stream().map(NBTSerializableValue::decodeTag).collect(Collectors.toList()));
         }


### PR DESCRIPTION
Resolves #746.

Basically that. If the requested address ends with `[]` it will create either a singleton with the element.

PENDING TESTING

Can this break apps relying on the old functionality?
I guess maybe? But most should work since the check that seems to be done usually is to convert it to a list if it's not, and this will just return lists in more cases. And it still returns null for no items.