### PR TITLE
Adding getTextByValue method to replace duplicate code

### DIFF
--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -523,7 +523,7 @@ public class Auxiliary {
                 targets = playerTargets;
                 res = lv.get(1).evalValue(c);
             }
-            Text message = (res instanceof FormattedTextValue)?((FormattedTextValue) res).getText():new LiteralText(res.getString());
+            Text message = FormattedTextValue.getTextByValue(res);
             if (targets == null)
             {
                 s.sendFeedback(message, false);

--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -575,16 +575,8 @@ public class Auxiliary {
             if (lv.size() > 2)
             {
                 pVal = lv.get(2).evalValue(c);
-                if (pVal instanceof FormattedTextValue)
-                {
-                    title = ((FormattedTextValue) pVal).getText();
-                    soundsTrue = !title.asString().isEmpty();
-                }
-                else
-                {
-                    title = new LiteralText(pVal.getString());
-                    soundsTrue = pVal.getBoolean();
-                }
+                title = FormattedTextValue.getTextByValue(pVal);
+                soundsTrue = pVal.getBoolean();
             }
             else title = null; // Will never happen, just to make lambda happy
             if (action == null)

--- a/src/main/java/carpet/script/api/Scoreboards.java
+++ b/src/main/java/carpet/script/api/Scoreboards.java
@@ -195,7 +195,7 @@ public class Scoreboards {
                     return (_c, _t) -> StringValue.of(objective.getCriterion().getName());
                 case "display_name":
                     if(modify) {
-                        Text text = (setValue instanceof FormattedTextValue)?((FormattedTextValue) setValue).getText():new LiteralText(setValue.getString());
+                        Text text = FormattedTextValue.getTextByValue(setValue);
                         objective.setDisplayName(text);
                         return LazyValue.TRUE;
                     }
@@ -408,11 +408,7 @@ public class Scoreboards {
 
                     Text displayName;
 
-                    if(settingVal instanceof FormattedTextValue) {
-                        displayName = ((FormattedTextValue) settingVal).getText();
-                    } else {
-                        displayName = new LiteralText(settingVal.getString());
-                    }
+                    displayName = FormattedTextValue.getTextByValue(settingVal);
 
                     team.setDisplayName(displayName);
 
@@ -451,11 +447,7 @@ public class Scoreboards {
 
                     Text prefix;
 
-                    if(settingVal instanceof FormattedTextValue) {
-                        prefix = ((FormattedTextValue) settingVal).getText();
-                    } else {
-                        prefix = new LiteralText(settingVal.getString());
-                    }
+                    prefix = FormattedTextValue.getTextByValue(settingVal);
 
                     team.setPrefix(prefix);
                     break;
@@ -481,11 +473,7 @@ public class Scoreboards {
 
                     Text suffix;
 
-                    if(settingVal instanceof FormattedTextValue) {
-                        suffix = ((FormattedTextValue) settingVal).getText();
-                    } else {
-                        suffix = new LiteralText(settingVal.getString());
-                    }
+                    suffix = FormattedTextValue.getTextByValue(settingVal);
 
                     team.setSuffix(suffix);
                     break;
@@ -547,11 +535,7 @@ public class Scoreboards {
                 case "name":
                     if(propertyValue == null) return (_c, _t) -> new FormattedTextValue(bossBar.getName());
 
-                    if(propertyValue instanceof FormattedTextValue) {
-                        bossBar.setName(((FormattedTextValue) propertyValue).getText());
-                    } else {
-                        bossBar.setName(new LiteralText(propertyValue.getString()));
-                    }
+                    bossBar.setName(FormattedTextValue.getTextByValue(propertyValue));
                     return LazyValue.TRUE;
                 case "add_player":
                     if(propertyValue == null) throw new InternalExpressionException("Bossbar property " + property + " can't be queried, add a third parameter");

--- a/src/main/java/carpet/script/value/EntityValue.java
+++ b/src/main/java/carpet/script/value/EntityValue.java
@@ -1106,7 +1106,7 @@ public class EntityValue extends Value
                 v = ((ListValue) v).getItems().get(0);
             }
             e.setCustomNameVisible(showName);
-            e.setCustomName(new LiteralText(v.getString()));
+            e.setCustomName(FormattedTextValue.getTextByValue(v));
         });
 
         put("persistence", (e, v) ->

--- a/src/main/java/carpet/script/value/FormattedTextValue.java
+++ b/src/main/java/carpet/script/value/FormattedTextValue.java
@@ -91,4 +91,8 @@ public class FormattedTextValue extends StringValue
         return new FormattedTextValue(Text.Serializer.fromJson(serialized));
     }
 
+    public static Text getTextByValue(Value value) {
+        return (value instanceof FormattedTextValue) ? ((FormattedTextValue) value).getText() : new LiteralText(value.getString());
+    }
+
 }

--- a/src/main/java/carpet/script/value/FormattedTextValue.java
+++ b/src/main/java/carpet/script/value/FormattedTextValue.java
@@ -49,7 +49,7 @@ public class FormattedTextValue extends StringValue
 
     @Override
     public boolean getBoolean() {
-          return text.getSiblings().size() > 0;
+        return !text.asString().isEmpty();
     }
 
     @Override


### PR DESCRIPTION
I noticed there are a lot of instances where there is a `value instanceof FormattedTextValue` check, so this static method in the `FormattedTextValue` class replaces all of those.

In the EntityValue modifying customName code, i also swapped the LiteralText constructor with this, which makes it possible to use formatted text here too, useful side effect.