### PR TITLE
Made deepslate generate below y16

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -769,7 +769,8 @@ public class CarpetSettings
     public static boolean renewableBlackstone = false;
 
     @Rule(
-            desc = "Lava and water generate deepslate and cobbled deepslate instead below y16",
+            desc = "Lava and water generate deepslate and cobbled deepslate instead below Y16",
+            extra = "This rule may change Y value to 0 with 1.18",
             category = FEATURE
     )
     public static boolean renewableDeepslate = false;

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -769,7 +769,7 @@ public class CarpetSettings
     public static boolean renewableBlackstone = false;
 
     @Rule(
-            desc = "Lava and water generate deepslate and cobbled deepslate instead below y0",
+            desc = "Lava and water generate deepslate and cobbled deepslate instead below y16",
             category = FEATURE
     )
     public static boolean renewableDeepslate = false;

--- a/src/main/java/carpet/mixins/FluidBlock_renewableDeepslateMixin.java
+++ b/src/main/java/carpet/mixins/FluidBlock_renewableDeepslateMixin.java
@@ -19,8 +19,10 @@ public abstract class FluidBlock_renewableDeepslateMixin {
     @Shadow protected abstract void playExtinguishSound(WorldAccess world, BlockPos pos);
 
     @Inject(method = "receiveNeighborFluids", at = @At(value = "INVOKE",target = "Lnet/minecraft/fluid/FluidState;isStill()Z"), cancellable = true)
-    private void receiveFluidToDeepslate(World world, BlockPos pos, BlockState state, CallbackInfoReturnable<Boolean> cir) {
-        if(CarpetSettings.renewableDeepslate && !world.getFluidState(pos).isStill() && pos.getY() < 0 && world.getRegistryKey() == World.OVERWORLD ) {
+    private void receiveFluidToDeepslate(World world, BlockPos pos, BlockState state, CallbackInfoReturnable<Boolean> cir)
+    {
+        if(CarpetSettings.renewableDeepslate && !world.getFluidState(pos).isStill() && world.getRegistryKey() == World.OVERWORLD && pos.getY() < 16)
+        {
             world.setBlockState(pos, Blocks.COBBLED_DEEPSLATE.getDefaultState());
             this.playExtinguishSound(world, pos);
             cir.setReturnValue(false);

--- a/src/main/java/carpet/mixins/LavaFluid_renewableDeepslateMixin.java
+++ b/src/main/java/carpet/mixins/LavaFluid_renewableDeepslateMixin.java
@@ -20,8 +20,10 @@ public abstract class LavaFluid_renewableDeepslateMixin {
     @Shadow protected abstract void playExtinguishEvent(WorldAccess world, BlockPos pos);
 
     @Inject(method = "flow", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;getDefaultState()Lnet/minecraft/block/BlockState;"), cancellable = true)
-    private void generateDeepslate(WorldAccess world, BlockPos pos, BlockState state, Direction direction, FluidState fluidState, CallbackInfo ci) {
-        if(CarpetSettings.renewableDeepslate && pos.getY() < 0 && ((World)world).getRegistryKey() == World.OVERWORLD) {
+    private void generateDeepslate(WorldAccess world, BlockPos pos, BlockState state, Direction direction, FluidState fluidState, CallbackInfo ci)
+    {
+        if(CarpetSettings.renewableDeepslate && ((World)world).getRegistryKey() == World.OVERWORLD && pos.getY() < 16)
+        {
             world.setBlockState(pos, Blocks.DEEPSLATE.getDefaultState(), 3);
             this.playExtinguishEvent(world, pos);
             ci.cancel();


### PR DESCRIPTION
Instead of only generating below y0, deepslate generates below y16 (where deepslate blobs are found too)
This is to make renewable deepslate work in standard 1.17 worlds as well, without extended world height below y0