### PR TITLE
Add the option to track and undo block state changes

### DIFF
--- a/docs/scarpet/api/BlocksAndWorldAccess.md
+++ b/docs/scarpet/api/BlocksAndWorldAccess.md
@@ -247,7 +247,7 @@ NB: It can thunder without there being a thunderstorm, there has to be both rain
 With two args, sets the weather to `type` for `ticks` ticks.
 
 ### `track_changes()`
-Keep track of any changes to the block states of blocks made by your scarpet script so they can be undone later if neccesary using `undo_changes()`. All changes tracked are undone when the script unloads, or if the server closes (unless you close a server with the x button, or it crashes). Does nothing if changes are already being tracked.
+Keep track of any changes to the block states of blocks made by your scarpet script so they can be undone later if neccesary using `undo_changes()`. All changes tracked are undone when the script unloads, or if the server closes (unless you close a server with the x button, or it crashes). Does nothing if changes are already being tracked. Only changes made using `set()` or `place_item()` are tracked.
 
 Returns a boolean for whether changes were being tracked before
 

--- a/docs/scarpet/api/BlocksAndWorldAccess.md
+++ b/docs/scarpet/api/BlocksAndWorldAccess.md
@@ -246,6 +246,57 @@ NB: It can thunder without there being a thunderstorm, there has to be both rain
 
 With two args, sets the weather to `type` for `ticks` ticks.
 
+### `track_changes()`
+Keep track of any changes to the block states of blocks made by your scarpet script so they can be undone later if neccesary using `undo_changes()`. All changes tracked are undone when the script unloads. Does nothing if changes are already being tracked.
+
+Returns a boolean for whether changes were being tracked before
+
+Only works in globally scoped apps
+
+```
+__config() -> {
+  'scope' -> 'global',
+  'commands' -> {
+    'block_one <block>' -> _(block) -> ( global_block1 = block; make_block(); ),
+    'block_two <block>' -> _(block) -> ( global_block2 = block; make_block(); ),
+    'ratio <ratio>' -> _(ratio) -> ( global_ratio = ratio; make_block(); ),
+    'commit' -> _() -> commit_changes()
+  },
+  'arguments' -> {
+    'block' -> { 'type' -> 'block' },
+    'ratio' -> { 'type' -> 'float', 'min' -> 0, 'max' -> 1 }
+  }
+};
+
+global_block1 = 'stone_bricks';
+global_block2 = 'cracked_stone_bricks';
+global_ratio = 0.5;
+
+make_block() -> (
+  undo_changes();
+  track_changes();
+  for (rect(l(0, 64, 0), l(5, 5, 5)),
+    if (rand(1) > global_ratio,
+      set(_, global_block1);
+    ,
+      set(_, global_block2);
+    );
+  );
+);
+
+make_block();
+```
+
+### `undo_changes()`
+Undo all the changes tracked by `track_changes()`. Stops tracking changes to block states
+
+Returns the amount of changes undone
+
+### `commit_changes()`
+Commit all changes tracked by `track_changes()` so they can't be undone. Stops tracking changes to block states
+
+Returns the amount of changes committed
+
 ## Block and World querying
 
 ### `pos(block), pos(entity)`

--- a/docs/scarpet/api/BlocksAndWorldAccess.md
+++ b/docs/scarpet/api/BlocksAndWorldAccess.md
@@ -247,7 +247,7 @@ NB: It can thunder without there being a thunderstorm, there has to be both rain
 With two args, sets the weather to `type` for `ticks` ticks.
 
 ### `track_changes()`
-Keep track of any changes to the block states of blocks made by your scarpet script so they can be undone later if neccesary using `undo_changes()`. All changes tracked are undone when the script unloads. Does nothing if changes are already being tracked.
+Keep track of any changes to the block states of blocks made by your scarpet script so they can be undone later if neccesary using `undo_changes()`. All changes tracked are undone when the script unloads, or if the server closes (unless you close a server with the x button, or it crashes). Does nothing if changes are already being tracked.
 
 Returns a boolean for whether changes were being tracked before
 

--- a/docs/scarpet/api/BlocksAndWorldAccess.md
+++ b/docs/scarpet/api/BlocksAndWorldAccess.md
@@ -251,11 +251,8 @@ Keep track of any changes to the block states of blocks made by your scarpet scr
 
 Returns a boolean for whether changes were being tracked before
 
-Only works in globally scoped apps
-
 ```
 __config() -> {
-  'scope' -> 'global',
   'commands' -> {
     'block_one <block>' -> _(block) -> ( global_block1 = block; make_block(); ),
     'block_two <block>' -> _(block) -> ( global_block2 = block; make_block(); ),

--- a/src/main/java/carpet/mixins/MinecraftServer_scarpetMixin.java
+++ b/src/main/java/carpet/mixins/MinecraftServer_scarpetMixin.java
@@ -2,6 +2,7 @@ package carpet.mixins;
 
 import carpet.fakes.MinecraftServerInterface;
 import carpet.helpers.TickSpeed;
+import carpet.script.ScriptHost;
 import net.minecraft.resource.ServerResourceManager;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.ServerTask;
@@ -85,5 +86,8 @@ public abstract class MinecraftServer_scarpetMixin extends ReentrantThreadExecut
         ENDER_TICK.onTick();
     }
 
-
+    @Inject(method = "stop", at = @At("HEAD"))
+    public void stop(boolean v, CallbackInfo info) {
+        ScriptHost.beforeClose();
+    }
 }

--- a/src/main/java/carpet/script/CarpetScriptHost.java
+++ b/src/main/java/carpet/script/CarpetScriptHost.java
@@ -12,6 +12,7 @@ import carpet.script.exception.CarpetExpressionException;
 import carpet.script.exception.ExpressionException;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.exception.InvalidCallbackException;
+import carpet.script.utils.SavedBlockChange;
 import carpet.script.value.EntityValue;
 import carpet.script.value.FunctionValue;
 import carpet.script.value.MapValue;
@@ -79,7 +80,7 @@ public class CarpetScriptHost extends ScriptHost
     Function<ServerCommandSource, Boolean> commandValidator;
     boolean isRuleApp;
 
-    private CarpetScriptHost(CarpetScriptServer server, Module code, boolean perUser, ScriptHost parent, Map<Value, Value> config, Map<String, CommandArgument> argTypes, Function<ServerCommandSource, Boolean> commandValidator, boolean isRuleApp)
+    private CarpetScriptHost(CarpetScriptServer server, Module code, boolean perUser, ScriptHost parent, Map<Value, Value> config, Map<String, CommandArgument> argTypes, Function<ServerCommandSource, Boolean> commandValidator, boolean isRuleApp, List<SavedBlockChange> blockChanges)
     {
         super(code, perUser, parent);
         this.saveTimeout = 0;
@@ -98,11 +99,12 @@ public class CarpetScriptHost extends ScriptHost
         appArgTypes = argTypes;
         this.commandValidator = commandValidator;
         this.isRuleApp = isRuleApp;
+        this.blockChanges = blockChanges;
     }
 
     public static CarpetScriptHost create(CarpetScriptServer scriptServer, Module module, boolean perPlayer, ServerCommandSource source, Function<ServerCommandSource, Boolean> commandValidator, boolean isRuleApp)
     {
-        CarpetScriptHost host = new CarpetScriptHost(scriptServer, module, perPlayer, null, Collections.emptyMap(), new HashMap<>(), commandValidator, isRuleApp);
+        CarpetScriptHost host = new CarpetScriptHost(scriptServer, module, perPlayer, null, Collections.emptyMap(), new HashMap<>(), commandValidator, isRuleApp, new ArrayList<>());
         // parse code and convert to expression
         if (module != null)
         {
@@ -243,7 +245,7 @@ public class CarpetScriptHost extends ScriptHost
     @Override
     protected ScriptHost duplicate()
     {
-        return new CarpetScriptHost(scriptServer, main, false, this, appConfig, appArgTypes, commandValidator, isRuleApp);
+        return new CarpetScriptHost(scriptServer, main, false, this, appConfig, appArgTypes, commandValidator, isRuleApp, new ArrayList<>(blockChanges));
     }
 
     @Override

--- a/src/main/java/carpet/script/ScriptHost.java
+++ b/src/main/java/carpet/script/ScriptHost.java
@@ -476,6 +476,8 @@ public abstract class ScriptHost
         executorServices.values().forEach(ThreadPoolExecutor::shutdown);
         for (ScriptHost host : userHosts.values()) host.onClose();
 
+        UndoChanges();
+
         if (taskCount() > 0)
         {
             executorServices.values().forEach(e -> {

--- a/src/main/java/carpet/script/ScriptHost.java
+++ b/src/main/java/carpet/script/ScriptHost.java
@@ -9,9 +9,15 @@ import carpet.script.value.FunctionValue;
 import carpet.script.value.Value;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.util.math.BlockPos;
+
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -38,6 +44,9 @@ public abstract class ScriptHost
     protected boolean inTermination = false;
 
     private final Set<String> deprecations = new HashSet<>();
+
+    public final List<Triple<BlockPos, BlockState, BlockEntity>> blockChanges = new ArrayList<>();
+    public boolean trackingBlockChanges = false;
 
     public Random getRandom(long aLong)
     {

--- a/src/main/java/carpet/script/api/WorldAccess.java
+++ b/src/main/java/carpet/script/api/WorldAccess.java
@@ -853,8 +853,6 @@ public class WorldAccess {
                 }
             }
 
-            c.host.SaveBlockStateChange(world, where);
-
             ItemStack tool = new ItemStack(item, 1);
             if (tag != null)
                 tool.setTag(tag);
@@ -926,8 +924,6 @@ public class WorldAccess {
             BlockPos where = locator.block.getPos();
             BlockState state = locator.block.getBlockState();
             Block block = state.getBlock();
-
-            c.host.SaveBlockStateChange(world, where);
 
             boolean success = false;
             if (!((block == Blocks.BEDROCK || block == Blocks.BARRIER) && player.interactionManager.isSurvivalLike()))

--- a/src/main/java/carpet/script/api/WorldAccess.java
+++ b/src/main/java/carpet/script/api/WorldAccess.java
@@ -15,14 +15,12 @@ import carpet.script.CarpetContext;
 import carpet.script.Context;
 import carpet.script.Expression;
 import carpet.script.Fluff;
-import carpet.script.LazyValue;
 import carpet.script.argument.BlockArgument;
 import carpet.script.argument.Vector3Argument;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.exception.ThrowStatement;
 import carpet.script.exception.Throwables;
 import carpet.script.utils.BiomeInfo;
-import carpet.script.utils.SavedBlockChange;
 import carpet.script.utils.WorldTools;
 import carpet.script.value.BlockValue;
 import carpet.script.value.BooleanValue;
@@ -103,7 +101,6 @@ import net.minecraft.world.poi.PointOfInterest;
 import net.minecraft.world.poi.PointOfInterestStorage;
 import net.minecraft.world.poi.PointOfInterestType;
 
-import org.apache.commons.lang3.tuple.Triple;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -786,7 +783,7 @@ public class WorldAccess {
             BlockPos targetPos = targetLocator.block.getPos();
             Boolean[] result = new Boolean[]{true};
             
-            SaveBlockStateChanges(c, world, targetPos);
+            c.host.SaveBlockStateChange(world, targetPos);
 
             cc.s.getMinecraftServer().submitAndJoin( () ->
             {
@@ -856,7 +853,7 @@ public class WorldAccess {
                 }
             }
 
-            SaveBlockStateChanges(c, world, where);
+            c.host.SaveBlockStateChange(world, where);
 
             ItemStack tool = new ItemStack(item, 1);
             if (tag != null)
@@ -930,7 +927,7 @@ public class WorldAccess {
             BlockState state = locator.block.getBlockState();
             Block block = state.getBlock();
 
-            SaveBlockStateChanges(c, world, where);
+            c.host.SaveBlockStateChange(world, where);
 
             boolean success = false;
             if (!((block == Blocks.BEDROCK || block == Blocks.BARRIER) && player.interactionManager.isSurvivalLike()))
@@ -1051,7 +1048,7 @@ public class WorldAccess {
                 throw new InternalExpressionException(e.getMessage());
             }
 
-            SaveBlockStateChanges(c, world, where);
+            c.host.SaveBlockStateChange(world, where);
 
             if (!(stackArg.getItem() instanceof BlockItem))
             {
@@ -1575,19 +1572,5 @@ public class WorldAccess {
 
             return new NumericValue(undoneChanges);
         });
-    }
-
-    /**
-     * Save the state of a block position so it can be undone later
-     * @param c
-     * @param world
-     * @param blockPos
-     */
-    private static void SaveBlockStateChanges(Context c, World world, BlockPos blockPos) {
-        if (c.host.trackingBlockChanges) {
-            BlockEntity entity = world.getBlockEntity(blockPos);
-            CompoundTag tag = entity == null ? null : entity.toTag(new CompoundTag());
-            c.host.blockChanges.add(new SavedBlockChange(world, blockPos, world.getBlockState(blockPos), tag));
-        }
     }
 }

--- a/src/main/java/carpet/script/utils/SavedBlockChange.java
+++ b/src/main/java/carpet/script/utils/SavedBlockChange.java
@@ -1,0 +1,20 @@
+package carpet.script.utils;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class SavedBlockChange {
+  public final World world;
+  public final BlockPos pos;
+  public final BlockState state;
+  public final CompoundTag entity;
+
+  public SavedBlockChange(World world, BlockPos pos, BlockState state, CompoundTag entity) {
+    this.world = world;
+    this.pos = pos;
+    this.state = state;
+    this.entity = entity;
+  }
+}


### PR DESCRIPTION
This would add the ability for scarpet scripts to easily track changes they make to the world, and undo them, or save them, using `track_changes()`, `undo_changes()`, and `commit_changes()`.

This would be especially useful for creative building scripts that apply modifications to an existing build. For example, a script to automatically do landscaping could save all the changes it makes, and if you decide there's too much tall grass or something, the script could undo, and go again with the new parameters.