### PR TITLE
Implement `@Locator.Function` and `@Locator.Vec3d`

### DIFF
--- a/src/main/java/carpet/script/annotation/Locator.java
+++ b/src/main/java/carpet/script/annotation/Locator.java
@@ -8,6 +8,8 @@ import java.util.Iterator;
 
 import org.apache.commons.lang3.NotImplementedException;
 
+import com.google.common.collect.Lists;
+
 import carpet.script.CarpetContext;
 import carpet.script.Context;
 import carpet.script.argument.Argument;
@@ -64,9 +66,9 @@ public interface Locator
     /**
      * <p>Represents that the annotated argument must be gotten by passing the arguments in there into a {@link Vector3Argument} locator.</p>
      * 
-     * <p>Must be used in either a {@link Vector3Argument} or a {@link Vec3d} parameter, though the latest may not get all the data.</p>
+     * <p>Must be used in either a {@link Vector3Argument} or a {@link net.minecraft.util.math.Vec3d Vec3d} parameter.</p>
      * 
-     * <p>Note: This locator has not been implemented yet (TODO)</p>
+     * @deprecated This locator has not been implemented yet (TODO)
      */
     @Documented
     @Retention(RUNTIME)
@@ -95,14 +97,11 @@ public interface Locator
      * <p>Can be used in both {@link FunctionArgument} and {@link FunctionValue} types, but the last won't have access to arguments provided to the
      * function, even though they will still be consumed from the arguments the function was called with.</p>
      * 
-     * <p><b>This will consume any remaining parameters passed to the function, therefore any other parameters after this will throw.</b></p>
-     * 
-     * <p>Note: This locator has not been implemented yet (TODO)</p>
+     * <p><b>This will consume any remaining parameters passed to the function, therefore any other parameter after this will throw.</b></p>
      */
     @Documented
     @Retention(RUNTIME)
     @Target({ PARAMETER, TYPE_USE })
-    @Deprecated // Not implemented
     public @interface Function
     {
         /**
@@ -228,8 +227,7 @@ public interface Locator
             {
                 this.returnFunctionValue = type == FunctionValue.class;
                 if (!returnFunctionValue && type != FunctionArgument.class)
-                    throw new IllegalArgumentException(
-                            "Params annotated with Locator.Function must be of either FunctionArgument or FunctionValue type");
+                    throw new IllegalArgumentException("Params annotated with Locator.Function must be of either FunctionArgument or FunctionValue type");
                 this.allowNone = annotation.allowNone();
                 this.checkArgs = annotation.checkArgs();
                 if (returnFunctionValue && allowNone)
@@ -240,11 +238,10 @@ public interface Locator
             public R checkAndConvert(Iterator<Value> valueIterator, Context context, Context.Type theLazyT)
             {
                 Module module = context.host.main;
-                FunctionArgument locator = null;
-                // TODO Make the locator
-                // return (R) (returnFunctionValue ? locator.function : locator);
-                throw new NotImplementedException("Locator.FunctionValue still requires adapting the annotation system to somehow get lv size"
-                        + "or FunctionArgument to not depend on it!");
+                FunctionArgument locator = FunctionArgument.findIn(context, module, Lists.newArrayList(valueIterator), 0, allowNone, checkArgs);
+                @SuppressWarnings("unchecked")
+                R ret = (R) (returnFunctionValue ? locator.function : locator);
+                return ret;
             }
 
             @Override

--- a/src/main/java/carpet/script/annotation/Locator.java
+++ b/src/main/java/carpet/script/annotation/Locator.java
@@ -6,8 +6,6 @@ import java.lang.annotation.Target;
 import java.lang.reflect.AnnotatedType;
 import java.util.Iterator;
 
-import org.apache.commons.lang3.NotImplementedException;
-
 import com.google.common.collect.Lists;
 
 import carpet.script.CarpetContext;

--- a/src/main/java/carpet/script/annotation/Locator.java
+++ b/src/main/java/carpet/script/annotation/Locator.java
@@ -26,9 +26,7 @@ import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * <p>Class that holds annotation for {@link Argument} locators to be used in Scarpet functions.</p>
- * 
- * <p>Note: Only {@link Block} locator is currently implemented.</p>
+ * <p>Class that holds the annotations for {@link Argument} locators, in order for them to be used in Scarpet functions.</p>
  */
 public interface Locator
 {

--- a/src/main/java/carpet/script/annotation/Locator.java
+++ b/src/main/java/carpet/script/annotation/Locator.java
@@ -67,13 +67,10 @@ public interface Locator
      * <p>Represents that the annotated argument must be gotten by passing the arguments in there into a {@link Vector3Argument} locator.</p>
      * 
      * <p>Must be used in either a {@link Vector3Argument} or a {@link net.minecraft.util.math.Vec3d Vec3d} parameter.</p>
-     * 
-     * @deprecated This locator has not been implemented yet (TODO)
      */
     @Documented
     @Retention(RUNTIME)
     @Target({ PARAMETER, TYPE_USE })
-    @Deprecated // Not implemented
     public @interface Vec3d
     {
         /**
@@ -210,10 +207,10 @@ public interface Locator
             @Override
             public R checkAndConvert(Iterator<Value> valueIterator, Context context, Context.Type theLazyT)
             {
-                Vector3Argument locator = null;
-                // TODO Make the locator
-                // return (R) (returnVec3d ? locator.vec : locator);
-                throw new NotImplementedException("Locator.Vec3d still require adapting Vector3Argument to accept iterators!");
+                Vector3Argument locator = Vector3Argument.findIn(valueIterator, 0, optionalDirection, optionalEntity);
+                @SuppressWarnings("unchecked")
+                R ret = (R) (returnVec3d ? locator.vec : locator);
+                return ret;
             }
         }
 

--- a/src/main/java/carpet/script/argument/FunctionArgument.java
+++ b/src/main/java/carpet/script/argument/FunctionArgument.java
@@ -1,8 +1,6 @@
 package carpet.script.argument;
 
 import carpet.script.Context;
-import carpet.script.Fluff;
-import carpet.script.LazyValue;
 import carpet.script.ScriptHost;
 import carpet.script.bundled.Module;
 import carpet.script.command.CommandArgument;

--- a/src/main/java/carpet/script/argument/FunctionArgument.java
+++ b/src/main/java/carpet/script/argument/FunctionArgument.java
@@ -31,7 +31,7 @@ public class FunctionArgument extends Argument
     /**
      * @param c context
      * @param module module
-     * @param params list of lazy params
+     * @param params list of params
      * @param offset offset where to start looking for functional argument
      * @param allowNone none indicates no function present, otherwise it will croak
      * @param checkArgs whether the caller expects trailing parameters to fully resolve function argument list

--- a/src/main/java/carpet/script/argument/Vector3Argument.java
+++ b/src/main/java/carpet/script/argument/Vector3Argument.java
@@ -1,7 +1,5 @@
 package carpet.script.argument;
 
-import carpet.script.CarpetContext;
-import carpet.script.LazyValue;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.value.BlockValue;
 import carpet.script.value.EntityValue;
@@ -11,7 +9,9 @@ import carpet.script.value.Value;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.Vec3d;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 public class Vector3Argument extends Argument
 {
@@ -52,11 +52,15 @@ public class Vector3Argument extends Argument
         return findIn(params, offset, false, false);
     }
 
-    public static Vector3Argument findIn(List<Value> params, int offset, boolean optionalDirection, boolean optionalEntity)
+    public static Vector3Argument findIn(List<Value> params, int offset, boolean optionalDirection, boolean optionalEntity) {
+        return findIn(params.listIterator(offset), offset, optionalDirection, optionalEntity);
+    }
+
+    public static Vector3Argument findIn(Iterator<Value> params, int offset, boolean optionalDirection, boolean optionalEntity)
     {
         try
         {
-            Value v1 = params.get(0 + offset);
+            Value v1 = params.next();
             if (v1 instanceof BlockValue)
             {
                 return (new Vector3Argument(Vec3d.ofCenter(((BlockValue) v1).getPos()), 1+offset)).fromBlock();
@@ -84,21 +88,21 @@ public class Vector3Argument extends Argument
             }
             Vec3d pos = new Vec3d(
                     NumericValue.asNumber(v1).getDouble(),
-                    NumericValue.asNumber(params.get(1 + offset)).getDouble(),
-                    NumericValue.asNumber(params.get(2 + offset)).getDouble());
+                    NumericValue.asNumber(params.next()).getDouble(),
+                    NumericValue.asNumber(params.next()).getDouble());
             double yaw = 0.0D;
             double pitch = 0.0D;
             int eatenLength = 3;
-            if (params.size()>3+offset && optionalDirection)
+            if (params.hasNext() && optionalDirection)
             {
-                yaw = NumericValue.asNumber(params.get(3 + offset)).getDouble();
-                pitch = NumericValue.asNumber(params.get(4 + offset)).getDouble();
+                yaw = NumericValue.asNumber(params.next()).getDouble();
+                pitch = NumericValue.asNumber(params.next()).getDouble();
                 eatenLength = 5;
             }
 
-            return new Vector3Argument(pos,offset+eatenLength, yaw, pitch);
+            return new Vector3Argument(pos, offset+eatenLength, yaw, pitch);
         }
-        catch (IndexOutOfBoundsException e)
+        catch (IndexOutOfBoundsException | NoSuchElementException e)
         {
             throw new InternalExpressionException("Position argument should be defined either by three coordinates (a triple or by three arguments), or a positioned block value");
         }


### PR DESCRIPTION
### `@Locator.Function`
By basically consuming the whole iterator, since that's what the locator was going to do anyway.

Small thing: Isn't the `offset` value of LocatorArgument incorrect in case of varargs? It isn't really used anyway since everything is consumed and passed to the args, but just mentioning.

### `@Locator.Vec3d`
Easier than expected, just had to change the size check for an `iterator.hasNext()`, since it's in the exact position.