### PR TITLE
Implement `@Locator.Block`

### DIFF
--- a/src/main/java/carpet/script/annotation/Locator.java
+++ b/src/main/java/carpet/script/annotation/Locator.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 
 import org.apache.commons.lang3.NotImplementedException;
 
+import carpet.script.CarpetContext;
 import carpet.script.Context;
 import carpet.script.argument.Argument;
 import carpet.script.argument.BlockArgument;
@@ -25,8 +26,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * <p>Class that holds annotation for {@link Argument} locators to be used in Scarpet functions.</p>
  * 
- * <p>Note: Nothing in this class has been implemented at this point in time, since it requires Carpet changes. There is an implementation for
- * Locator.Block working, but not implemented.</p>
+ * <p>Note: Only {@link Block} locator is currently implemented.</p>
  */
 public interface Locator
 {
@@ -38,7 +38,6 @@ public interface Locator
     @Documented
     @Retention(RUNTIME)
     @Target({ PARAMETER, TYPE_USE })
-    @Deprecated // Not implemented, although implementation available
     public @interface Block
     {
         /**
@@ -166,10 +165,8 @@ public interface Locator
             @Override
             public R checkAndConvert(Iterator<Value> valueIterator, Context context, Context.Type theLazyT)
             {
-                BlockArgument locator = null; // BlockArgument.findIn((CarpetContext)context, valueIterator (requires changing to Value), 0,
-                                              // acceptString, optional, anyString);
-                // return (R) (returnBlockValue ? locator.block : locator);
-                throw new NotImplementedException("Locator.Block still requires adapting BlockArgument to accept iterators (which is actually simple)");
+                BlockArgument locator = BlockArgument.findIn((CarpetContext) context, valueIterator, 0, acceptString, optional, anyString);
+                return (R) (returnBlockValue ? locator.block : locator);
             }
         }
 

--- a/src/main/java/carpet/script/annotation/Locator.java
+++ b/src/main/java/carpet/script/annotation/Locator.java
@@ -18,6 +18,8 @@ import carpet.script.bundled.Module;
 import carpet.script.value.BlockValue;
 import carpet.script.value.FunctionValue;
 import carpet.script.value.Value;
+import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
 
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE_USE;
@@ -33,7 +35,7 @@ public interface Locator
     /**
      * <p>Represents that the annotated argument must be gotten by passing the arguments in there into a {@link BlockArgument} locator.</p>
      * 
-     * <p>Must be used in either {@link BlockValue} or {@link BlockArgument} parameters</p>
+     * <p>Must be used in either {@link BlockArgument}, {@link BlockValue} or {@link BlockPos} parameters</p>
      */
     @Documented
     @Retention(RUNTIME)
@@ -139,7 +141,7 @@ public interface Locator
 
         private static class BlockLocator<R> extends AbstractLocator<R>
         {
-            private final boolean returnBlockValue;
+            private final java.util.function.Function<BlockArgument, R> returnFunction;
             private final boolean acceptString;
             private final boolean anyString;
             private final boolean optional;
@@ -149,11 +151,24 @@ public interface Locator
                 this.acceptString = annotation.acceptString();
                 this.anyString = annotation.anyString();
                 this.optional = annotation.optional();
-                this.returnBlockValue = type == BlockValue.class;
-                if (returnBlockValue && (anyString || optional))
+                if (type != BlockArgument.class && (anyString || optional))
                     throw new IllegalArgumentException("Can only use anyString or optional parameters of Locator.Block if targeting a BlockArgument");
-                if (!returnBlockValue && type != BlockArgument.class)
-                    throw new IllegalArgumentException("Locator.Block can only be used against BlockArgument or BlockValue types!");
+                this.returnFunction = getReturnFunction(type);
+                if (returnFunction == null)
+                    throw new IllegalArgumentException("Locator.Block can only be used against BlockArgument, BlockValue, BlockPos or BlockState types!");
+            }
+
+            @SuppressWarnings("unchecked")
+            private static <R> java.util.function.Function<BlockArgument, R> getReturnFunction(Class<R> type) {
+                if (type == BlockArgument.class)
+                    return r -> (R) r;
+                if (type == BlockValue.class)
+                    return r -> (R) r.block;
+                if (type == BlockPos.class)
+                    return r -> (R) r.block.getPos();
+                if (type == BlockState.class)
+                    return r -> (R) r.block.getBlockState();
+                return null;
             }
 
             @Override
@@ -166,7 +181,7 @@ public interface Locator
             public R checkAndConvert(Iterator<Value> valueIterator, Context context, Context.Type theLazyT)
             {
                 BlockArgument locator = BlockArgument.findIn((CarpetContext) context, valueIterator, 0, acceptString, optional, anyString);
-                return (R) (returnBlockValue ? locator.block : locator);
+                return returnFunction.apply(locator);
             }
         }
 

--- a/src/main/java/carpet/script/annotation/Locator.java
+++ b/src/main/java/carpet/script/annotation/Locator.java
@@ -35,7 +35,7 @@ public interface Locator
     /**
      * <p>Represents that the annotated argument must be gotten by passing the arguments in there into a {@link BlockArgument} locator.</p>
      * 
-     * <p>Must be used in either {@link BlockArgument}, {@link BlockValue} or {@link BlockPos} parameters</p>
+     * <p>Must be used in either {@link BlockArgument}, {@link BlockValue}, {@link BlockPos} or {@link BlockState} parameters</p>
      */
     @Documented
     @Retention(RUNTIME)

--- a/src/main/java/carpet/script/argument/BlockArgument.java
+++ b/src/main/java/carpet/script/argument/BlockArgument.java
@@ -1,7 +1,6 @@
 package carpet.script.argument;
 
 import carpet.script.CarpetContext;
-import carpet.script.LazyValue;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.value.BlockValue;
 import carpet.script.value.ListValue;
@@ -11,7 +10,9 @@ import carpet.script.value.StringValue;
 import carpet.script.value.Value;
 import net.minecraft.util.math.BlockPos;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 public class BlockArgument extends Argument
 {
@@ -42,25 +43,30 @@ public class BlockArgument extends Argument
 
     public static BlockArgument findIn(CarpetContext c, List<Value> params, int offset, boolean acceptString, boolean optional, boolean anyString)
     {
+        return findIn(c, params.listIterator(offset), offset, acceptString, optional, anyString);
+    }
+
+    public static BlockArgument findIn(CarpetContext c, Iterator<Value> params, int offset, boolean acceptString, boolean optional, boolean anyString)
+    {
         try
         {
-            Value v1 = params.get(0 + offset);
+            Value v1 = params.next();
             //add conditional from string name
             if (optional && v1 instanceof NullValue)
             {
-                return new BlockArgument(null, 1+offset);
+                return new BlockArgument(null, 1 + offset);
             }
             if (anyString && v1 instanceof StringValue)
             {
-                return new BlockArgument(null, 1+offset, v1.getString());
+                return new BlockArgument(null, 1 + offset, v1.getString());
             }
             if (acceptString && v1 instanceof StringValue)
             {
-                return new BlockArgument(BlockValue.fromString(v1.getString()), 1+offset);
+                return new BlockArgument(BlockValue.fromString(v1.getString()), 1 + offset);
             }
             if (v1 instanceof BlockValue)
             {
-                return new BlockArgument(((BlockValue) v1), 1+offset);
+                return new BlockArgument(((BlockValue) v1), 1 + offset);
             }
             if (v1 instanceof ListValue)
             {
@@ -74,21 +80,21 @@ public class BlockArgument extends Argument
                                 c.s.getWorld(),
                                 new BlockPos(c.origin.getX() + xpos, c.origin.getY() + ypos, c.origin.getZ() + zpos)
                         ),
-                        1+offset);
+                        1 + offset);
             }
             int xpos = (int) NumericValue.asNumber(v1).getLong();
-            int ypos = (int) NumericValue.asNumber( params.get(1 + offset)).getLong();
-            int zpos = (int) NumericValue.asNumber( params.get(2 + offset)).getLong();
+            int ypos = (int) NumericValue.asNumber( params.next()).getLong();
+            int zpos = (int) NumericValue.asNumber( params.next()).getLong();
             return new BlockArgument(
                     new BlockValue(
                             null,
                             c.s.getWorld(),
                             new BlockPos(c.origin.getX() + xpos, c.origin.getY() + ypos, c.origin.getZ() + zpos)
                     ),
-                    3+offset
+                    3 + offset
             );
         }
-        catch (IndexOutOfBoundsException e)
+        catch (IndexOutOfBoundsException | NoSuchElementException e)
         {
             throw handleError(optional, acceptString);
         }


### PR DESCRIPTION
Does so by making the end function use an iterator, that for current functions comes from a `params.listIterator(offset)` call in order to keep current Scarpet functions working.

Small note: `BlockArgument.findInValues(...)` seems to do exactly the same as `findIn` (assuming it's from before the lazy refactor). I think it could be dropped. Edit: Nothing seems to call it.

About the other locators: I don't really know how to implement them (at least yet) since they require list length, which an iterator can't provide.