### PR TITLE
Deprecate old boolean constructor and move existing usages

### DIFF
--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -465,7 +465,7 @@ public class CarpetEventServer
             public void onMountControls(ServerPlayerEntity player, float strafeSpeed, float forwardSpeed, boolean jumping, boolean sneaking)
             {
                 handler.call( () -> Arrays.asList(new EntityValue(player),
-                        new NumericValue(forwardSpeed), new NumericValue(strafeSpeed), new NumericValue(jumping), new NumericValue(sneaking)
+                        new NumericValue(forwardSpeed), new NumericValue(strafeSpeed), BooleanValue.of(jumping), BooleanValue.of(sneaking)
                 ), player::getCommandSource);
             }
         };
@@ -700,7 +700,7 @@ public class CarpetEventServer
                         Arrays.asList(
                                 new EntityValue(player),
                                 StringValue.of(NBTSerializableValue.nameFromRegistryId(recipe)),
-                                new NumericValue(fullStack)
+                                BooleanValue.of(fullStack)
                         ), player::getCommandSource);
             }
         };

--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -452,7 +452,7 @@ public class Auxiliary {
             if (lv.get(0).isNull()) return Value.FALSE;
             Tag source = ((NBTSerializableValue)(NBTSerializableValue.fromValue(lv.get(0)))).getTag();
             Tag match = ((NBTSerializableValue)(NBTSerializableValue.fromValue(lv.get(1)))).getTag();
-            return new NumericValue(NbtHelper.matches(match, source, numParam == 2 || lv.get(2).getBoolean()));
+            return BooleanValue.of(NbtHelper.matches(match, source, numParam == 2 || lv.get(2).getBoolean()));
         });
 
         expression.addFunction("encode_nbt", lv -> {
@@ -776,7 +776,7 @@ public class Auxiliary {
                     return;
                 if (what.equalsIgnoreCase("boulder"))  // there might be more of those
                     WorldTools.forceChunkUpdate(locator.block.getPos(), ((CarpetContext) c).s.getWorld());
-                result[0] = new NumericValue(res);
+                result[0] = BooleanValue.of(res);
             });
             return result[0];
         });

--- a/src/main/java/carpet/script/api/Inventories.java
+++ b/src/main/java/carpet/script/api/Inventories.java
@@ -194,7 +194,7 @@ public class Inventories {
             CarpetContext cc = (CarpetContext) c;
             NBTSerializableValue.InventoryLocator inventoryLocator = NBTSerializableValue.locateInventory(cc, lv, 0);
             if (inventoryLocator == null) return Value.NULL;
-            return new NumericValue(!inventoryLocator.inventory.isEmpty());
+            return BooleanValue.of(!inventoryLocator.inventory.isEmpty());
         });
 
         //inventory_get(<b, e>, <n>) -> item_triple

--- a/src/main/java/carpet/script/api/Scoreboards.java
+++ b/src/main/java/carpet/script/api/Scoreboards.java
@@ -8,6 +8,7 @@ import carpet.script.LazyValue;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.exception.ThrowStatement;
 import carpet.script.exception.Throwables;
+import carpet.script.value.BooleanValue;
 import carpet.script.value.EntityValue;
 import carpet.script.value.ListValue;
 import carpet.script.value.NullValue;
@@ -301,7 +302,7 @@ public class Scoreboards {
             Value playerVal = lv.get(0);
             String player = EntityValue.getPlayerNameByValue(playerVal);
             if(player == null) return Value.NULL;
-            return new NumericValue(scoreboard.clearPlayerTeam(player));
+            return BooleanValue.of(scoreboard.clearPlayerTeam(player));
         });
 
         expression.addContextFunction("team_property", -1, (c, t, lv) ->
@@ -357,7 +358,7 @@ public class Scoreboards {
                     team.setDisplayName(displayName);
                     break;
                 case "friendlyFire":
-                    if(!modifying) return new NumericValue(team.isFriendlyFireAllowed());
+                    if(!modifying) return BooleanValue.of(team.isFriendlyFireAllowed());
                     if(!(settingVal instanceof NumericValue)) throw  new InternalExpressionException("'team_property' requires a boolean as the third argument for the property " + propertyVal.getString());
                     boolean friendlyFire = settingVal.getBoolean();
                     team.setFriendlyFireAllowed(friendlyFire);
@@ -378,7 +379,7 @@ public class Scoreboards {
                     team.setPrefix(prefix);
                     break;
                 case "seeFriendlyInvisibles":
-                    if(!modifying) return new NumericValue(team.shouldShowFriendlyInvisibles());
+                    if(!modifying) return BooleanValue.of(team.shouldShowFriendlyInvisibles());
                     if(!(settingVal instanceof NumericValue)) throw  new InternalExpressionException("'team_property' requires a boolean as the third argument for the property " + propertyVal.getString());
                     boolean seeFriendlyInvisibles = settingVal.getBoolean();
                     team.setShowFriendlyInvisibles(seeFriendlyInvisibles);
@@ -500,7 +501,7 @@ public class Scoreboards {
                     bossBar.setValue(((NumericValue) propertyValue).getInt());
                     return Value.TRUE;
                 case "visible":
-                    if(propertyValue == null) return new NumericValue(bossBar.isVisible());
+                    if(propertyValue == null) return BooleanValue.of(bossBar.isVisible());
 
                     bossBar.setVisible(propertyValue.getBoolean());
                     return Value.TRUE;

--- a/src/main/java/carpet/script/api/WorldAccess.java
+++ b/src/main/java/carpet/script/api/WorldAccess.java
@@ -492,7 +492,7 @@ public class WorldAccess {
         });
 
         expression.addContextFunction("solid", -1, (c, t, lv) ->
-                genericStateTest(c, "solid", lv, (s, p, w) -> new NumericValue(s.isSolidBlock(w, p)))); // isSimpleFullBlock
+                genericStateTest(c, "solid", lv, (s, p, w) -> BooleanValue.of(s.isSolidBlock(w, p)))); // isSimpleFullBlock
 
         expression.addContextFunction("air", -1, (c, t, lv) ->
                 booleanStateTest(c, "air", lv, (s, p) -> s.isAir()));
@@ -525,7 +525,7 @@ public class WorldAccess {
                 genericStateTest(c, "sky_light", lv, (s, p, w) -> new NumericValue(w.getLightLevel(LightType.SKY, p))));
 
         expression.addContextFunction("see_sky", -1, (c, t, lv) ->
-                genericStateTest(c, "see_sky", lv, (s, p, w) -> new NumericValue(w.isSkyVisible(p))));
+                genericStateTest(c, "see_sky", lv, (s, p, w) -> BooleanValue.of(w.isSkyVisible(p))));
 
         expression.addContextFunction("brightness", -1, (c, t, lv) ->
                 genericStateTest(c, "brightness", lv, (s, p, w) -> new NumericValue(w.getBrightness(p))));
@@ -540,7 +540,7 @@ public class WorldAccess {
         {
             BlockPos pos = BlockArgument.findIn((CarpetContext)c, lv, 0).block.getPos();
             ChunkPos chunkPos = new ChunkPos(pos);
-            return new NumericValue(ChunkRandom.getSlimeRandom(
+            return BooleanValue.of(ChunkRandom.getSlimeRandom(
                     chunkPos.x, chunkPos.z,
                     ((CarpetContext)c).s.getWorld().getSeed(),
                     987234911L
@@ -593,7 +593,7 @@ public class WorldAccess {
             boolean force = false;
             if (lv.size() > locator.offset)
                 force = lv.get(locator.offset).getBoolean();
-            return new NumericValue(canHasChunk(((CarpetContext)c).s.getWorld(), new ChunkPos(pos), null, force));
+            return BooleanValue.of(canHasChunk(((CarpetContext)c).s.getWorld(), new ChunkPos(pos), null, force));
         });
 
         expression.addContextFunction("generation_status", -1, (c, t, lv) ->
@@ -653,7 +653,7 @@ public class WorldAccess {
         });
 
         expression.addContextFunction("suffocates", -1, (c, t, lv) ->
-                genericStateTest(c, "suffocates", lv, (s, p, w) -> new NumericValue(s.shouldSuffocate(w, p)))); // canSuffocate
+                genericStateTest(c, "suffocates", lv, (s, p, w) -> BooleanValue.of(s.shouldSuffocate(w, p)))); // canSuffocate
 
         expression.addContextFunction("power", -1, (c, t, lv) ->
                 genericStateTest(c, "power", lv, (s, p, w) -> new NumericValue(w.getReceivedRedstonePower(p))));

--- a/src/main/java/carpet/script/command/CommandArgument.java
+++ b/src/main/java/carpet/script/command/CommandArgument.java
@@ -6,6 +6,7 @@ import carpet.script.CarpetScriptHost;
 import carpet.script.argument.FunctionArgument;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.value.BlockValue;
+import carpet.script.value.BooleanValue;
 import carpet.script.value.EntityValue;
 import carpet.script.value.FormattedTextValue;
 import carpet.script.value.ListValue;
@@ -114,7 +115,7 @@ public abstract class CommandArgument
             new StringArgument(),
             // vanilla arguments as per https://minecraft.gamepedia.com/Argument_types
             new VanillaUnconfigurableArgument( "bool", BoolArgumentType::bool,
-                    (c, p) -> new NumericValue(BoolArgumentType.getBool(c, p)), false
+                    (c, p) -> BooleanValue.of(BoolArgumentType.getBool(c, p)), false
             ),
             new FloatArgument(),
             new IntArgument(),

--- a/src/main/java/carpet/script/language/DataStructures.java
+++ b/src/main/java/carpet/script/language/DataStructures.java
@@ -7,6 +7,7 @@ import carpet.script.exception.InternalExpressionException;
 import carpet.script.exception.ThrowStatement;
 import carpet.script.exception.Throwables;
 import carpet.script.utils.ScarpetJsonDeserializer;
+import carpet.script.value.BooleanValue;
 import carpet.script.value.ContainerValueInterface;
 import carpet.script.value.LContainerValue;
 import carpet.script.value.LazyListValue;
@@ -246,7 +247,7 @@ public class DataStructures {
                 ContainerValueInterface container = ((LContainerValue) v).getContainer();
                 if (container == null)
                     return LazyValue.NULL;
-                Value ret = new NumericValue(container.has(((LContainerValue) v).getAddress()));
+                Value ret = BooleanValue.of(container.has(((LContainerValue) v).getAddress()));
                 return (cc, tt) -> ret;
             }
             Value container = lv.get(0).evalValue(c);
@@ -257,7 +258,7 @@ public class DataStructures {
             }
             if (!(container instanceof ContainerValueInterface))
                 return LazyValue.NULL;
-            Value ret = new NumericValue(((ContainerValueInterface) container).has(lv.get(lv.size()-1).evalValue(c)));
+            Value ret = BooleanValue.of(((ContainerValueInterface) container).has(lv.get(lv.size()-1).evalValue(c)));
             return (cc, tt) -> ret;
         });
 
@@ -278,7 +279,7 @@ public class DataStructures {
                 }
                 Value address = ((LContainerValue) container).getAddress();
                 Value what = lv.get(1).evalValue(c);
-                Value retVal = new NumericValue( (lv.size() > 2)
+                Value retVal = BooleanValue.of((lv.size() > 2)
                         ? internalContainer.put(address, what, lv.get(2).evalValue(c))
                         : internalContainer.put(address, what));
                 return (cc, tt) -> retVal;
@@ -294,7 +295,7 @@ public class DataStructures {
             }
             Value where = lv.get(1).evalValue(c);
             Value what = lv.get(2).evalValue(c);
-            Value retVal = new NumericValue( (lv.size()>3)
+            Value retVal = BooleanValue.of((lv.size()>3)
                     ? ((ContainerValueInterface) container).put(where, what, lv.get(3).evalValue(c))
                     : ((ContainerValueInterface) container).put(where, what));
             return (cc, tt) -> retVal;
@@ -313,7 +314,7 @@ public class DataStructures {
                 ContainerValueInterface container = ((LContainerValue) v).getContainer();
                 if (container == null)
                     return LazyValue.NULL;
-                Value ret = new NumericValue(container.delete(((LContainerValue) v).getAddress()));
+                Value ret = BooleanValue.of(container.delete(((LContainerValue) v).getAddress()));
                 return (cc, tt) -> ret;
             }
             Value container = lv.get(0).evalValue(c);
@@ -324,7 +325,7 @@ public class DataStructures {
             }
             if (!(container instanceof ContainerValueInterface))
                 return LazyValue.NULL;
-            Value ret = new NumericValue(((ContainerValueInterface) container).delete(lv.get(lv.size()-1).evalValue(c)));
+            Value ret = BooleanValue.of(((ContainerValueInterface) container).delete(lv.get(lv.size()-1).evalValue(c)));
             return (cc, tt) -> ret;
         });
 

--- a/src/main/java/carpet/script/language/Threading.java
+++ b/src/main/java/carpet/script/language/Threading.java
@@ -4,6 +4,7 @@ import carpet.script.Expression;
 import carpet.script.argument.FunctionArgument;
 import carpet.script.exception.ExitStatement;
 import carpet.script.exception.InternalExpressionException;
+import carpet.script.value.BooleanValue;
 import carpet.script.value.NumericValue;
 import carpet.script.value.ThreadValue;
 import carpet.script.value.Value;
@@ -62,7 +63,7 @@ public class Threading
         {
             if (!(v instanceof ThreadValue))
                 throw new InternalExpressionException("'task_completed' could only be used with a task value");
-            return new NumericValue(((ThreadValue) v).isFinished());
+            return BooleanValue.of(((ThreadValue) v).isFinished());
         });
 
         // lazy cause expr is evaluated in the same type

--- a/src/main/java/carpet/script/utils/ShapeDispatcher.java
+++ b/src/main/java/carpet/script/utils/ShapeDispatcher.java
@@ -8,6 +8,7 @@ import carpet.script.exception.ThrowStatement;
 import carpet.script.exception.Throwables;
 import carpet.script.language.Sys;
 import carpet.script.value.BlockValue;
+import carpet.script.value.BooleanValue;
 import carpet.script.value.EntityValue;
 import carpet.script.value.FormattedTextValue;
 import carpet.script.value.ListValue;
@@ -1023,7 +1024,7 @@ public class ShapeDispatcher
         @Override
         public Value decode(Tag tag)
         {
-            return new NumericValue(((ByteTag) tag).getByte() > 0);
+            return BooleanValue.of(((ByteTag) tag).getByte() > 0);
         }
     }
     public static class FloatParam extends NumericParam

--- a/src/main/java/carpet/script/utils/SystemInfo.java
+++ b/src/main/java/carpet/script/utils/SystemInfo.java
@@ -60,7 +60,7 @@ public class SystemInfo {
         });
 
         put("game_difficulty", c -> StringValue.of(c.s.getMinecraftServer().getSaveProperties().getDifficulty().getName()));
-        put("game_hardcore", c -> new NumericValue(c.s.getMinecraftServer().getSaveProperties().isHardcore()));
+        put("game_hardcore", c -> BooleanValue.of(c.s.getMinecraftServer().getSaveProperties().isHardcore()));
         put("game_storage_format", c -> StringValue.of(c.s.getMinecraftServer().getSaveProperties().getFormatName(c.s.getMinecraftServer().getSaveProperties().getVersion())));
         put("game_default_gamemode", c -> StringValue.of(c.s.getMinecraftServer().getDefaultGameMode().getName()));
         put("game_max_players", c -> new NumericValue(c.s.getMinecraftServer().getMaxPlayerCount()));
@@ -82,7 +82,7 @@ public class SystemInfo {
         put("game_pack_version", c->NumericValue.of(SharedConstants.getGameVersion().getPackVersion()));
 
         put("server_ip", c -> StringValue.of(c.s.getMinecraftServer().getServerIp()));
-        put("server_whitelisted", c -> new NumericValue(c.s.getMinecraftServer().isEnforceWhitelist()));
+        put("server_whitelisted", c -> BooleanValue.of(c.s.getMinecraftServer().isEnforceWhitelist()));
         put("server_whitelist", c -> {
             MapValue whitelist = new MapValue(Collections.emptyList());
             for (String s: c.s.getMinecraftServer().getPlayerManager().getWhitelistedNames())
@@ -107,7 +107,7 @@ public class SystemInfo {
             }
             return whitelist;
         });
-        put("server_dev_environment", c-> new NumericValue(FabricLoader.getInstance().isDevelopmentEnvironment()));
+        put("server_dev_environment", c-> BooleanValue.of(FabricLoader.getInstance().isDevelopmentEnvironment()));
         put("server_mods", c -> {
             Map<Value, Value> ret = new HashMap<>();
             for (ModContainer mod : FabricLoader.getInstance().getAllMods())

--- a/src/main/java/carpet/script/value/BooleanValue.java
+++ b/src/main/java/carpet/script/value/BooleanValue.java
@@ -18,7 +18,7 @@ public class BooleanValue extends NumericValue
 
     public static BooleanValue of(boolean value)
     {
-        return value?TRUE:FALSE;
+        return value ? TRUE : FALSE;
     }
 
     @Override

--- a/src/main/java/carpet/script/value/EntityValue.java
+++ b/src/main/java/carpet/script/value/EntityValue.java
@@ -409,7 +409,7 @@ public class EntityValue extends Value
 
     private static final Map<String, BiFunction<Entity, Value, Value>> featureAccessors = new HashMap<String, BiFunction<Entity, Value, Value>>() {{
         //put("test", (e, a) -> a == null ? Value.NULL : new StringValue(a.getString()));
-        put("removed", (entity, arg) -> new NumericValue(entity.removed));
+        put("removed", (entity, arg) -> BooleanValue.of(entity.removed));
         put("uuid",(e, a) -> new StringValue(e.getUuidAsString()));
         put("id",(e, a) -> new NumericValue(e.getEntityId()));
         put("pos", (e, a) -> ListValue.of(new NumericValue(e.getX()), new NumericValue(e.getY()), new NumericValue(e.getZ())));
@@ -425,30 +425,30 @@ public class EntityValue extends Value
         put("motion_x", (e, a) -> new NumericValue(e.getVelocity().x));
         put("motion_y", (e, a) -> new NumericValue(e.getVelocity().y));
         put("motion_z", (e, a) -> new NumericValue(e.getVelocity().z));
-        put("on_ground", (e, a) -> new NumericValue(e.isOnGround()));
+        put("on_ground", (e, a) -> BooleanValue.of(e.isOnGround()));
         put("name", (e, a) -> new StringValue(e.getName().getString()));
         put("display_name", (e, a) -> new FormattedTextValue(e.getDisplayName()));
         put("command_name", (e, a) -> new StringValue(e.getEntityName()));
         put("custom_name", (e, a) -> e.hasCustomName()?new StringValue(e.getCustomName().getString()):Value.NULL);
         put("type", (e, a) -> new StringValue(nameFromRegistryId(Registry.ENTITY_TYPE.getId(e.getType()))));
-        put("is_riding", (e, a) -> new NumericValue(e.hasVehicle()));
-        put("is_ridden", (e, a) -> new NumericValue(e.hasPassengers()));
+        put("is_riding", (e, a) -> BooleanValue.of(e.hasVehicle()));
+        put("is_ridden", (e, a) -> BooleanValue.of(e.hasPassengers()));
         put("passengers", (e, a) -> ListValue.wrap(e.getPassengerList().stream().map(EntityValue::new).collect(Collectors.toList())));
         put("mount", (e, a) -> (e.getVehicle()!=null)?new EntityValue(e.getVehicle()):Value.NULL);
-        put("unmountable", (e, a) -> new NumericValue(((EntityInterface)e).isPermanentVehicle()));
+        put("unmountable", (e, a) -> BooleanValue.of(((EntityInterface)e).isPermanentVehicle()));
         // deprecated
         put("tags", (e, a) -> ListValue.wrap(e.getScoreboardTags().stream().map(StringValue::new).collect(Collectors.toList())));
 
         put("scoreboard_tags", (e, a) -> ListValue.wrap(e.getScoreboardTags().stream().map(StringValue::new).collect(Collectors.toList())));
         put("entity_tags", (e, a) -> ListValue.wrap(e.getServer().getTagManager().getEntityTypes().getTags().entrySet().stream().filter(entry -> entry.getValue().contains(e.getType())).map(entry -> ValueConversions.of(entry.getKey())).collect(Collectors.toList())));
         // deprecated
-        put("has_tag", (e, a) -> new NumericValue(e.getScoreboardTags().contains(a.getString())));
+        put("has_tag", (e, a) -> BooleanValue.of(e.getScoreboardTags().contains(a.getString())));
 
-        put("has_scoreboard_tag", (e, a) -> new NumericValue(e.getScoreboardTags().contains(a.getString())));
+        put("has_scoreboard_tag", (e, a) -> BooleanValue.of(e.getScoreboardTags().contains(a.getString())));
         put("has_entity_tag", (e, a) -> {
             net.minecraft.tag.Tag<EntityType<?>> tag = e.getServer().getTagManager().getEntityTypes().getTag(new Identifier(a.getString()));
             if (tag == null) return Value.NULL;
-            return new NumericValue(e.getType().isIn(tag));
+            return BooleanValue.of(e.getType().isIn(tag));
         });
 
         put("yaw", (e, a)-> new NumericValue(e.yaw));
@@ -472,13 +472,13 @@ public class EntityValue extends Value
             Vec3d look = e.getRotationVector();
             return ListValue.of(new NumericValue(look.x),new NumericValue(look.y),new NumericValue(look.z));
         });
-        put("is_burning", (e, a) -> new NumericValue(e.isOnFire()));
+        put("is_burning", (e, a) -> BooleanValue.of(e.isOnFire()));
         put("fire", (e, a) -> new NumericValue(e.getFireTicks()));
-        put("silent", (e, a)-> new NumericValue(e.isSilent()));
-        put("gravity", (e, a) -> new NumericValue(!e.hasNoGravity()));
-        put("immune_to_fire", (e, a) -> new NumericValue(e.isFireImmune()));
+        put("silent", (e, a)-> BooleanValue.of(e.isSilent()));
+        put("gravity", (e, a) -> BooleanValue.of(!e.hasNoGravity()));
+        put("immune_to_fire", (e, a) -> BooleanValue.of(e.isFireImmune()));
 
-        put("invulnerable", (e, a) -> new NumericValue(e.isInvulnerable()));
+        put("invulnerable", (e, a) -> BooleanValue.of(e.isInvulnerable()));
         put("dimension", (e, a) -> new StringValue(nameFromRegistryId(e.world.getRegistryKey().getValue()))); // getDimId
         put("height", (e, a) -> new NumericValue(e.getDimensions(EntityPose.STANDING).height));
         put("width", (e, a) -> new NumericValue(e.getDimensions(EntityPose.STANDING).width));
@@ -492,7 +492,7 @@ public class EntityValue extends Value
         put("portal_cooldown", (e , a) ->new NumericValue(((EntityInterface)e).getPortalTimer()));
         put("portal_timer", (e , a) ->new NumericValue(((EntityInterface)e).getPublicNetherPortalCooldown()));
         // ItemEntity -> despawn timer via ssGetAge
-        put("is_baby", (e, a) -> (e instanceof LivingEntity)?new NumericValue(((LivingEntity) e).isBaby()):Value.NULL);
+        put("is_baby", (e, a) -> (e instanceof LivingEntity)?BooleanValue.of(((LivingEntity) e).isBaby()):Value.NULL);
         put("target", (e, a) -> {
             if (e instanceof MobEntity)
             {
@@ -520,7 +520,7 @@ public class EntityValue extends Value
                         ValueConversions.of(spe.getSpawnPointPosition()),
                         ValueConversions.of(spe.getSpawnPointDimension()),
                         new NumericValue(spe.getSpawnAngle()),
-                        new NumericValue(spe.isSpawnPointSet()) // true if forced spawn point
+                        BooleanValue.of(spe.isSpawnPointSet())
                         );
             }
             return Value.NULL;
@@ -530,7 +530,7 @@ public class EntityValue extends Value
         put("sprinting", (e, a) -> e.isSprinting()?Value.TRUE:Value.FALSE);
         put("swimming", (e, a) -> e.isSwimming()?Value.TRUE:Value.FALSE);
         put("swinging", (e, a) -> {
-            if (e instanceof LivingEntity) return new NumericValue(((LivingEntity) e).handSwinging);
+            if (e instanceof LivingEntity) return BooleanValue.of(((LivingEntity) e).handSwinging);
             return Value.NULL;
         });
 
@@ -542,7 +542,7 @@ public class EntityValue extends Value
             return StringValue.of(lang);
         });
         put("persistence", (e, a) -> {
-            if (e instanceof MobEntity) return new NumericValue(((MobEntity) e).isPersistent());
+            if (e instanceof MobEntity) return BooleanValue.of(((MobEntity) e).isPersistent());
             return Value.NULL;
         });
         put("hunger", (e, a) -> {

--- a/src/main/java/carpet/script/value/NumericValue.java
+++ b/src/main/java/carpet/script/value/NumericValue.java
@@ -227,6 +227,13 @@ public class NumericValue extends Value
         this.longValue = value;
         this.value = (double)value;
     }
+
+    /**
+     * Creates a legacy {@link NumericValue} for a {@code boolean}.
+     * @param boolval The boolean to set 1 or 0 for this {@link NumericValue}
+     * @deprecated Use {@link BooleanValue#of(boolean)} instead
+     */
+    @Deprecated
     public NumericValue(boolean boolval)
     {
         this(boolval?1L:0L);

--- a/src/main/java/carpet/script/value/ValueConversions.java
+++ b/src/main/java/carpet/script/value/ValueConversions.java
@@ -102,7 +102,7 @@ public class ValueConversions
     {
         return ListValue.of(
                 StringValue.of(criteria.getName()),
-                new NumericValue(criteria.isReadOnly())
+                BooleanValue.of(criteria.isReadOnly())
         );
     }
 
@@ -209,7 +209,7 @@ public class ValueConversions
                     new BlockValue(null, world, node.getPos()),
                     new StringValue(node.type.name().toLowerCase(Locale.ROOT)),
                     new NumericValue(node.penalty),
-                    new NumericValue(node.visited)
+                    BooleanValue.of(node.visited)
             ));
         }
         return ListValue.wrap(nodes);
@@ -243,7 +243,7 @@ public class ValueConversions
         }
         if (v instanceof Boolean)
         {
-            return new NumericValue((Boolean) v);
+            return BooleanValue.of((Boolean) v);
         }
         if (v instanceof UUID)
         {


### PR DESCRIPTION
Shouldn't change behaviour since `BooleanValue` extends `NumericValue`.

I'm currently in the process of finding whether other extensions are using the constructor in order to make it protected (for boolean and null constructors) instead of deprecated (couldn't those use the numeric constructor with `0`?).
Update: Used by Carpet TIS Addition