### PR TITLE
Use newer Java features in places where it makes sense and more

### DIFF
--- a/src/main/java/carpet/helpers/FeatureGenerator.java
+++ b/src/main/java/carpet/helpers/FeatureGenerator.java
@@ -2,7 +2,6 @@ package carpet.helpers;
 
 import carpet.CarpetSettings;
 import carpet.fakes.StructureFeatureInterface;
-import com.google.common.collect.ImmutableList;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.structure.StructureManager;
@@ -36,6 +35,7 @@ import net.minecraft.world.gen.feature.StructurePoolFeatureConfig;
 import net.minecraft.world.gen.feature.TreeFeatureConfig;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class FeatureGenerator
@@ -175,13 +175,13 @@ public class FeatureGenerator
     }
 
     public static final Map<String, Thing> featureMap = new HashMap<String, Thing>() {{
-        put("oak_bees", simpleTree(ConfiguredFeatures.OAK.getConfig().setTreeDecorators(ImmutableList.of(new BeehiveTreeDecorator(1.0F)))));
-        put("fancy_oak_bees", simpleTree(ConfiguredFeatures.FANCY_OAK.getConfig().setTreeDecorators(ImmutableList.of(new BeehiveTreeDecorator(1.0F)))));
-        put("birch_bees", simpleTree(ConfiguredFeatures.BIRCH.getConfig().setTreeDecorators(ImmutableList.of(new BeehiveTreeDecorator(1.0F)))));
+        put("oak_bees", simpleTree(ConfiguredFeatures.OAK.getConfig().setTreeDecorators(List.of(new BeehiveTreeDecorator(1.0F)))));
+        put("fancy_oak_bees", simpleTree(ConfiguredFeatures.FANCY_OAK.getConfig().setTreeDecorators(List.of(new BeehiveTreeDecorator(1.0F)))));
+        put("birch_bees", simpleTree(ConfiguredFeatures.BIRCH.getConfig().setTreeDecorators(List.of(new BeehiveTreeDecorator(1.0F)))));
         put("coral_tree", simplePlop(Feature.CORAL_TREE.configure(FeatureConfig.DEFAULT)));
         put("coral_claw", simplePlop(Feature.CORAL_CLAW.configure(FeatureConfig.DEFAULT)));
         put("coral_mushroom", simplePlop(Feature.CORAL_MUSHROOM.configure(FeatureConfig.DEFAULT)));
-        put("coral", simplePlop(Feature.SIMPLE_RANDOM_SELECTOR.configure(new SimpleRandomFeatureConfig(ImmutableList.of(
+        put("coral", simplePlop(Feature.SIMPLE_RANDOM_SELECTOR.configure(new SimpleRandomFeatureConfig(List.of(
                 () -> Feature.CORAL_TREE.configure(FeatureConfig.DEFAULT),
                 () -> Feature.CORAL_CLAW.configure(FeatureConfig.DEFAULT),
                 () -> Feature.CORAL_MUSHROOM.configure(FeatureConfig.DEFAULT)
@@ -191,7 +191,7 @@ public class FeatureGenerator
                 new StructurePoolFeatureConfig(() -> new StructurePool(
                         new Identifier("bastion/starts"),
                         new Identifier("empty"),
-                        ImmutableList.of(
+                        List.of(
                                 Pair.of(StructurePoolElement.ofProcessedSingle("bastion/units/air_base", StructureProcessorLists.BASTION_GENERIC_DEGRADATION), 1)
                         ),
                         StructurePool.Projection.RIGID
@@ -203,7 +203,7 @@ public class FeatureGenerator
                 new StructurePoolFeatureConfig(() -> new StructurePool(
                         new Identifier("bastion/starts"),
                         new Identifier("empty"),
-                        ImmutableList.of(
+                        List.of(
                                 Pair.of(StructurePoolElement.ofProcessedSingle("bastion/hoglin_stable/air_base", StructureProcessorLists.BASTION_GENERIC_DEGRADATION), 1)
                         ),
                         StructurePool.Projection.RIGID
@@ -215,7 +215,7 @@ public class FeatureGenerator
                 new StructurePoolFeatureConfig(() -> new StructurePool(
                         new Identifier("bastion/starts"),
                         new Identifier("empty"),
-                        ImmutableList.of(
+                        List.of(
                                 Pair.of(StructurePoolElement.ofProcessedSingle("bastion/treasure/big_air_full", StructureProcessorLists.BASTION_GENERIC_DEGRADATION), 1)
                         ),
                         StructurePool.Projection.RIGID
@@ -227,7 +227,7 @@ public class FeatureGenerator
                 new StructurePoolFeatureConfig(() -> new StructurePool(
                         new Identifier("bastion/starts"),
                         new Identifier("empty"),
-                        ImmutableList.of(
+                        List.of(
                                 Pair.of(StructurePoolElement.ofProcessedSingle("bastion/bridge/starting_pieces/entrance_base", StructureProcessorLists.BASTION_GENERIC_DEGRADATION), 1)
                         ),
                         StructurePool.Projection.RIGID

--- a/src/main/java/carpet/helpers/HopperCounter.java
+++ b/src/main/java/carpet/helpers/HopperCounter.java
@@ -5,8 +5,6 @@ import carpet.fakes.IngredientInterface;
 import carpet.fakes.RecipeManagerInterface;
 import carpet.utils.WoolTool;
 import carpet.utils.Messenger;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import it.unimi.dsi.fastutil.objects.Object2LongLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import net.minecraft.block.AbstractBannerBlock;
@@ -42,6 +40,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static java.util.Map.entry;
+
 /**
  * The actual object residing in each hopper counter which makes them count the items and saves them. There is one for each
  * colour in MC.
@@ -67,7 +67,7 @@ public class HopperCounter
         {
             counterMap.put(color, new HopperCounter(color));
         }
-        COUNTERS = Maps.immutableEnumMap(counterMap);
+        COUNTERS = Collections.unmodifiableMap(counterMap);
     }
 
     /**
@@ -243,92 +243,91 @@ public class HopperCounter
      * Maps items that don't get a good block to reference for colour, or those that colour is wrong to a number of blocks, so we can get their colours easily with the
      * {@link Block#getDefaultMaterialColor()} method as these items have those same colours.
      */
-    private static final ImmutableMap<Item, Block> DEFAULTS = new ImmutableMap.Builder<Item, Block>()
-            .put(Items.DANDELION, Blocks.YELLOW_WOOL)
-            .put(Items.POPPY, Blocks.RED_WOOL)
-            .put(Items.BLUE_ORCHID, Blocks.LIGHT_BLUE_WOOL)
-            .put(Items.ALLIUM, Blocks.MAGENTA_WOOL)
-            .put(Items.AZURE_BLUET, Blocks.SNOW_BLOCK)
-            .put(Items.RED_TULIP, Blocks.RED_WOOL)
-            .put(Items.ORANGE_TULIP, Blocks.ORANGE_WOOL)
-            .put(Items.WHITE_TULIP, Blocks.SNOW_BLOCK)
-            .put(Items.PINK_TULIP, Blocks.PINK_WOOL)
-            .put(Items.OXEYE_DAISY, Blocks.SNOW_BLOCK)
-            .put(Items.CORNFLOWER, Blocks.BLUE_WOOL)
-            .put(Items.WITHER_ROSE, Blocks.BLACK_WOOL)
-            .put(Items.LILY_OF_THE_VALLEY, Blocks.WHITE_WOOL)
-            .put(Items.BROWN_MUSHROOM, Blocks.BROWN_MUSHROOM_BLOCK)
-            .put(Items.RED_MUSHROOM, Blocks.RED_MUSHROOM_BLOCK)
-            .put(Items.STICK, Blocks.OAK_PLANKS)
-            .put(Items.GOLD_INGOT, Blocks.GOLD_BLOCK)
-            .put(Items.IRON_INGOT, Blocks.IRON_BLOCK)
-            .put(Items.DIAMOND, Blocks.DIAMOND_BLOCK)
-            .put(Items.NETHERITE_INGOT, Blocks.NETHERITE_BLOCK)
-            .put(Items.SUNFLOWER, Blocks.YELLOW_WOOL)
-            .put(Items.LILAC, Blocks.MAGENTA_WOOL)
-            .put(Items.ROSE_BUSH, Blocks.RED_WOOL)
-            .put(Items.PEONY, Blocks.PINK_WOOL)
-            .put(Items.CARROT, Blocks.ORANGE_WOOL)
-            .put(Items.APPLE,Blocks.RED_WOOL)
-            .put(Items.WHEAT,Blocks.HAY_BLOCK)
-            .put(Items.PORKCHOP, Blocks.PINK_WOOL)
-            .put(Items.RABBIT,Blocks.PINK_WOOL)
-            .put(Items.CHICKEN,Blocks.WHITE_TERRACOTTA)
-            .put(Items.BEEF,Blocks.NETHERRACK)
-            .put(Items.ENCHANTED_GOLDEN_APPLE,Blocks.GOLD_BLOCK)
-            .put(Items.COD,Blocks.WHITE_TERRACOTTA)
-            .put(Items.SALMON,Blocks.ACACIA_PLANKS)
-            .put(Items.ROTTEN_FLESH,Blocks.BROWN_WOOL)
-            .put(Items.PUFFERFISH,Blocks.YELLOW_TERRACOTTA)
-            .put(Items.TROPICAL_FISH,Blocks.ORANGE_WOOL)
-            .put(Items.POTATO,Blocks.WHITE_TERRACOTTA)
-            .put(Items.MUTTON, Blocks.RED_WOOL)
-            .put(Items.BEETROOT,Blocks.NETHERRACK)
-            .put(Items.MELON_SLICE,Blocks.MELON)
-            .put(Items.POISONOUS_POTATO,Blocks.SLIME_BLOCK)
-            .put(Items.SPIDER_EYE,Blocks.NETHERRACK)
-            .put(Items.GUNPOWDER,Blocks.GRAY_WOOL)
-            .put(Items.SCUTE,Blocks.LIME_WOOL)
-            .put(Items.FEATHER,Blocks.WHITE_WOOL)
-            .put(Items.FLINT,Blocks.BLACK_WOOL)
-            .put(Items.LEATHER,Blocks.SPRUCE_PLANKS)
-            .put(Items.GLOWSTONE_DUST,Blocks.GLOWSTONE)
-            .put(Items.PAPER,Blocks.WHITE_WOOL)
-            .put(Items.BRICK,Blocks.BRICKS)
-            .put(Items.INK_SAC,Blocks.BLACK_WOOL)
-            .put(Items.SNOWBALL,Blocks.SNOW_BLOCK)
-            .put(Items.WATER_BUCKET,Blocks.WATER)
-            .put(Items.LAVA_BUCKET,Blocks.LAVA)
-            .put(Items.MILK_BUCKET,Blocks.WHITE_WOOL)
-            .put(Items.CLAY_BALL, Blocks.CLAY)
-            .put(Items.COCOA_BEANS,Blocks.COCOA)
-            .put(Items.BONE,Blocks.BONE_BLOCK)
-            .put(Items.COD_BUCKET,Blocks.BROWN_TERRACOTTA)
-            .put(Items.PUFFERFISH_BUCKET,Blocks.YELLOW_TERRACOTTA)
-            .put(Items.SALMON_BUCKET,Blocks.PINK_TERRACOTTA)
-            .put(Items.TROPICAL_FISH_BUCKET,Blocks.ORANGE_TERRACOTTA)
-            .put(Items.SUGAR,Blocks.WHITE_WOOL)
-            .put(Items.BLAZE_POWDER,Blocks.GOLD_BLOCK)
-            .put(Items.ENDER_PEARL,Blocks.WARPED_PLANKS)
-            .put(Items.NETHER_STAR,Blocks.DIAMOND_BLOCK)
-            .put(Items.PRISMARINE_CRYSTALS,Blocks.SEA_LANTERN)
-            .put(Items.PRISMARINE_SHARD,Blocks.PRISMARINE)
-            .put(Items.RABBIT_HIDE,Blocks.OAK_PLANKS)
-            .put(Items.CHORUS_FRUIT,Blocks.PURPUR_BLOCK)
-            .put(Items.SHULKER_SHELL,Blocks.SHULKER_BOX)
-            .put(Items.NAUTILUS_SHELL,Blocks.BONE_BLOCK)
-            .put(Items.HEART_OF_THE_SEA,Blocks.CONDUIT)
-            .put(Items.HONEYCOMB,Blocks.HONEYCOMB_BLOCK)
-            .put(Items.NAME_TAG,Blocks.BONE_BLOCK)
-            .put(Items.TOTEM_OF_UNDYING,Blocks.YELLOW_TERRACOTTA)
-            .put(Items.TRIDENT,Blocks.PRISMARINE)
-            .put(Items.GHAST_TEAR,Blocks.WHITE_WOOL)
-            .put(Items.PHANTOM_MEMBRANE,Blocks.BONE_BLOCK)
-            .put(Items.EGG,Blocks.BONE_BLOCK)
-            //.put(Items.,Blocks.)
-            .put(Items.COPPER_INGOT,Blocks.COPPER_BLOCK)
-            .put(Items.AMETHYST_SHARD, Blocks.AMETHYST_BLOCK)
-            .build();
+    private static final Map<Item, Block> DEFAULTS = Map.ofEntries(
+            entry(Items.DANDELION, Blocks.YELLOW_WOOL),
+            entry(Items.POPPY, Blocks.RED_WOOL),
+            entry(Items.BLUE_ORCHID, Blocks.LIGHT_BLUE_WOOL),
+            entry(Items.ALLIUM, Blocks.MAGENTA_WOOL),
+            entry(Items.AZURE_BLUET, Blocks.SNOW_BLOCK),
+            entry(Items.RED_TULIP, Blocks.RED_WOOL),
+            entry(Items.ORANGE_TULIP, Blocks.ORANGE_WOOL),
+            entry(Items.WHITE_TULIP, Blocks.SNOW_BLOCK),
+            entry(Items.PINK_TULIP, Blocks.PINK_WOOL),
+            entry(Items.OXEYE_DAISY, Blocks.SNOW_BLOCK),
+            entry(Items.CORNFLOWER, Blocks.BLUE_WOOL),
+            entry(Items.WITHER_ROSE, Blocks.BLACK_WOOL),
+            entry(Items.LILY_OF_THE_VALLEY, Blocks.WHITE_WOOL),
+            entry(Items.BROWN_MUSHROOM, Blocks.BROWN_MUSHROOM_BLOCK),
+            entry(Items.RED_MUSHROOM, Blocks.RED_MUSHROOM_BLOCK),
+            entry(Items.STICK, Blocks.OAK_PLANKS),
+            entry(Items.GOLD_INGOT, Blocks.GOLD_BLOCK),
+            entry(Items.IRON_INGOT, Blocks.IRON_BLOCK),
+            entry(Items.DIAMOND, Blocks.DIAMOND_BLOCK),
+            entry(Items.NETHERITE_INGOT, Blocks.NETHERITE_BLOCK),
+            entry(Items.SUNFLOWER, Blocks.YELLOW_WOOL),
+            entry(Items.LILAC, Blocks.MAGENTA_WOOL),
+            entry(Items.ROSE_BUSH, Blocks.RED_WOOL),
+            entry(Items.PEONY, Blocks.PINK_WOOL),
+            entry(Items.CARROT, Blocks.ORANGE_WOOL),
+            entry(Items.APPLE,Blocks.RED_WOOL),
+            entry(Items.WHEAT,Blocks.HAY_BLOCK),
+            entry(Items.PORKCHOP, Blocks.PINK_WOOL),
+            entry(Items.RABBIT,Blocks.PINK_WOOL),
+            entry(Items.CHICKEN,Blocks.WHITE_TERRACOTTA),
+            entry(Items.BEEF,Blocks.NETHERRACK),
+            entry(Items.ENCHANTED_GOLDEN_APPLE,Blocks.GOLD_BLOCK),
+            entry(Items.COD,Blocks.WHITE_TERRACOTTA),
+            entry(Items.SALMON,Blocks.ACACIA_PLANKS),
+            entry(Items.ROTTEN_FLESH,Blocks.BROWN_WOOL),
+            entry(Items.PUFFERFISH,Blocks.YELLOW_TERRACOTTA),
+            entry(Items.TROPICAL_FISH,Blocks.ORANGE_WOOL),
+            entry(Items.POTATO,Blocks.WHITE_TERRACOTTA),
+            entry(Items.MUTTON, Blocks.RED_WOOL),
+            entry(Items.BEETROOT,Blocks.NETHERRACK),
+            entry(Items.MELON_SLICE,Blocks.MELON),
+            entry(Items.POISONOUS_POTATO,Blocks.SLIME_BLOCK),
+            entry(Items.SPIDER_EYE,Blocks.NETHERRACK),
+            entry(Items.GUNPOWDER,Blocks.GRAY_WOOL),
+            entry(Items.SCUTE,Blocks.LIME_WOOL),
+            entry(Items.FEATHER,Blocks.WHITE_WOOL),
+            entry(Items.FLINT,Blocks.BLACK_WOOL),
+            entry(Items.LEATHER,Blocks.SPRUCE_PLANKS),
+            entry(Items.GLOWSTONE_DUST,Blocks.GLOWSTONE),
+            entry(Items.PAPER,Blocks.WHITE_WOOL),
+            entry(Items.BRICK,Blocks.BRICKS),
+            entry(Items.INK_SAC,Blocks.BLACK_WOOL),
+            entry(Items.SNOWBALL,Blocks.SNOW_BLOCK),
+            entry(Items.WATER_BUCKET,Blocks.WATER),
+            entry(Items.LAVA_BUCKET,Blocks.LAVA),
+            entry(Items.MILK_BUCKET,Blocks.WHITE_WOOL),
+            entry(Items.CLAY_BALL, Blocks.CLAY),
+            entry(Items.COCOA_BEANS,Blocks.COCOA),
+            entry(Items.BONE,Blocks.BONE_BLOCK),
+            entry(Items.COD_BUCKET,Blocks.BROWN_TERRACOTTA),
+            entry(Items.PUFFERFISH_BUCKET,Blocks.YELLOW_TERRACOTTA),
+            entry(Items.SALMON_BUCKET,Blocks.PINK_TERRACOTTA),
+            entry(Items.TROPICAL_FISH_BUCKET,Blocks.ORANGE_TERRACOTTA),
+            entry(Items.SUGAR,Blocks.WHITE_WOOL),
+            entry(Items.BLAZE_POWDER,Blocks.GOLD_BLOCK),
+            entry(Items.ENDER_PEARL,Blocks.WARPED_PLANKS),
+            entry(Items.NETHER_STAR,Blocks.DIAMOND_BLOCK),
+            entry(Items.PRISMARINE_CRYSTALS,Blocks.SEA_LANTERN),
+            entry(Items.PRISMARINE_SHARD,Blocks.PRISMARINE),
+            entry(Items.RABBIT_HIDE,Blocks.OAK_PLANKS),
+            entry(Items.CHORUS_FRUIT,Blocks.PURPUR_BLOCK),
+            entry(Items.SHULKER_SHELL,Blocks.SHULKER_BOX),
+            entry(Items.NAUTILUS_SHELL,Blocks.BONE_BLOCK),
+            entry(Items.HEART_OF_THE_SEA,Blocks.CONDUIT),
+            entry(Items.HONEYCOMB,Blocks.HONEYCOMB_BLOCK),
+            entry(Items.NAME_TAG,Blocks.BONE_BLOCK),
+            entry(Items.TOTEM_OF_UNDYING,Blocks.YELLOW_TERRACOTTA),
+            entry(Items.TRIDENT,Blocks.PRISMARINE),
+            entry(Items.GHAST_TEAR,Blocks.WHITE_WOOL),
+            entry(Items.PHANTOM_MEMBRANE,Blocks.BONE_BLOCK),
+            entry(Items.EGG,Blocks.BONE_BLOCK),
+            //entry(Items.,Blocks.),
+            entry(Items.COPPER_INGOT,Blocks.COPPER_BLOCK),
+            entry(Items.AMETHYST_SHARD, Blocks.AMETHYST_BLOCK));
 
     /**
      * Gets the colour to print an item in when printing its count in a hopper counter.

--- a/src/main/java/carpet/logging/logHelpers/ExplosionLogHelper.java
+++ b/src/main/java/carpet/logging/logHelpers/ExplosionLogHelper.java
@@ -92,34 +92,11 @@ public class ExplosionLogHelper
     }
 
 
-    public static class EntityChangedStatusWithCount
+    public static record EntityChangedStatusWithCount(Vec3d pos, EntityType type, Vec3d accel)
     {
-        public final Vec3d pos;
-        public final EntityType type;
-        public final Vec3d accel;
-
         public EntityChangedStatusWithCount(Entity e, Vec3d accel)
         {
-            this.pos = e.getPos();
-            this.type = e.getType();
-            this.accel = accel;
-        }
-
-        @Override
-        public boolean equals(Object obj)
-        {
-            if (obj instanceof EntityChangedStatusWithCount)
-            {
-                EntityChangedStatusWithCount other = (EntityChangedStatusWithCount) obj;
-                return other.pos.equals(pos) && other.accel.equals(accel) && other.type.equals(type);
-            }
-            return super.equals(obj);
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return pos.hashCode()+ type.hashCode()+accel.hashCode();
+            this(e.getPos(), e.getType(), accel);
         }
     }
 }

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -135,18 +135,8 @@ public class CarpetEventServer
         {
             return function.getString()+((host==null)?"":"(from "+host+(optionalTarget == null?"":"/"+optionalTarget)+")");
         }
-        public static class Signature
-        {
-            String function;
-            String host;
-            String target;
-            public Signature(String fun, String h, String t)
-            {
-                function = fun;
-                host = h;
-                target = t;
-            }
-        }
+        public static record Signature(String function, String host, String target) {}
+        
         public static Signature fromString(String str)
         {
             Pattern find = Pattern.compile("(\\w+)(?:\\(from (\\w+)(?:/(\\w+))?\\))?");

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -94,7 +94,7 @@ public class CarpetScriptServer
      * @param app The {@link BundledModule} of the app.
      */
     public static void registerSettingsApp(BundledModule app) {
-    	ruleModuleData.add(app);
+        ruleModuleData.add(app);
     }
 
     static
@@ -493,16 +493,11 @@ public class CarpetScriptServer
         });
     }
 
-    static class TransferData
+    private static record TransferData(boolean perUser, Predicate<ServerCommandSource> commandValidator, boolean isRuleApp)
     {
-        boolean perUser;
-        Predicate<ServerCommandSource> commandValidator;
-        boolean isRuleApp;
         private TransferData(CarpetScriptHost host)
         {
-            perUser = host.perUser;
-            commandValidator = host.commandValidator;
-            isRuleApp = host.isRuleApp;
+            this(host.perUser, host.commandValidator, host.isRuleApp);
         }
     }
 

--- a/src/main/java/carpet/script/Expression.java
+++ b/src/main/java/carpet/script/Expression.java
@@ -33,8 +33,6 @@ import carpet.script.value.FunctionValue;
 import carpet.script.value.NumericValue;
 import carpet.script.value.StringValue;
 import carpet.script.value.Value;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 
 import java.math.BigInteger;
@@ -98,7 +96,7 @@ public class Expression
         functionalEquivalence.put(operator, function);
     }
 
-    private final Map<String, Value> constants = ImmutableMap.of(
+    private final Map<String, Value> constants = Map.of(
             "euler", Arithmetic.euler,
             "pi", Arithmetic.PI,
             "null", Value.NULL,
@@ -972,7 +970,7 @@ public class Expression
                     final ExpressionNode v1 = nodeStack.pop();
                     final ExpressionNode v2 = nodeStack.pop();
                     LazyValue result = (c,t) -> operators.get(token.surface).lazyEval(c, t,this, token, v2.op, v1.op).evalValue(c, t);
-                    nodeStack.push(new ExpressionNode(result, ImmutableList.of(v2, v1), token ));
+                    nodeStack.push(new ExpressionNode(result, List.of(v2, v1), token ));
                     break;
                 case VARIABLE:
                     Value constant = getConstantFor(token.surface);

--- a/src/main/java/carpet/script/Fluff.java
+++ b/src/main/java/carpet/script/Fluff.java
@@ -101,10 +101,12 @@ public abstract class Fluff
             return name;
         }
 
+        @Override
         public int getNumParams() {
             return numParams;
         }
 
+        @Override
         public boolean numParamsVaries() {
             return numParams < 0;
         }
@@ -162,6 +164,7 @@ public abstract class Fluff
             return new LazyValue()
             { // eager evaluation always ignores the required type and evals params by none default
                 private List<Value> params;
+                @Override
                 public Value evalValue(Context c, Context.Type type)
                 {
                     ILazyFunction.checkInterrupts();
@@ -202,10 +205,12 @@ public abstract class Fluff
             this.leftAssoc = leftAssoc;
         }
 
+        @Override
         public int getPrecedence() {
             return precedence;
         }
 
+        @Override
         public boolean isLeftAssoc() {
             return leftAssoc;
         }

--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -38,8 +38,6 @@ import carpet.script.value.StringValue;
 import carpet.script.value.Value;
 import carpet.script.value.ValueConversions;
 import carpet.utils.Messenger;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import net.minecraft.SharedConstants;
 import net.minecraft.block.BlockState;
@@ -104,7 +102,6 @@ import net.minecraft.world.gen.chunk.ChunkGenerator;
 import net.minecraft.world.level.UnmodifiableLevelProperties;
 import net.minecraft.world.level.storage.LevelStorage;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.tuple.Pair;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -334,7 +331,7 @@ public class Auxiliary {
             ServerWorld world = cc.s.getWorld();
             MinecraftServer server = world.getServer();
             Set<ServerPlayerEntity> playerTargets = new HashSet<>();
-            List<Pair<ShapeDispatcher.ExpiringShape, Map<String,Value>>> shapes = new ArrayList<>();
+            List<ShapeDispatcher.ShapeWithConfig> shapes = new ArrayList<>();
             if (lv.size() == 1) // bulk
             {
                 Value specLoad = lv.get(0);
@@ -1062,10 +1059,10 @@ public class Auxiliary {
             {
                 try {
                     //Files.createDirectory(packFloder);
-                    try (FileSystem zipfs = FileSystems.newFileSystem(URI.create("jar:" + packFloder.toUri().toString()), ImmutableMap.of("create", "true"))) {
+                    try (FileSystem zipfs = FileSystems.newFileSystem(URI.create("jar:" + packFloder.toUri().toString()), Map.of("create", "true"))) {
                         Path zipRoot = zipfs.getPath("/");
                         zipValueToJson(zipRoot.resolve("pack.mcmeta"), MapValue.wrap(
-                                ImmutableMap.of(StringValue.of("pack"), MapValue.wrap(ImmutableMap.of(
+                                Map.of(StringValue.of("pack"), MapValue.wrap(Map.of(
                                         StringValue.of("pack_format"), new NumericValue(SharedConstants.getGameVersion().getPackVersion()),
                                         StringValue.of("description"), StringValue.of(name),
                                         StringValue.of("source"), StringValue.of("scarpet")
@@ -1144,7 +1141,7 @@ public class Auxiliary {
                     DimensionType dimensionType3 = entry.getValue().getDimensionType();
                     ChunkGenerator chunkGenerator3 = entry.getValue().getChunkGenerator();
                     UnmodifiableLevelProperties unmodifiableLevelProperties = new UnmodifiableLevelProperties(saveProperties, ((ServerWorldInterface) server.getOverworld()).getWorldPropertiesCM());
-                    ServerWorld serverWorld2 = new ServerWorld(server, Util.getMainWorkerExecutor(), session, unmodifiableLevelProperties, registryKey2, dimensionType3, WorldTools.NOOP_LISTENER, chunkGenerator3, bl, m, ImmutableList.of(), false);
+                    ServerWorld serverWorld2 = new ServerWorld(server, Util.getMainWorkerExecutor(), session, unmodifiableLevelProperties, registryKey2, dimensionType3, WorldTools.NOOP_LISTENER, chunkGenerator3, bl, m, List.of(), false);
                     server.getOverworld().getWorldBorder().addListener(new WorldBorderListener.WorldBorderSyncer(serverWorld2.getWorldBorder()));
                     existing_worlds.put(registryKey2, serverWorld2);
                 }

--- a/src/main/java/carpet/script/api/Inventories.java
+++ b/src/main/java/carpet/script/api/Inventories.java
@@ -181,7 +181,7 @@ public class Inventories {
             CarpetContext cc = (CarpetContext) c;
             NBTSerializableValue.InventoryLocator inventoryLocator = NBTSerializableValue.locateInventory(cc, lv, 0);
             if (inventoryLocator == null) return Value.NULL;
-            return new NumericValue(inventoryLocator.inventory.size());
+            return new NumericValue(inventoryLocator.inventory().size());
         });
 
         expression.addContextFunction("inventory_has_items", -1, (c, t, lv) ->
@@ -189,7 +189,7 @@ public class Inventories {
             CarpetContext cc = (CarpetContext) c;
             NBTSerializableValue.InventoryLocator inventoryLocator = NBTSerializableValue.locateInventory(cc, lv, 0);
             if (inventoryLocator == null) return Value.NULL;
-            return BooleanValue.of(!inventoryLocator.inventory.isEmpty());
+            return BooleanValue.of(!inventoryLocator.inventory().isEmpty());
         });
 
         //inventory_get(<b, e>, <n>) -> item_triple
@@ -198,17 +198,17 @@ public class Inventories {
             CarpetContext cc = (CarpetContext) c;
             NBTSerializableValue.InventoryLocator inventoryLocator = NBTSerializableValue.locateInventory(cc, lv, 0);
             if (inventoryLocator == null) return Value.NULL;
-            if (lv.size() == inventoryLocator.offset)
+            if (lv.size() == inventoryLocator.offset())
             {
                 List<Value> fullInventory = new ArrayList<>();
-                for (int i = 0, maxi = inventoryLocator.inventory.size(); i < maxi; i++)
-                    fullInventory.add(ValueConversions.of(inventoryLocator.inventory.getStack(i)));
+                for (int i = 0, maxi = inventoryLocator.inventory().size(); i < maxi; i++)
+                    fullInventory.add(ValueConversions.of(inventoryLocator.inventory().getStack(i)));
                 return ListValue.wrap(fullInventory);
             }
-            int slot = (int)NumericValue.asNumber(lv.get(inventoryLocator.offset)).getLong();
-            slot = NBTSerializableValue.validateSlot(slot, inventoryLocator.inventory);
-            if (slot == inventoryLocator.inventory.size()) return Value.NULL;
-            return ValueConversions.of(inventoryLocator.inventory.getStack(slot));
+            int slot = (int)NumericValue.asNumber(lv.get(inventoryLocator.offset())).getLong();
+            slot = NBTSerializableValue.validateSlot(slot, inventoryLocator.inventory());
+            if (slot == inventoryLocator.inventory().size()) return Value.NULL;
+            return ValueConversions.of(inventoryLocator.inventory().getStack(slot));
         });
 
         //inventory_set(<b,e>, <n>, <count>, <item>, <nbt>)
@@ -217,33 +217,33 @@ public class Inventories {
             CarpetContext cc = (CarpetContext) c;
             NBTSerializableValue.InventoryLocator inventoryLocator = NBTSerializableValue.locateInventory(cc, lv, 0);
             if (inventoryLocator == null) return Value.NULL;
-            if (lv.size() < inventoryLocator.offset+2)
+            if (lv.size() < inventoryLocator.offset()+2)
                 throw new InternalExpressionException("'inventory_set' requires at least slot number and new stack size, and optional new item");
-            int slot = (int) NumericValue.asNumber(lv.get(inventoryLocator.offset+0)).getLong();
-            slot = NBTSerializableValue.validateSlot(slot, inventoryLocator.inventory);
-            if (slot == inventoryLocator.inventory.size()) return Value.NULL;
-            int count = (int) NumericValue.asNumber(lv.get(inventoryLocator.offset+1)).getLong();
+            int slot = (int) NumericValue.asNumber(lv.get(inventoryLocator.offset()+0)).getLong();
+            slot = NBTSerializableValue.validateSlot(slot, inventoryLocator.inventory());
+            if (slot == inventoryLocator.inventory().size()) return Value.NULL;
+            int count = (int) NumericValue.asNumber(lv.get(inventoryLocator.offset()+1)).getLong();
             if (count == 0)
             {
                 // clear slot
-                ItemStack removedStack = inventoryLocator.inventory.removeStack(slot);
+                ItemStack removedStack = inventoryLocator.inventory().removeStack(slot);
                 syncPlayerInventory(inventoryLocator, slot);
                 //Value res = ListValue.fromItemStack(removedStack); // that tuple will be read only but cheaper if noone cares
                 return ValueConversions.of(removedStack);
             }
-            if (lv.size() < inventoryLocator.offset+3)
+            if (lv.size() < inventoryLocator.offset()+3)
             {
-                ItemStack previousStack = inventoryLocator.inventory.getStack(slot);
+                ItemStack previousStack = inventoryLocator.inventory().getStack(slot);
                 ItemStack newStack = previousStack.copy();
                 newStack.setCount(count);
-                inventoryLocator.inventory.setStack(slot, newStack);
+                inventoryLocator.inventory().setStack(slot, newStack);
                 syncPlayerInventory(inventoryLocator, slot);
                 return ValueConversions.of(previousStack);
             }
             NbtCompound nbt = null; // skipping one argument
-            if (lv.size() > inventoryLocator.offset+3)
+            if (lv.size() > inventoryLocator.offset()+3)
             {
-                Value nbtValue = lv.get(inventoryLocator.offset+3);
+                Value nbtValue = lv.get(inventoryLocator.offset()+3);
                 if (nbtValue instanceof NBTSerializableValue)
                     nbt = ((NBTSerializableValue)nbtValue).getCompoundTag();
                 else if (nbtValue instanceof NullValue)
@@ -251,11 +251,11 @@ public class Inventories {
                 else
                     nbt = new NBTSerializableValue(nbtValue.getString()).getCompoundTag();
             }
-            ItemStackArgument newitem = NBTSerializableValue.parseItem(lv.get(inventoryLocator.offset+2).getString(), nbt);
-            ItemStack previousStack = inventoryLocator.inventory.getStack(slot);
+            ItemStackArgument newitem = NBTSerializableValue.parseItem(lv.get(inventoryLocator.offset()+2).getString(), nbt);
+            ItemStack previousStack = inventoryLocator.inventory().getStack(slot);
             try
             {
-                inventoryLocator.inventory.setStack(slot, newitem.createStack(count, false));
+                inventoryLocator.inventory().setStack(slot, newitem.createStack(count, false));
                 syncPlayerInventory(inventoryLocator, slot);
             }
             catch (CommandSyntaxException e)
@@ -272,21 +272,21 @@ public class Inventories {
             NBTSerializableValue.InventoryLocator inventoryLocator = NBTSerializableValue.locateInventory(cc, lv, 0);
             if (inventoryLocator == null) return Value.NULL;
             ItemStackArgument itemArg = null;
-            if (lv.size() > inventoryLocator.offset)
+            if (lv.size() > inventoryLocator.offset())
             {
-                Value secondArg = lv.get(inventoryLocator.offset+0);
+                Value secondArg = lv.get(inventoryLocator.offset()+0);
                 if (!(secondArg instanceof NullValue))
                     itemArg = NBTSerializableValue.parseItem(secondArg.getString());
             }
             int startIndex = 0;
-            if (lv.size() > inventoryLocator.offset+1)
+            if (lv.size() > inventoryLocator.offset()+1)
             {
-                startIndex = (int) NumericValue.asNumber(lv.get(inventoryLocator.offset+1)).getLong();
+                startIndex = (int) NumericValue.asNumber(lv.get(inventoryLocator.offset()+1)).getLong();
             }
-            startIndex = NBTSerializableValue.validateSlot(startIndex, inventoryLocator.inventory);
-            for (int i = startIndex, maxi = inventoryLocator.inventory.size(); i < maxi; i++)
+            startIndex = NBTSerializableValue.validateSlot(startIndex, inventoryLocator.inventory());
+            for (int i = startIndex, maxi = inventoryLocator.inventory().size(); i < maxi; i++)
             {
-                ItemStack stack = inventoryLocator.inventory.getStack(i);
+                ItemStack stack = inventoryLocator.inventory().getStack(i);
                 if ( (itemArg == null && stack.isEmpty()) || (itemArg != null && itemArg.getItem().equals(stack.getItem())) )
                     return new NumericValue(i);
             }
@@ -299,18 +299,18 @@ public class Inventories {
             CarpetContext cc = (CarpetContext) c;
             NBTSerializableValue.InventoryLocator inventoryLocator = NBTSerializableValue.locateInventory(cc, lv, 0);
             if (inventoryLocator == null) return Value.NULL;
-            if (lv.size() <= inventoryLocator.offset)
+            if (lv.size() <= inventoryLocator.offset())
                 throw new InternalExpressionException("'inventory_remove' requires at least an item to be removed");
-            ItemStackArgument searchItem = NBTSerializableValue.parseItem(lv.get(inventoryLocator.offset).getString());
+            ItemStackArgument searchItem = NBTSerializableValue.parseItem(lv.get(inventoryLocator.offset()).getString());
             int amount = 1;
-            if (lv.size() > inventoryLocator.offset+1)
-                amount = (int)NumericValue.asNumber(lv.get(inventoryLocator.offset+1)).getLong();
+            if (lv.size() > inventoryLocator.offset()+1)
+                amount = (int)NumericValue.asNumber(lv.get(inventoryLocator.offset()+1)).getLong();
             // not enough
-            if (((amount == 1) && (!inventoryLocator.inventory.containsAny(Sets.newHashSet(searchItem.getItem()))))
-                    || (inventoryLocator.inventory.count(searchItem.getItem()) < amount)) return Value.FALSE;
-            for (int i = 0, maxi = inventoryLocator.inventory.size(); i < maxi; i++)
+            if (((amount == 1) && (!inventoryLocator.inventory().containsAny(Sets.newHashSet(searchItem.getItem()))))
+                    || (inventoryLocator.inventory().count(searchItem.getItem()) < amount)) return Value.FALSE;
+            for (int i = 0, maxi = inventoryLocator.inventory().size(); i < maxi; i++)
             {
-                ItemStack stack = inventoryLocator.inventory.getStack(i);
+                ItemStack stack = inventoryLocator.inventory().getStack(i);
                 if (stack.isEmpty())
                     continue;
                 if (!stack.getItem().equals(searchItem.getItem()))
@@ -319,13 +319,13 @@ public class Inventories {
                 if (left > 0)
                 {
                     stack.setCount(left);
-                    inventoryLocator.inventory.setStack(i, stack);
+                    inventoryLocator.inventory().setStack(i, stack);
                     syncPlayerInventory(inventoryLocator, i);
                     return Value.TRUE;
                 }
                 else
                 {
-                    inventoryLocator.inventory.removeStack(i);
+                    inventoryLocator.inventory().removeStack(i);
                     syncPlayerInventory(inventoryLocator, i);
                     amount -= stack.getCount();
                 }
@@ -341,22 +341,22 @@ public class Inventories {
             CarpetContext cc = (CarpetContext) c;
             NBTSerializableValue.InventoryLocator inventoryLocator = NBTSerializableValue.locateInventory(cc, lv, 0);
             if (inventoryLocator == null) return Value.NULL;
-            if (lv.size() == inventoryLocator.offset)
+            if (lv.size() == inventoryLocator.offset())
                 throw new InternalExpressionException("Slot number is required for inventory_drop");
-            int slot = (int)NumericValue.asNumber(lv.get(inventoryLocator.offset)).getLong();
-            slot = NBTSerializableValue.validateSlot(slot, inventoryLocator.inventory);
-            if (slot == inventoryLocator.inventory.size()) return Value.NULL;
+            int slot = (int)NumericValue.asNumber(lv.get(inventoryLocator.offset())).getLong();
+            slot = NBTSerializableValue.validateSlot(slot, inventoryLocator.inventory());
+            if (slot == inventoryLocator.inventory().size()) return Value.NULL;
             int amount = 0;
-            if (lv.size() > inventoryLocator.offset+1)
-                amount = (int)NumericValue.asNumber(lv.get(inventoryLocator.offset+1)).getLong();
+            if (lv.size() > inventoryLocator.offset()+1)
+                amount = (int)NumericValue.asNumber(lv.get(inventoryLocator.offset()+1)).getLong();
             if (amount < 0)
                 throw new InternalExpressionException("Cannot throw negative number of items");
-            ItemStack stack = inventoryLocator.inventory.getStack(slot);
+            ItemStack stack = inventoryLocator.inventory().getStack(slot);
             if (stack == null || stack.isEmpty()) return Value.ZERO;
             if (amount == 0) amount = stack.getCount();
-            ItemStack droppedStack = inventoryLocator.inventory.removeStack(slot, amount);
+            ItemStack droppedStack = inventoryLocator.inventory().removeStack(slot, amount);
             if (droppedStack.isEmpty()) return Value.ZERO;
-            Object owner = inventoryLocator.owner;
+            Object owner = inventoryLocator.owner();
             ItemEntity item;
             if (owner instanceof PlayerEntity)
             {
@@ -375,7 +375,7 @@ public class Inventories {
             }
             else
             {
-                Vec3d point = Vec3d.ofCenter(inventoryLocator.position); //pos+0.5v
+                Vec3d point = Vec3d.ofCenter(inventoryLocator.position()); //pos+0.5v
                 item = new ItemEntity(cc.s.getWorld(), point.x, point.y, point.z, droppedStack);
                 item.setToDefaultPickupDelay();
                 cc.s.getWorld().spawnEntity(item);
@@ -386,13 +386,13 @@ public class Inventories {
 
     private static void syncPlayerInventory(NBTSerializableValue.InventoryLocator inventory, int int_1)
     {
-        if (inventory.owner instanceof ServerPlayerEntity && !inventory.isEnder)
+        if (inventory.owner() instanceof ServerPlayerEntity && !inventory.isEnder())
         {
-            ServerPlayerEntity player = (ServerPlayerEntity) inventory.owner;
+            ServerPlayerEntity player = (ServerPlayerEntity) inventory.owner();
             player.networkHandler.sendPacket(new ScreenHandlerSlotUpdateS2CPacket(
                     -2, 0, // resolve mystery argument
                     int_1,
-                    inventory.inventory.getStack(int_1)
+                    inventory.inventory().getStack(int_1)
             ));
         }
     }

--- a/src/main/java/carpet/script/api/Monitoring.java
+++ b/src/main/java/carpet/script/api/Monitoring.java
@@ -3,7 +3,6 @@ package carpet.script.api;
 import carpet.fakes.SpawnHelperInnerInterface;
 import carpet.script.CarpetContext;
 import carpet.script.Expression;
-import carpet.script.LazyValue;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.utils.SystemInfo;
 import carpet.script.value.ListValue;

--- a/src/main/java/carpet/script/argument/FileArgument.java
+++ b/src/main/java/carpet/script/argument/FileArgument.java
@@ -9,7 +9,6 @@ import carpet.script.exception.Throwables;
 import carpet.script.value.MapValue;
 import carpet.script.value.StringValue;
 import carpet.script.value.Value;
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
@@ -523,7 +522,7 @@ public class FileArgument
             Throwable exc = e;
             if(e.getCause() != null)
                 exc = e.getCause();
-            throw new ThrowStatement(MapValue.wrap(ImmutableMap.of(
+            throw new ThrowStatement(MapValue.wrap(Map.of(
                     StringValue.of("error"), StringValue.of(exc.getMessage()),
                     StringValue.of("path"), StringValue.of(filePath.toString())
             )), Throwables.JSON_ERROR);

--- a/src/main/java/carpet/script/language/ControlFlow.java
+++ b/src/main/java/carpet/script/language/ControlFlow.java
@@ -13,8 +13,8 @@ import carpet.script.value.MapValue;
 import carpet.script.value.NumericValue;
 import carpet.script.value.StringValue;
 import carpet.script.value.Value;
-import com.google.common.collect.ImmutableMap;
 
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class ControlFlow {
@@ -106,7 +106,7 @@ public class ControlFlow {
                 LazyValue __ = c.getVariable("_");
                 c.setVariable("_", (__c, __t) -> ret.data.reboundedTo("_"));
                 LazyValue _trace = c.getVariable("_trace");
-                c.setVariable("_trace", (__c, __t) -> MapValue.wrap(ImmutableMap.of(
+                c.setVariable("_trace", (__c, __t) -> MapValue.wrap(Map.of(
                         StringValue.of("stack"), ListValue.wrap(ret.stack.stream().map(f -> ListValue.of(
                                 StringValue.of(f.getModule().getName()),
                                 StringValue.of(f.getString()),

--- a/src/main/java/carpet/script/utils/SimplexNoiseSampler.java
+++ b/src/main/java/carpet/script/utils/SimplexNoiseSampler.java
@@ -38,6 +38,7 @@ public class SimplexNoiseSampler extends PerlinNoiseSampler {
         return g;
     }
 
+    @Override
     public double sample2d(double x, double y) {
         x = x/2;
         y = y/2;
@@ -75,6 +76,7 @@ public class SimplexNoiseSampler extends PerlinNoiseSampler {
         return 35.0D * (aa + ab + ac)+0.5;
     }
 
+    @Override
     public double sample3d(double d, double e, double f) {
         d = d/2;
         e = e/2;

--- a/src/main/java/carpet/script/utils/SnoopyCommandSource.java
+++ b/src/main/java/carpet/script/utils/SnoopyCommandSource.java
@@ -122,6 +122,7 @@ public class SnoopyCommandSource extends ServerCommandSource
         return new SnoopyCommandSource(output, position, rotation, world, level, simpleName, name, server, entity, consumer, entityAnchor, error, chatOutput);
     }
 
+    @Override
     public ServerCommandSource mergeConsumers(ResultConsumer<ServerCommandSource> consumer, BinaryOperator<ResultConsumer<ServerCommandSource>> binaryOperator)
     {
         ResultConsumer<ServerCommandSource> resultConsumer = binaryOperator.apply(this.resultConsumer, consumer);

--- a/src/main/java/carpet/script/utils/SystemInfo.java
+++ b/src/main/java/carpet/script/utils/SystemInfo.java
@@ -133,7 +133,7 @@ public class SystemInfo {
         put("java_system_cpu_load", c -> {
             OperatingSystemMXBean osBean = ManagementFactory.getPlatformMXBean(
                     OperatingSystemMXBean.class);
-            return new NumericValue(osBean.getSystemCpuLoad());
+            return new NumericValue(osBean.getCpuLoad());
         });
         put("java_process_cpu_load", c -> {
             OperatingSystemMXBean osBean = ManagementFactory.getPlatformMXBean(

--- a/src/main/java/carpet/script/utils/WorldTools.java
+++ b/src/main/java/carpet/script/utils/WorldTools.java
@@ -1,7 +1,6 @@
 package carpet.script.utils;
 
 import carpet.fakes.MinecraftServerInterface;
-import com.google.common.collect.ImmutableList;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.network.packet.s2c.play.ChunkDataS2CPacket;
@@ -93,7 +92,7 @@ public class WorldTools
         boolean bl = generatorOptions.isDebugWorld();
         long l = generatorOptions.getSeed();
         long m = BiomeAccess.hashSeed(l);
-        List<Spawner> list = ImmutableList.of();
+        List<Spawner> list = List.of();
         SimpleRegistry<DimensionOptions> simpleRegistry = generatorOptions.getDimensions();
         DimensionOptions dimensionOptions = simpleRegistry.get(DimensionOptions.OVERWORLD);
         ChunkGenerator chunkGenerator2;

--- a/src/main/java/carpet/script/value/AbstractListValue.java
+++ b/src/main/java/carpet/script/value/AbstractListValue.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public abstract class AbstractListValue extends Value implements Iterable<Value>
 {
-    public abstract Iterator<Value> iterator();
+    @Override public abstract Iterator<Value> iterator();
     public List<Value> unpack() { return Lists.newArrayList(iterator()); }
     public void fatality() { }
     public void append(Value v)

--- a/src/main/java/carpet/script/value/BooleanValue.java
+++ b/src/main/java/carpet/script/value/BooleanValue.java
@@ -12,7 +12,7 @@ public class BooleanValue extends NumericValue
 
     boolean boolValue;
     private BooleanValue(boolean boolval) {
-        super(boolval);
+        super(boolval ? 1L : 0L);
         boolValue = boolval;
     }
 

--- a/src/main/java/carpet/script/value/EntityValue.java
+++ b/src/main/java/carpet/script/value/EntityValue.java
@@ -413,14 +413,14 @@ public class EntityValue extends Value
             throw new InternalExpressionException("Cannot fetch '"+what+"' with these arguments");
         }
     }
-    private static final Map<String, EquipmentSlot> inventorySlots = new HashMap<String, EquipmentSlot>(){{
-        put("mainhand", EquipmentSlot.MAINHAND);
-        put("offhand", EquipmentSlot.OFFHAND);
-        put("head", EquipmentSlot.HEAD);
-        put("chest", EquipmentSlot.CHEST);
-        put("legs", EquipmentSlot.LEGS);
-        put("feet", EquipmentSlot.FEET);
-    }};
+    private static final Map<String, EquipmentSlot> inventorySlots = Map.of(
+        "mainhand", EquipmentSlot.MAINHAND,
+        "offhand", EquipmentSlot.OFFHAND,
+        "head", EquipmentSlot.HEAD,
+        "chest", EquipmentSlot.CHEST,
+        "legs", EquipmentSlot.LEGS,
+        "feet", EquipmentSlot.FEET
+    );
 
     private static final Map<String, BiFunction<Entity, Value, Value>> featureAccessors = new HashMap<String, BiFunction<Entity, Value, Value>>() {{
         //put("test", (e, a) -> a == null ? Value.NULL : new StringValue(a.getString()));

--- a/src/main/java/carpet/script/value/LazyListValue.java
+++ b/src/main/java/carpet/script/value/LazyListValue.java
@@ -109,9 +109,9 @@ public abstract class LazyListValue extends AbstractListValue implements Iterato
     {
         return hasNext();
     }
-    public abstract boolean hasNext();
+    @Override public abstract boolean hasNext();
 
-    public abstract Value next();
+    @Override public abstract Value next();
 
     @Override
     public void fatality() {reset();}

--- a/src/main/java/carpet/script/value/ListValue.java
+++ b/src/main/java/carpet/script/value/ListValue.java
@@ -149,6 +149,8 @@ public class ListValue extends AbstractListValue implements ContainerValueInterf
     {
         items.add(v);
     }
+
+    @Override
     public Value subtract(Value other)
     {
         ListValue output = new ListValue();
@@ -182,6 +184,7 @@ public class ListValue extends AbstractListValue implements ContainerValueInterf
     }
 
 
+    @Override
     public Value multiply(Value other)
     {
         ListValue output = new ListValue();
@@ -209,6 +212,8 @@ public class ListValue extends AbstractListValue implements ContainerValueInterf
         }
         return output;
     }
+
+    @Override
     public Value divide(Value other)
     {
         ListValue output = new ListValue();
@@ -272,8 +277,10 @@ public class ListValue extends AbstractListValue implements ContainerValueInterf
         return items;
     }
 
+    @Override
     public Iterator<Value> iterator() { return new ArrayList<>(items).iterator(); } // should be thread safe
 
+    @Override
     public List<Value> unpack()
     {
         return new ArrayList<>(items);

--- a/src/main/java/carpet/script/value/NBTSerializableValue.java
+++ b/src/main/java/carpet/script/value/NBTSerializableValue.java
@@ -633,25 +633,11 @@ public class NBTSerializableValue extends Value implements ContainerValueInterfa
         return false;
     }
 
-    public static class InventoryLocator
+    public static record InventoryLocator(Object owner, BlockPos position, Inventory inventory, int offset, boolean isEnder)
     {
-        public Object owner;
-        public BlockPos position;
-        public Inventory inventory;
-        public int offset;
-        public boolean isEnder;
         InventoryLocator(Object owner, BlockPos pos, Inventory i, int o)
         {
             this(owner, pos, i, o, false);
-        }
-
-        InventoryLocator(Object owner, BlockPos pos, Inventory i, int o, boolean isEnder)
-        {
-            this.owner = owner;
-            position = pos;
-            inventory = i;
-            offset = o;
-            this.isEnder = isEnder;
         }
     }
 

--- a/src/main/java/carpet/script/value/NullValue.java
+++ b/src/main/java/carpet/script/value/NullValue.java
@@ -33,7 +33,7 @@ public class NullValue extends NumericValue // TODO check nonsingleton code
     {
         return new NullValue();
     }
-    private NullValue() {super(false);}
+    private NullValue() {super(0);}
 
     @Override
     public boolean equals(final Object o)

--- a/src/main/java/carpet/script/value/NumericValue.java
+++ b/src/main/java/carpet/script/value/NumericValue.java
@@ -121,6 +121,8 @@ public class NumericValue extends Value
         }
         return super.add(v);
     }
+
+    @Override
     public Value subtract(Value v) {  // TODO test if definintn add(NumericVlaue) woud solve the casting
         if (v instanceof NumericValue)
         {
@@ -133,6 +135,8 @@ public class NumericValue extends Value
         }
         return super.subtract(v);
     }
+
+    @Override
     public Value multiply(Value v)
     {
         if (v instanceof NumericValue)
@@ -150,6 +154,8 @@ public class NumericValue extends Value
         }
         return new StringValue(StringUtils.repeat(v.getString(), (int) getLong()));
     }
+
+    @Override
     public Value divide(Value v)
     {
         //if (1+2==3) throw new ArithmeticException("Booyah");
@@ -226,17 +232,6 @@ public class NumericValue extends Value
     {
         this.longValue = value;
         this.value = (double)value;
-    }
-
-    /**
-     * Creates a legacy {@link NumericValue} for a {@code boolean}.
-     * @param boolval The boolean to set 1 or 0 for this {@link NumericValue}
-     * @deprecated Use {@link BooleanValue#of(boolean)} instead
-     */
-    @Deprecated
-    public NumericValue(boolean boolval)
-    {
-        this(boolval?1L:0L);
     }
 
     @Override

--- a/src/main/java/carpet/settings/ParsedRule.java
+++ b/src/main/java/carpet/settings/ParsedRule.java
@@ -2,7 +2,6 @@ package carpet.settings;
 
 import carpet.utils.Translations;
 import carpet.utils.Messenger;
-import com.google.common.collect.ImmutableList;
 import net.minecraft.server.command.ServerCommandSource;
 
 import java.lang.reflect.Constructor;
@@ -11,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ClassUtils;
 
@@ -29,9 +29,9 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
     public final String name;
     public final String description;
     public final String scarpetApp;
-    public final ImmutableList<String> extraInfo;
-    public final ImmutableList<String> categories;
-    public final ImmutableList<String> options;
+    public final List<String> extraInfo;
+    public final List<String> categories;
+    public final List<String> options;
     public boolean isStrict;
     public boolean isClient;
     public final Class<T> type;
@@ -47,8 +47,8 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
         this.type = (Class<T>) field.getType();
         this.description = rule.desc();
         this.isStrict = rule.strict();
-        this.extraInfo = ImmutableList.copyOf(rule.extra());
-        this.categories = ImmutableList.copyOf(rule.category());
+        this.extraInfo = List.of(rule.extra());
+        this.categories = List.of(rule.category());
         this.scarpetApp = rule.appSource();
         this.settingsManager = settingsManager;
         this.validators = new ArrayList<>();
@@ -76,22 +76,22 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
         this.defaultAsString = convertToString(this.defaultValue);
         if (rule.options().length > 0)
         {
-            this.options = ImmutableList.copyOf(rule.options());
+            this.options = List.of(rule.options());
         }
         else if (this.type == boolean.class){
-            this.options = ImmutableList.of("true","false");
+            this.options = List.of("true","false");
         }
         else if(this.type == String.class && categories.contains(RuleCategory.COMMAND))
         {
-            this.options = ImmutableList.of("true", "false", "ops");
+            this.options = List.of("true", "false", "ops");
         }
         else if (this.type.isEnum())
         {
-            this.options = Arrays.stream(this.type.getEnumConstants()).map(e -> ((Enum) e).name().toLowerCase(Locale.ROOT)).collect(ImmutableList.toImmutableList());
+            this.options = Arrays.stream(this.type.getEnumConstants()).map(e -> ((Enum) e).name().toLowerCase(Locale.ROOT)).collect(Collectors.toUnmodifiableList());
         }
         else
         {
-            this.options = ImmutableList.of();
+            this.options = List.of();
         }
         if (isStrict && !this.options.isEmpty())
         {

--- a/src/main/java/carpet/settings/Validator.java
+++ b/src/main/java/carpet/settings/Validator.java
@@ -2,9 +2,9 @@ package carpet.settings;
 
 import carpet.CarpetServer;
 import carpet.utils.Messenger;
-import com.google.common.collect.ImmutableList;
 import net.minecraft.server.command.ServerCommandSource;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
@@ -48,7 +48,7 @@ public abstract class Validator<T>
     }
 
     public static class _COMMAND_LEVEL_VALIDATOR extends Validator<String> {
-        private static ImmutableList<String> OPTIONS = ImmutableList.of("true", "false", "ops", "0", "1", "2", "3", "4");
+        private static List<String> OPTIONS = List.of("true", "false", "ops", "0", "1", "2", "3", "4");
         @Override public String validate(ServerCommandSource source, ParsedRule<String> currentRule, String newValue, String userString) {
             if (!OPTIONS.contains(userString.toLowerCase(Locale.ROOT)))
             {
@@ -59,7 +59,7 @@ public abstract class Validator<T>
             }
             return userString.toLowerCase(Locale.ROOT);
         }
-        public String description() { return "Can be limited to 'ops' only, or a custom permission level";}
+        @Override public String description() { return "Can be limited to 'ops' only, or a custom permission level";}
     }
     
     public static class _SCARPET<T> extends Validator<T> {
@@ -68,7 +68,7 @@ public abstract class Validator<T>
         {
             return newValue;
         }
-        public String description() {
+        @Override public String description() {
             return "It controls an accompanying Scarpet App";
         }
     }

--- a/src/main/java/carpet/utils/CarpetProfiler.java
+++ b/src/main/java/carpet/utils/CarpetProfiler.java
@@ -50,19 +50,11 @@ public class CarpetProfiler
         TILEENTITY
     }
 
-    public static class ProfilerToken
+    public static record ProfilerToken(TYPE type, Object section, long start, World world)
     {
-        public final TYPE type;
-        public final Object section;
-        public final long start;
-        public final World world;
-
         public ProfilerToken(TYPE type, Object section, World world)
         {
-            this.type = type;
-            this.section = section;
-            this.start = System.nanoTime();
-            this.world = world;
+            this(type, section, System.nanoTime(), world);
         }
     }
 

--- a/src/main/java/carpet/utils/SpawnReporter.java
+++ b/src/main/java/carpet/utils/SpawnReporter.java
@@ -1,4 +1,3 @@
-
 package carpet.utils;
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap;


### PR DESCRIPTION
So I did some upgrading off camera...

This PR (ready):

- Changes all tuples (pair and triple) I knew how to call their parameters to use records instead (the rest are still there)
- Changes all references to guava ImmutableList and ImmutableMap to use Java's new List.of() and Map.of() that also return immutable collections (also Set)
- Upgrades some classes that were candidate to be a record to, well, a record
- Removes deprecated `NumericValue(boolean)` constructor given it was already deprecated and the only extension that used it hasn't used since early 1.17 snapshots
- Also adds `@Override` to non-mixin classes, makes it easier to find that a method implements something. Not understanding why a `divide` method in ListValue and discovering it's an override later can be frustrating.

Not in this PR (Coming Soon™ in different PRs):

- #1019
- Finding and upgrading more of the double `{{` initializations to Map.of(), etc
- Maybe making use of abstract classes in mixins to be able to use the more compatible (relatively-recently upgraded in Mixin) Accessor and Invoker with the current fakes and that can live together with other Mixin code to make them simpler
- Maybe adding `@Override` to mixins too
- Maybe porting some Scarpet functions to annotations
- Maybe some `var`s, though those are currently remapped to their type on migrateMappings until Mercury is updated and gets bumped in Loom

Take your time to review it.

NOTE: At the time of sending this PR (and now), it has got almost no testing.

NOTE 2: In those nested records that previously accessed public final fields, I haven't changed the calls to their functional versions, since it's still possible from the same class (though I _think_ it produces bridge methods), tell me if you want me to change that.