### PR TITLE
Fix Value detection in ValueConverter selection 

### DIFF
--- a/src/main/java/carpet/script/annotation/ValueConverter.java
+++ b/src/main/java/carpet/script/annotation/ValueConverter.java
@@ -137,7 +137,7 @@ public interface ValueConverter<R>
         }
 
         // Class only checks
-        if (type.isAssignableFrom(Value.class))
+        if (Value.class.isAssignableFrom(type))
             return Objects.requireNonNull(ValueCaster.get(type), "Value subclass " + type + " is not registered. Register it in ValueCaster to use it");
         // if (type == LazyValue.class) // No longer supported
         //     return (ValueConverter<R>) Params.LAZY_VALUE_IDENTITY;


### PR DESCRIPTION
Oops, my bad.

Had only tested `Value` directly for that small branch of the code. Now it does work.

(NumericValue, etc wouldn't check in ValueCaster but fall below, throwing)