### PR TITLE
Use primitive specific Predicate instead of Boolean Function

### DIFF
--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -37,7 +37,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static net.minecraft.server.command.CommandManager.argument;
@@ -226,7 +226,7 @@ public class CarpetScriptServer
         return modules.get(name);
     }
 
-    public boolean addScriptHost(ServerCommandSource source, String name, Function<ServerCommandSource, Boolean> commandValidator,
+    public boolean addScriptHost(ServerCommandSource source, String name, Predicate<ServerCommandSource> commandValidator,
                                  boolean perPlayer, boolean autoload, boolean isRuleApp)
     {
         CarpetProfiler.ProfilerToken currentSection = CarpetProfiler.start_section(null, "Scarpet load", CarpetProfiler.TYPE.GENERAL);
@@ -457,7 +457,7 @@ public class CarpetScriptServer
     static class TransferData
     {
         boolean perUser;
-        Function<ServerCommandSource, Boolean> commandValidator;
+        Predicate<ServerCommandSource> commandValidator;
         boolean isRuleApp;
         private TransferData(CarpetScriptHost host)
         {

--- a/src/main/java/carpet/script/api/WorldAccess.java
+++ b/src/main/java/carpet/script/api/WorldAccess.java
@@ -113,6 +113,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -132,7 +133,7 @@ public class WorldAccess {
             Context c,
             String name,
             List<Value> params,
-            BiFunction<BlockState, BlockPos, Boolean> test
+            BiPredicate<BlockState, BlockPos> test
     )
     {
         CarpetContext cc = (CarpetContext) c;
@@ -140,9 +141,9 @@ public class WorldAccess {
             throw new InternalExpressionException("'" + name + "' requires at least one parameter");
         Value v0 = params.get(0);
         if (v0 instanceof BlockValue)
-            return BooleanValue.of(test.apply(((BlockValue) v0).getBlockState(), ((BlockValue) v0).getPos()));
+            return BooleanValue.of(test.test(((BlockValue) v0).getBlockState(), ((BlockValue) v0).getPos()));
         BlockValue block = BlockArgument.findIn(cc, params, 0).block;
-        return BooleanValue.of(test.apply(block.getBlockState(), block.getPos()));
+        return BooleanValue.of(test.test(block.getBlockState(), block.getPos()));
     }
 
     private static Value stateStringQuery(


### PR DESCRIPTION
A bit more compact and prevents autoboxing. Was mostly bored.

Also (completely unrelated to this PR), Carpet for releases could still be built using Loom 0.7, since that's supposedly more stable and has support for building using Java 8 through 16 (rn Carpet requires Java 16 to be built since Loom 0.8 targets it).

Edit: `test.test()` may not be the most expressive name for the function, yeah, but at that time I just changed the types.