### PR TITLE
Java 16 build compatibility

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 16
       uses: actions/setup-java@v1
       with:
         java-version: 1.8

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -3,10 +3,7 @@
 
 name: Pull Request Builds
 
-on:
-  pull_request:
-    paths:
-    - "src/**"
+on: [pull_request]
 
 jobs:
   Build:
@@ -16,8 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 16
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: 'adopt'
         java-version: 16
     - name: Cache Gradle packages
       uses: actions/cache@v2

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up JDK 16
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 16
     - name: Cache Gradle packages
       uses: actions/cache@v2
       with:

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 16
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 16
     - name: Cache Gradle packages
       uses: actions/cache@v2
       with:

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -3,10 +3,7 @@
 
 name: Development Builds
 
-on:
-  push:
-    paths:
-    - "src/**"
+on: [push]
 
 jobs:
   Build:
@@ -16,8 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 16
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: 'adopt'
         java-version: 16
     - name: Cache Gradle packages
       uses: actions/cache@v2

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -65,10 +65,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ steps.getbranchinfo.outputs.branchname }}
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 16
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 16
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:
@@ -139,10 +140,11 @@ jobs:
     steps:
       - name: Checkout Carpet sources
         uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 16
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: 16
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.5-SNAPSHOT'
+	id 'fabric-loom' version '0.6-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -18,7 +18,7 @@ dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modCompile "net.fabricmc:fabric-loader:${project.loader_version}"
+	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	// modCompile "net.fabricmc:fabric:${project.fabric_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -31,13 +31,8 @@ dependencies {
 processResources {
 	inputs.property "version", project.version
 
-	from(sourceSets.main.resources.srcDirs) {
-		include "fabric.mod.json"
-		expand "version": project.mod_version
-	}
-
-	from(sourceSets.main.resources.srcDirs) {
-		exclude "fabric.mod.json"
+	filesMatching("fabric.mod.json") {
+		expand "version": project.version
 	}
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Well, Minecraft is now Java 16...

Meaning Carpet will at some point need to be compatible with it when building too.

This PR changes the actions to run using Java 16 instead of 8 (there are no problems with compiling for older java versions until 1.17 releases, since target version is still 8) and updates the buildscript to use Gradle 7.0 (needed for Java 16 compatibility) and Loom 0.6 (needed for compatibility with Gradle 7), including a few fixes for removed features.

Also updates `setup-java` action step to v2 while at it, and makes the ci builds run when any file is changed, not only in src, just cause why not, that way there is always a green check if it works.

~Still a draft since I've just done this fast in the Github web app and I have to test it.~ Tested and it works, both ci and releases (once it's merged to 1.17 branch ofc).