### PR TITLE
Use primitive doubles in `NumericValue` and allow adding exhaustion with floats

### DIFF
--- a/src/main/java/carpet/script/value/EntityValue.java
+++ b/src/main/java/carpet/script/value/EntityValue.java
@@ -1,6 +1,5 @@
 package carpet.script.value;
 
-import carpet.CarpetServer;
 import carpet.fakes.BrainInterface;
 import carpet.fakes.EntityInterface;
 import carpet.fakes.ItemEntityInterface;
@@ -59,7 +58,6 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.text.LiteralText;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.hit.BlockHitResult;
@@ -1458,7 +1456,7 @@ public class EntityValue extends Value
         });
 
         put("add_exhaustion", (e, v)-> {
-            if(e instanceof PlayerEntity) ((PlayerEntity) e).getHungerManager().addExhaustion((int) NumericValue.asNumber(v).getLong());
+            if (e instanceof PlayerEntity) ((PlayerEntity) e).getHungerManager().addExhaustion(NumericValue.asNumber(v).getFloat());
         });
 
         put("absorption", (e, v) -> {

--- a/src/main/java/carpet/script/value/NumericValue.java
+++ b/src/main/java/carpet/script/value/NumericValue.java
@@ -19,7 +19,7 @@ import static java.lang.Math.signum;
 
 public class NumericValue extends Value
 {
-    private final Double value;
+    private final double value;
     private Long longValue;
     private final static double epsilon = abs(32*((7*0.1)*10-7));
     private final static MathContext displayRounding = new MathContext(12, RoundingMode.HALF_EVEN);
@@ -56,8 +56,8 @@ public class NumericValue extends Value
         }
         try
         {
-            if (value.isInfinite()) return "INFINITY";
-            if (value.isNaN()) return "NaN";
+            if (Double.isInfinite(value)) return "INFINITY";
+            if (Double.isNaN(value)) return "NaN";
             if (abs(value) < epsilon) return (signum(value) < 0)?"-0":"0"; //zero rounding fails with big decimals
             // dobules have 16 point precision, 12 is plenty to display
             return BigDecimal.valueOf(value).round(displayRounding).stripTrailingZeros().toPlainString();
@@ -93,7 +93,7 @@ public class NumericValue extends Value
     }
     public float getFloat()
     {
-        return value.floatValue();
+        return (float) value;
     }
 
     private static long floor(double double_1) {
@@ -178,7 +178,7 @@ public class NumericValue extends Value
             NumericValue no = (NumericValue)o;
             if (longValue != null && no.longValue != null)
                 return longValue.compareTo(no.longValue);
-            return value.compareTo(no.value);
+            return Double.compare(value, no.value);
         }
         return getString().compareTo(o.getString());
     }


### PR DESCRIPTION
Title.

Resolves #879.

Changes `NumericValue` to hold a primitive double, I guess should help with heavy loads with numbers by avoiding autoboxing and autounboxing (there were no `null` checks or assignations to that variable) (haven't tested it, at least yet, just no compile errors).