### PR TITLE
Add a crash report section for Scarpet apps

### DIFF
--- a/src/main/java/carpet/mixins/CrashReport_addScarpetAppsMixin.java
+++ b/src/main/java/carpet/mixins/CrashReport_addScarpetAppsMixin.java
@@ -1,0 +1,28 @@
+package carpet.mixins;
+
+import java.util.stream.Collectors;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import carpet.CarpetServer;
+import net.minecraft.util.crash.CrashReport;
+import net.minecraft.util.crash.CrashReportSection;
+
+@Mixin(CrashReport.class)
+public abstract class CrashReport_addScarpetAppsMixin
+{
+    @Shadow
+    public abstract CrashReportSection getSystemDetailsSection();
+    
+    @Inject(at = @At("RETURN"), method = "fillSystemDetails")
+    private void fillSystemDetails(CallbackInfo info) {
+        if (CarpetServer.scriptServer == null || CarpetServer.scriptServer.modules.isEmpty()) return;
+        getSystemDetailsSection().add("Loaded Scarpet Apps", () -> {
+            return CarpetServer.scriptServer.modules.keySet().stream().collect(Collectors.joining("\n\t\t", "\n\t\t", ""));
+        });
+    }
+}

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -184,6 +184,7 @@
     "ServerWorld_scarpetMixin",
     "HungerManagerMixin_scarpetEventsMixin",
     "ReloadCommand_reloadAppsMixin",
+    "CrashReport_addScarpetAppsMixin",
 
     "RecipeManager_scarpetMixin",
     "Ingredient_scarpetMixin",


### PR DESCRIPTION
At least until all those crashes caused by Scarpet apps are fixed.

Uses the same mixin as `fabric-crash-report-info-v1` in order to do so.

Only adds the section if the `scriptServer` is not null and if there are apps loaded.

<details>
<summary>Example crash (no FAPI, therefore no modlist)</summary>

```
...

-- System Details --
Details:
	Minecraft Version: 1.16.5
	Minecraft Version ID: 1.16.5
	Operating System: Windows 10 (amd64) version 10.0
	Java Version: 16.0.1, AdoptOpenJDK
	Java VM Version: OpenJDK 64-Bit Server VM (mixed mode, sharing), AdoptOpenJDK
	Memory: 311382680 bytes (296 MB) / 563085312 bytes (537 MB) up to 2116026368 bytes (2018 MB)
	CPUs: 8
	JVM Flags: 1 total; -XX:+ShowCodeDetailsInExceptionMessages
	Loaded Scarpet Apps: 
		world-edit
		cam
	Player Count: 0 / 20; []
	Data Packs: vanilla
	Is Modded: Definitely; Server brand changed to 'fabric'
	Type: Dedicated Server (map_server.txt)
```

</details>