### PR TITLE
Remove the number_classes set in favour of ClassUtils

### DIFF
--- a/src/main/java/carpet/settings/ParsedRule.java
+++ b/src/main/java/carpet/settings/ParsedRule.java
@@ -3,7 +3,6 @@ package carpet.settings;
 import carpet.utils.Translations;
 import carpet.utils.Messenger;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
 import net.minecraft.server.command.ServerCommandSource;
 
 import java.lang.reflect.Constructor;
@@ -12,7 +11,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
+
+import org.apache.commons.lang3.ClassUtils;
 
 import static carpet.utils.Translations.tr;
 
@@ -39,7 +39,6 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
     public final T defaultValue;
     public final String defaultAsString;
     public final SettingsManager settingsManager;
-    private static final Set<Class<?>> NUMBER_CLASSES = Sets.newHashSet(byte.class, short.class, int.class, long.class, float.class, double.class);
 
     ParsedRule(Field field, Rule rule, SettingsManager settingsManager)
     {
@@ -216,7 +215,7 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
     public boolean getBoolValue()
     {
         if (type == boolean.class) return (Boolean) get();
-        if (NUMBER_CLASSES.contains(type)) return ((Number) get()).doubleValue() > 0;
+        if (ClassUtils.primitiveToWrapper(type).isAssignableFrom(Number.class)) return ((Number) get()).doubleValue() > 0;
         return false;
     }
 


### PR DESCRIPTION
That was a thing of mine when fixing `getBoolValue` for Scarpet rules.

This new way removes the set in favour of using Apache's ClassUtils `primitiveToWrapper` method, which gets the wrapper class, that actually extends `Number`.

Technically fixes rules (from extensions maybe?) using wrappers as their numbers. However other parts checking specifically for primitives aren't changed (e.g. checks for `boolean.class`) (would it be worth setting `type` to the wrapper and only check equality with wrappers? Not sure)