### PR TITLE
Fix creativeFlyDrag and creativeFlySpeed not loading from config

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -820,6 +820,7 @@ public class CarpetSettings
                     "but this also means it will work on vanilla servers as well"
             },
             category = {CREATIVE, CLIENT},
+            strict = false,
             validate = Validator.NONNEGATIVE_NUMBER.class
     )
     public static double creativeFlySpeed = 1.0;
@@ -835,6 +836,7 @@ public class CarpetSettings
                     "but this also means it will work on vanilla servers as well"
             },
             category = {CREATIVE, CLIENT},
+            strict = false,
             validate = Validator.PROBABILITY.class
     )
     public static double creativeFlyDrag = 0.09;


### PR DESCRIPTION
Those were strict, and it seems like `double` strict rules can be set, but not loaded (they print invalid and skip them).

This fixes that bug, but the behaviour from config read and rule set should probably unified at some point.