### PR TITLE
Allow static methods for Scarpet Functions

### DIFF
--- a/src/main/java/carpet/script/annotation/AnnotationParser.java
+++ b/src/main/java/carpet/script/annotation/AnnotationParser.java
@@ -84,9 +84,8 @@ public final class AnnotationParser
      * <p>There is a set of requirements for the class and its methods:</p>
      * <ul>
      * <li>Class must be concrete. That is, no interfaces or abstract classes should be passed</li>
-     * <li>Class must have the default constructor (or an equivalent) available. That is done in order to not need the {@code static} modifier in every method, making them faster to
-     * code and simpler to look at.</li>
-     * <li>Annotated methods must not be {@code static}. See claim above</li>
+     * <li>Class must have the default constructor (or an equivalent) available. That is done in order to not need the {@code static} modifier in every 
+     * method, making them faster to code and simpler to look at.</li>
      * <li>Annotated methods must not throw checked exceptions. They can throw regular {@link RuntimeException}s (including but not limited to 
      * {@link InternalExpressionException}).
      * Basically, it's fine as long as you don't add a {@code throws} declaration to your methods.</li>
@@ -121,9 +120,7 @@ public final class AnnotationParser
         {
             if (!method.isAnnotationPresent(ScarpetFunction.class))
                 continue;
-            // Checks
-            if (Modifier.isStatic(method.getModifiers()))
-                throw new IllegalArgumentException("Annotated method '" + method.getName() + "', provided in '" + clazz + "' must not be static");
+
             if (method.getExceptionTypes().length != 0)
                 throw new IllegalArgumentException("Annotated method '" + method.getName() +"', provided in '"+clazz+"' must not declare checked exceptions");
 
@@ -212,7 +209,8 @@ public final class AnnotationParser
             try
             {
                 MethodHandle tempHandle = MethodHandles.publicLookup().unreflect(method).asFixedArity().asSpreader(Object[].class, this.methodParamCount);
-                this.handle = tempHandle.asType(tempHandle.type().changeReturnType(Object.class)).bindTo(instance);
+                tempHandle = tempHandle.asType(tempHandle.type().changeReturnType(Object.class));
+                this.handle = Modifier.isStatic(method.getModifiers()) ? tempHandle : tempHandle.bindTo(instance);
             } catch (IllegalAccessException e)
             {
                 throw new IllegalArgumentException(e);

--- a/src/main/java/carpet/script/annotation/Param.java
+++ b/src/main/java/carpet/script/annotation/Param.java
@@ -133,42 +133,14 @@ public interface Param
     /**
      * <p>Class that holds the actual converters and converter getting logic for those annotated types and things.</p>
      * 
-     * <p>It also holds the registry for strict {@link ValueConverter}s.</p>
+     * <p>It also holds the registry for strict and custom {@link ValueConverter}s.</p>
      * 
      * @see #registerStrictConverter(Class, boolean, ValueConverter)
+     * @see #registerCustomConverterFactory(BiFunction)
      *
      */
     public static final class Params
     {
-        /**
-         * <p>A {@link ValueConverter} that outputs the given {@link LazyValue} when running {@link #checkAndConvert(Iterator, Context, Context.Type)}, and
-         * throws {@link UnsupportedOperationException} when trying to convert a {@link Value} directly.</p>
-         * 
-         * <p>Public in order to allow custom {@link ValueConverter} to check whether values should be evaluated while testing conditions.</p>
-         */
-        /*public static final ValueConverter<LazyValue> LAZY_VALUE_IDENTITY = new ValueConverter<LazyValue>()
-        { // No longer possible
-
-            @Override
-            public LazyValue convert(Value val)
-            {
-                throw new UnsupportedOperationException(
-                        "Called convert() with a Value in LazyValue identity, where only evalAndConvert is supported");
-            }
-
-            @Override
-            public LazyValue checkAndConvert(Iterator<Value> lazyValueIterator, Context c, Context.Type theLazyT)
-            {
-                return lazyValueIterator.hasNext() ? lazyValueIterator.next() : null;
-            }
-
-            @Override
-            public String getTypeName()
-            {
-                return "something";
-            }
-        };*/
-
         /**
          * <p>A {@link ValueConverter} that outputs the {@link Context} in which the function has been called, and throws {@link UnsupportedOperationException} when trying to convert a {@link Value}
          * directly.</p>
@@ -228,7 +200,7 @@ public interface Param
          * 
          * <p>Stored as {@code <Pair<Type, shallow?>, Converter>}</p>
          */
-        private static Map<Pair<Class<?>, Boolean>, ValueConverter<?>> strictParamsByClassAndShallowness = new HashMap<>();
+        private static final Map<Pair<Class<?>, Boolean>, ValueConverter<?>> strictParamsByClassAndShallowness = new HashMap<>();
         static
         { // TODO Specify strictness in name?
             registerStrictConverter(String.class, false, new SimpleTypeConverter<>(StringValue.class, StringValue::getString, "string"));
@@ -279,7 +251,7 @@ public interface Param
             strictParamsByClassAndShallowness.put(key, converter);
         }
 
-        private static List<BiFunction<AnnotatedType, Class<?>, ValueConverter<?>>> customFactories = new ArrayList<>();
+        private static final List<BiFunction<AnnotatedType, Class<?>, ValueConverter<?>>> customFactories = new ArrayList<>();
 
         /**
          * <p>Allows extensions to register <b>COMPLEX</b> {@link ValueConverter} factories in order to be used with the {@link Param.Custom}

--- a/src/main/java/carpet/script/annotation/ScarpetFunction.java
+++ b/src/main/java/carpet/script/annotation/ScarpetFunction.java
@@ -29,7 +29,7 @@ import carpet.script.value.Value;
  * {@link AnnotationParser#parseFunctionClass(Class)} ONCE. The provided {@link Class} must be concrete and provide the default constructor or an
  * equivalent to it.</p>
  * 
- * <p>Methods annotated with this annotation must not be static and must not declare throwing any checked exceptions.</p>
+ * <p>Methods annotated with this annotation must not declare throwing any checked exceptions.</p>
  * 
  * <p>If one of the method's parameters is {@link Context}, Carpet will pass the actual {@link Context} of the expression to the
  * method. If one of the method's parameters is {@link Context.Type}, Carpet will pass the Context Type the function was called inside. That


### PR DESCRIPTION
What was I thinking? Not sure.

Allows reusing the methods in there without needing a stupid instance. Still allows non-static methods.

```java
new ScarpetFunctions().do_something(); /* -> */ ScarpetFunctions.do_something();
```

Also makes minor changes to javadoc, makes two "registries" final, and removes the old, commented out `LazyValue` provider.