### PR TITLE
Fix fake player name too long (length > 16) cause server kick all player

### DIFF
--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -267,7 +267,7 @@ public class PlayerCommand
         }
         catch (CommandSyntaxException ignored) {}
         String playerName = StringArgumentType.getString(context, "player");
-        if (playerName.length()>40)
+        if (playerName.length()>16)
         {
             Messenger.m(context.getSource(), "rb Player name: "+playerName+" is too long");
             return 0;


### PR DESCRIPTION
In online server, the length of fake player name is restricted by Mojang's auth server, so when you spawn a fake player with name length > 16, carpet will report "cannot spawn in online mode" instead of "name is too long". But in offline server, client can spawn fake player which name's length > 16 and < 41, that cause server kick out all client and refuse client to connect server.

Here is a video about this problem: https://streamable.com/y3dcnn