### PR TITLE
Fixed missing static keyword at method HUDController.register

### DIFF
--- a/src/main/java/carpet/logging/HUDController.java
+++ b/src/main/java/carpet/logging/HUDController.java
@@ -36,7 +36,7 @@ public class HUDController
      * Adds listener to be called when HUD is updated for logging information
      * @param listener - a method to be called when new HUD inforation are collected
      */
-    public void register(Consumer<MinecraftServer> listener)
+    public static void register(Consumer<MinecraftServer> listener)
     {
         HUDListeners.add(listener);
     }


### PR DESCRIPTION
This method should be static, isn't it? I don't think there's a reason for not having the `static`, since it's wired for extensions to instantiate a `HUDController` object to register a hud listener

https://github.com/gnembon/fabric-carpet/blob/8ed4c60b9c321860932b629e7fcd987b61111d30/src/main/java/carpet/logging/HUDController.java#L35-L42
