### PR TITLE
Add missing `remap = false` to mixins to fix build warnings

### DIFF
--- a/src/main/java/carpet/mixins/BiomeArray_cleanLogsMixin.java
+++ b/src/main/java/carpet/mixins/BiomeArray_cleanLogsMixin.java
@@ -12,7 +12,8 @@ public class BiomeArray_cleanLogsMixin
 {
     @Redirect(method = "<init>(Lnet/minecraft/util/collection/IndexedIterable;[I)V", at = @At(
             value = "INVOKE",
-            target = "Lorg/apache/logging/log4j/Logger;warn(Ljava/lang/String;)V")
+            target = "Lorg/apache/logging/log4j/Logger;warn(Ljava/lang/String;)V",
+            remap = false)
     )
     private void skipLog(Logger logger, String message)
     {

--- a/src/main/java/carpet/mixins/CommandManagerMixin.java
+++ b/src/main/java/carpet/mixins/CommandManagerMixin.java
@@ -45,7 +45,8 @@ public abstract class CommandManagerMixin
     @SuppressWarnings("UnresolvedMixinReference")
     @Redirect(method = "execute", at = @At(
                 value = "INVOKE",
-                target = "Lorg/apache/logging/log4j/Logger;isDebugEnabled()Z"
+                target = "Lorg/apache/logging/log4j/Logger;isDebugEnabled()Z",
+                remap = false
             ),
         require = 0
     )

--- a/src/main/java/carpet/mixins/ReloadCommand_reloadAppsMixin.java
+++ b/src/main/java/carpet/mixins/ReloadCommand_reloadAppsMixin.java
@@ -14,7 +14,7 @@ public class ReloadCommand_reloadAppsMixin {
     //method_13530(Lcom/mojang/brigadier/context/CommandContext;)I
     // internal of register.
     @SuppressWarnings("UnresolvedMixinReference")
-    @Inject(method = "method_13530", at = @At("TAIL"))
+    @Inject(method = "method_13530", at = @At("TAIL"), remap = false)
     private static void onReload(CommandContext<ServerCommandSource> context, CallbackInfoReturnable<Integer> cir)
     {
         // can't fetch here the reference to the server

--- a/src/main/java/carpet/mixins/ThreadedAnvilChunkStorage_scarpetChunkCreationMixin.java
+++ b/src/main/java/carpet/mixins/ThreadedAnvilChunkStorage_scarpetChunkCreationMixin.java
@@ -107,7 +107,7 @@ public abstract class ThreadedAnvilChunkStorage_scarpetChunkCreationMixin implem
         value = "INVOKE",
         target = "Lnet/minecraft/server/world/ThreadedAnvilChunkStorage;convertToFullChunk(Lnet/minecraft/server/world/ChunkHolder;)Ljava/util/concurrent/CompletableFuture;",
         shift = At.Shift.AFTER
-    ))
+    ), remap = false)
     private void onChunkGenerated(final ChunkHolder chunkHolder, final Chunk chunk, final CallbackInfoReturnable<CompletableFuture> cir)
     {
         if (CHUNK_GENERATED.isNeeded())


### PR DESCRIPTION
Removes build log warnings about unresolved references, since those don't actually have to be remapped for various reasons.

Still a draft because it has not yet been tested in production, there's at least one mixin I think may need an explicit `remap = true` inside the `@At`.

About the `UnresolvedMixinReference` SuppressWarnings... No idea. I haven't set up Mixin/whatever gives those in my IDE, so mine just shows unsupported SuppressWarnings for them at any moment.