### PR TITLE
Change how resource `type` works, allow proper app and library installation

### DIFF
--- a/docs/scarpet/api/Overview.md
+++ b/docs/scarpet/api/Overview.md
@@ -104,7 +104,7 @@ predicate that is volatile and might change, the command might falsely do or do 
 however player will always be able to type it in and either succeed, or fail, based on their current permissions.
 Custom permission applies to legacy commands with `'legacy_command_type_support'` as well
 as for the custom commands defined with `'commands'`, see below.
-*  `'resources'` - list of all downloadable resources or dependencies when installing the app from an app store. List of resources needs to be 
+*  `'resources'` - list of all downloadable resources when installing the app from an app store. List of resources needs to be 
 in a list and contain of map-like resources descriptors, looking like
    ```
    'resources' -> [
@@ -118,23 +118,38 @@ in a list and contain of map-like resources descriptors, looking like
             'shared' -> true,
         },
         {
-            'source' -> 'carpets.sc',
-            'type' -> 'app',
-            'target' -> 'flying_carpets.sc',
+            'source' -> 'circle.sc', // Relative path
+            'target' -> 'apps/circle.sc', // This won't install the app, use 'libraries' for that
         },
     ]
    ```
    `source` indicates resource location: either an arbitrary url (starting with `http://` or `https://`), 
    absolute location of a file in the app store (starting with a slash `/`),
 or a relative location in the same folder as the app in question (the relative location directly). 
-`'target'` points to the path in app data, or shared app data folder
+`'target'` points to the path in app data, or shared app data folder. If not specified it will place the app into the main data folder with the name it has.
 if `'shared'` is specified and `true`. When re-downloading the app, all resources will be re-downloaded as well. 
-If `type` is specified as `app`, the `source` must point to a scarpet app or library, and the app will be downloaded and installed as well.
-If the app has relative resources dependencies, Carpet will use its own path in case the app was loaded from the same app store, or none if the 
+Currently, app resources are only downloaded when using `/carpet download` command.
+*   `libraries` - list of libraries or apps to be downloaded when installing the app from the app store. It needs to be a list of map-like resource
+descriptors, like the above `resources` field.
+   ```
+   'libraries' -> [
+        {
+            'source' -> '/tutorial/carpets.sc'
+        },
+        {
+            'source' -> '/fundamentals/heap.sc',
+            'target' -> 'heap-lib.sc'
+        }
+    ]
+   ```
+    `source` indicates resource location and must point to a scarpet app or library. It can be either an arbitrary url (starting with `http://` 
+    or `https://`), absolute location of a file in the app store (starting with a slash `/`), or a relative location in the same folder as the app
+    in question (the relative location directly). 
+    `target` is an optional field indicating the new name of the app. If not specified it will place the app into the main data folder with the name it has.
+If the app has relative resources dependencies, Carpet will use the app's path for relatives if the app was loaded from the same app store, or none if the 
 app was loaded from an external url.
 If you need to `import()` from dependencies indicated in this block, make sure to have the `__config()` map before any import that references your
-remote dependencies, in order to allow them to be downloaded.
-Currently, app resources are only downloaded when using `/carpet download` command.
+remote dependencies, in order to allow them to be downloaded and initialized before the import is executed.
 *   `'arguments'` - defines custom argument types for legacy commands with `'legacy_command_type_support'` as well
 as for the custom commands defined with `'commands'`, see below.
 *   `'commands'` - defines custom commands for the app to be executed with `/<app>` command, see below.

--- a/docs/scarpet/api/Overview.md
+++ b/docs/scarpet/api/Overview.md
@@ -104,7 +104,7 @@ predicate that is volatile and might change, the command might falsely do or do 
 however player will always be able to type it in and either succeed, or fail, based on their current permissions.
 Custom permission applies to legacy commands with `'legacy_command_type_support'` as well
 as for the custom commands defined with `'commands'`, see below.
-*  `'resources'` - list of all downloadable resources when installing the app from an app store. List of resources needs to be 
+*  `'resources'` - list of all downloadable resources or dependencies when installing the app from an app store. List of resources needs to be 
 in a list and contain of map-like resources descriptors, looking like
    ```
    'resources' -> [
@@ -120,7 +120,7 @@ in a list and contain of map-like resources descriptors, looking like
         {
             'source' -> 'carpets.sc',
             'type' -> 'app',
-            'target' -> 'apps/flying_carpets.sc',
+            'target' -> 'flying_carpets.sc',
         },
     ]
    ```
@@ -132,6 +132,8 @@ if `'shared'` is specified and `true`. When re-downloading the app, all resource
 If `type` is specified as `app`, the `source` must point to a scarpet app or library, and the app will be downloaded and installed as well.
 If the app has relative resources dependencies, Carpet will use its own path in case the app was loaded from the same app store, or none if the 
 app was loaded from an external url.
+If you need to `import()` from dependencies indicated in this block, make sure to have the `__config()` map before any import that references your
+remote dependencies, in order to allow them to be downloaded.
 Currently, app resources are only downloaded when using `/carpet download` command.
 *   `'arguments'` - defines custom argument types for legacy commands with `'legacy_command_type_support'` as well
 as for the custom commands defined with `'commands'`, see below.

--- a/docs/scarpet/api/Overview.md
+++ b/docs/scarpet/api/Overview.md
@@ -110,12 +110,10 @@ in a list and contain of map-like resources descriptors, looking like
    'resources' -> [
         {
             'source' -> 'https://raw.githubusercontent.com/gnembon/fabric-carpet/master/src/main/resources/assets/carpet/icon.png',
-            'type' -> 'url',
             'target' -> 'foo/photos.zip/foo/cm.png',
         },
         {
-            'source' -> 'survival/README.md',
-            'type' -> 'store',
+            'source' -> '/survival/README.md',
             'target' -> 'survival_readme.md',
             'shared' -> true,
         },
@@ -123,17 +121,18 @@ in a list and contain of map-like resources descriptors, looking like
             'source' -> 'carpets.sc',
             'type' -> 'app',
             'target' -> 'apps/flying_carpets.sc',
-            'shared' -> true,
         },
     ]
    ```
-   `source` and `type` indicate resource location: either an arbitrary url (type `'url'`), 
-   absolute location of a file in the app store (type `'store'`),
-or a relative location in the same folder as the app in question (type `'app'`). 
+   `source` indicates resource location: either an arbitrary url (starting with `http://` or `https://`), 
+   absolute location of a file in the app store (starting with a slash `/`),
+or a relative location in the same folder as the app in question (the relative location directly). 
 `'target'` points to the path in app data, or shared app data folder
 if `'shared'` is specified and `true`. When re-downloading the app, all resources will be re-downloaded as well. 
-Currently, app resources
-are only downloaded when using `/carpet download` command.
+If `type` is specified as `app`, the `source` must point to a scarpet app or library, and the app will be downloaded and installed as well.
+If the app has relative resources dependencies, Carpet will use its own path in case the app was loaded from the same app store, or none if the 
+app was loaded from an external url.
+Currently, app resources are only downloaded when using `/carpet download` command.
 *   `'arguments'` - defines custom argument types for legacy commands with `'legacy_command_type_support'` as well
 as for the custom commands defined with `'commands'`, see below.
 *   `'commands'` - defines custom commands for the app to be executed with `/<app>` command, see below.

--- a/docs/scarpet/language/FunctionsAndControlFlow.md
+++ b/docs/scarpet/language/FunctionsAndControlFlow.md
@@ -141,6 +141,10 @@ but if symbols are used directly in the module body rather than functions, it ma
 Returns full list of available symbols that could be imported from this module, which can be used to debug import 
 issues, and list contents of libraries.
 
+You can load and import functions from dependencies in a remote app store's source specified in your config's `libraries` block, but make sure
+to place your config _before_ the import in order to allow the remote dependency to be downloaded (currently, app resources are only downloaded
+when using the `/carpet download` command).
+
 ### `call(function, ? args ...)`
 
 calls a user defined function with specified arguments. It is equivalent to calling `function(args...)` directly 

--- a/src/main/java/carpet/commands/ScriptCommand.java
+++ b/src/main/java/carpet/commands/ScriptCommand.java
@@ -110,7 +110,7 @@ public class ScriptCommand
     }
 
     /**
-     * A method to suggest the available scarpet scripts based off of the current player input and {@link AppStoreManager#appStoreRoot}
+     * A method to suggest the available scarpet scripts based off of the current player input and {@link AppStoreManager#APP_STORE_ROOT}
      * variable.
      */
     private static CompletableFuture<Suggestions> suggestDownloadableApps(

--- a/src/main/java/carpet/script/CarpetScriptHost.java
+++ b/src/main/java/carpet/script/CarpetScriptHost.java
@@ -328,6 +328,15 @@ public class CarpetScriptHost extends ScriptHost
                         AppStoreManager.addResource(this, storeSource, resource);
                     }
                 }
+                Value libraries = config.get(new StringValue("libraries"));
+                if (libraries != null)
+                {
+                    if (!(libraries instanceof ListValue)) throw new InternalExpressionException("App libraries not defined as a list");
+                    for (Value library : ((ListValue) libraries).getItems())
+                    {
+                        AppStoreManager.addLibrary(this, storeSource, library);
+                    }
+                }
             }
             appConfig = config;
         }

--- a/src/main/java/carpet/script/CarpetScriptHost.java
+++ b/src/main/java/carpet/script/CarpetScriptHost.java
@@ -70,7 +70,7 @@ import static net.minecraft.server.command.CommandManager.literal;
 public class CarpetScriptHost extends ScriptHost
 {
     private final CarpetScriptServer scriptServer;
-    ServerCommandSource responsibleSource;
+    public ServerCommandSource responsibleSource;
 
     private Tag globalState;
     private int saveTimeout;

--- a/src/main/java/carpet/script/utils/AppStoreManager.java
+++ b/src/main/java/carpet/script/utils/AppStoreManager.java
@@ -296,6 +296,7 @@ public class AppStoreManager
             {
                 if (useTrash)
                 {
+                    Files.createDirectories(scriptLocation.getParent().resolve("trash"));
                     Path trashPath = scriptLocation.getParent().resolve("trash").resolve(path);
                     int i = 0;
                     while (Files.exists(trashPath))

--- a/src/main/java/carpet/script/utils/AppStoreManager.java
+++ b/src/main/java/carpet/script/utils/AppStoreManager.java
@@ -5,6 +5,7 @@ import carpet.script.CarpetScriptHost;
 import carpet.script.CarpetScriptServer;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.value.MapValue;
+import carpet.script.value.StringValue;
 import carpet.script.value.Value;
 import carpet.settings.ParsedRule;
 import carpet.settings.Validator;
@@ -370,7 +371,7 @@ public class AppStoreManager
         }
         catch (IOException e)
         {
-            return null; // Shouldn't ever happen, but let's not give an incorrect node just in case
+            return null; // Should never happen, but let's not give a potentially incorrect node just in case
         }
         return next;
     }
@@ -385,7 +386,7 @@ public class AppStoreManager
         String source = resourceMap.get("source").getString();
         String target = resourceMap.get("target").getString();
         boolean shared = resourceMap.getOrDefault("shared", Value.FALSE).getBoolean();
-        String type = resourceMap.get("type").getString();
+        String type = resourceMap.getOrDefault("type", StringValue.EMPTY).getString();
         String contentUrl;
         if (type.equalsIgnoreCase("store")) // deprecated, but necessary since it allows 'absolute' paths without starting slash
         {


### PR DESCRIPTION
Fixes #954.

This PR changes how the `type` argument is used for and allows properly loading apps and libraries when requested resource is of `app` type.

The `type` property is changed to instead of reflecting whether the path is relative, absolute or a full url with (IMO) misleading names, reflect whether you are requesting a regular file or another app/library. In order to determine the type of path, I added a new method (`getFullContentUrl`) that checks whether the path starts with `http(s)://` (then URL), starts with `/` (then absolute path) or none of the previous ones (relative path). In order to keep possible older apps working, `type -> store` is kept but deprecated to create absolute paths from otherwise relative ones. `type` is no longer mandatory.

The loading of apps and libraries checks two extra things that regular files don't: Urls must end with `.sc(l)` and their target must not contain any slash (trying to sandbox them a bit so they don't get elsewhere, tell me if you know a better way). Then a new `StoreNode` is calculated to use for that app in order to search for respective dependencies. It will either be none (app was from full url), or one calculated according to its location. The app will then be downloaded using the same method that gets the initial app.

Once/if this is merged, please merge the updated `resource_app.sc` in gnembon/scarpet#228 too.

~TODO~:

- [x] Check new library system works
- [x] Trash
- [x] Update docs