### PR TITLE
Filter script download suggestions according to player input

### DIFF
--- a/src/main/java/carpet/script/utils/AppStoreManager.java
+++ b/src/main/java/carpet/script/utils/AppStoreManager.java
@@ -215,10 +215,15 @@ public class AppStoreManager
         StoreNode appKiosk = appStoreRoot;
         for(String pathElement : path)
         {
-            if (appKiosk.cannotContinueFor(pathElement)) return appKiosk.createPathSuggestions();
+            if (appKiosk.cannotContinueFor(pathElement)) break;
             appKiosk = appKiosk.children.get(pathElement);
         }
-        return appKiosk.createPathSuggestions();
+        List<String> filteredSuggestions = appKiosk.createPathSuggestions().stream().filter(s -> s.startsWith(currentPath)).collect(Collectors.toList());
+        if (filteredSuggestions.size() == 1) {
+            if (!appKiosk.isLeaf())
+                return suggestionsFromPath(filteredSuggestions.get(0)); // Start suggesting directory contents
+        }
+        return filteredSuggestions;
     }
 
 


### PR DESCRIPTION
Fixes #957.

This PR makes the suggestion builder of the `/script download` command filter the suggestions according to the player's input. The reason it's a bit more complex than just stream & filter is to "open" and suggest directory contents when only a single folder is left after the filtering.