### PR TITLE
Fix dedicated server crash with hopper counters

### DIFF
--- a/src/main/java/carpet/helpers/HopperCounter.java
+++ b/src/main/java/carpet/helpers/HopperCounter.java
@@ -40,6 +40,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class HopperCounter
@@ -275,13 +276,14 @@ public class HopperCounter
         if (item instanceof DyeItem) return TextColor.fromRgb(appropriateColor(((DyeItem) item).getColor().getMaterialColor().color));
         Block block = null;
         Identifier id = Registry.ITEM.getId(item);
+        Optional<Block> optionalBlock;
         if (item instanceof BlockItem)
         {
             block = ((BlockItem) item).getBlock();
         }
-        else if (Registry.BLOCK.containsId(id))
+        else if ((optionalBlock = Registry.BLOCK.getOrEmpty(id)).isPresent())
         {
-            block = Registry.BLOCK.get(id);
+            block = optionalBlock.get();
         }
         if (block != null)
         {


### PR DESCRIPTION
Fixes #864.

The new color thing was using a method that is only present in the client (`containsId`), so I changed it to `getOrEmpty().isPresent()`. Also saved the result of `getOrEmpty` so there's no need to poll the registry twice.