### PR TITLE
Fixed boolean value of FormattedText being incorrect

### DIFF
--- a/src/main/java/carpet/script/value/FormattedTextValue.java
+++ b/src/main/java/carpet/script/value/FormattedTextValue.java
@@ -54,7 +54,7 @@ public class FormattedTextValue extends StringValue
 
     @Override
     public boolean getBoolean() {
-        return !text.asString().isEmpty();
+        return !text.getString().isEmpty();
     }
 
     @Override


### PR DESCRIPTION
Fixed formatted texts sometimes being false as boolean, even if it contains text.

`bool(format('db test'))` used to return false, now it returns true

Another side effect is that the display_title header/footer didnt work with a formatted text, since it checks for the boolean value and clears them if false.

This was introduced in e26e332a6d319cd818f8c8d29f4dc20ca9a0d238

When testing it a bit now, asString returned an empty string in some cases, with text contained in the FormattedText value (not just a empty, but formatted string)
Apparently getString works, not sure why that would be different though
