### PR TITLE
Add web requests to scarpet

### DIFF
--- a/src/main/java/carpet/script/exception/Throwables.java
+++ b/src/main/java/carpet/script/exception/Throwables.java
@@ -28,6 +28,7 @@ public class Throwables {
     public static final Throwables NBT_ERROR             = register("nbt_error", IO_EXCEPTION);
     public static final Throwables JSON_ERROR            = register("json_error", IO_EXCEPTION);
     public static final Throwables B64_ERROR             = register("b64_error", IO_EXCEPTION);
+    public static final Throwables HTML_ERROR            = register("html_error", IO_EXCEPTION);//todo figure out exactly what kind of error it is
     public static final Throwables USER_DEFINED          = register("user_exception", THROWN_EXCEPTION_TYPE);
 
     /**


### PR DESCRIPTION
This will add HTTP API scarpet, so allow for access to the broader internet. As happens with most of my prs, it seems, I will end up making a very restricted initial template, which gnembon, altrisi or both will improve ten-thousand-fold (see the state of my in-built draw and distance _beta apps, /script download, scarpet command system... ).

Putting my personal internal resentments aside, here is a comprehensive list of things I wanna add with this pr:

- [ ] Ability to query URLs, and get at the very least a string response. Here, I want to make a handler event of some sort, to account for slower connections, so when you make the html request, you can set a function to trigger when you get the response.
- [ ] One or more throwable errors (the current one is temporary until I figure out exactly what needs to be thrown and how, I just needed a commit so I could make the pr)
- [ ] Make the `http_request` function (not committed yet) return a task value, as opposed to running a function when the response arrives.
- [ ] Allow to send additional information along with the request, i.e some form of metadata
- [ ] All the suggestions and improvements that altrisi and gnembon will undoubtedly make.