### PR TITLE
Re-implement `fastRedstoneDust` Optimization in 1.16.5+

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -251,7 +251,7 @@ public class CarpetSettings
     @Rule( desc = "Merges stationary primed TNT entities", category = TNT )
     public static boolean mergeTNT = false;
 
-    /*@Rule(
+    @Rule(
             desc = "Lag optimizations for redstone dust",
             extra = {
                     "by Theosib",
@@ -260,7 +260,7 @@ public class CarpetSettings
             },
             category = {EXPERIMENTAL, OPTIMIZATION}
     )
-    public static boolean fastRedstoneDust = false;*/
+    public static boolean fastRedstoneDust = false;
 
     @Rule(desc = "Only husks spawn in desert temples", category = FEATURE)
     public static boolean huskSpawningInTemples = false;


### PR DESCRIPTION
This PR re-introduces the `fastRedstoneDust` optimization in 1.16.5+ that seems to have been removed after the changes to redstone dust in snapshot 20w18a.

My assumption for the removal of this optimization was due to the changes of the vanilla redstone wire code. These changes did not seem as significant as they appeared to be as they consisted primarily of code reorganization. I reworked the `RedstoneWireBlockMixin` class around these changes so that it functions in the same way as the previous successful implementation while keeping the changes to a minimum.

Any feedback is greatly appreciated, and hopefully we can get this optimization back into the Carpet mod!