### PR TITLE
Use pattern matching for instanceof

### DIFF
--- a/src/main/java/carpet/helpers/OptimizedExplosion.java
+++ b/src/main/java/carpet/helpers/OptimizedExplosion.java
@@ -180,8 +180,7 @@ public class OptimizedExplosion
 
                         entity.setVelocity(entity.getVelocity().add(d5 * d11, d7 * d11, d9 * d11));
 
-                        if (entity instanceof PlayerEntity) {
-                            PlayerEntity player = (PlayerEntity) entity;
+                        if (entity instanceof PlayerEntity player) {
 
                             if (!player.isSpectator()
                                     && (!player.isCreative() || !player.getAbilities().flying)) {  //getAbilities

--- a/src/main/java/carpet/logging/logHelpers/ExplosionLogHelper.java
+++ b/src/main/java/carpet/logging/logHelpers/ExplosionLogHelper.java
@@ -108,9 +108,8 @@ public class ExplosionLogHelper
         @Override
         public boolean equals(Object obj)
         {
-            if (obj instanceof EntityChangedStatusWithCount)
+            if (obj instanceof EntityChangedStatusWithCount other)
             {
-                EntityChangedStatusWithCount other = (EntityChangedStatusWithCount) obj;
                 return other.pos.equals(pos) && other.accel.equals(accel) && other.type.equals(type);
             }
             return super.equals(obj);

--- a/src/main/java/carpet/script/api/Inventories.java
+++ b/src/main/java/carpet/script/api/Inventories.java
@@ -362,9 +362,8 @@ public class Inventories {
             {
                 item = ((PlayerEntity) owner).dropItem(droppedStack, false, true);
             }
-            else if (owner instanceof LivingEntity)
+            else if (owner instanceof LivingEntity villager)
             {
-                LivingEntity villager = (LivingEntity)owner;
                 // stolen from LookTargetUtil.give((VillagerEntity)owner, droppedStack, (LivingEntity) owner);
                 double double_1 = villager.getY() - 0.30000001192092896D + (double)villager.getStandingEyeHeight();
                 item = new ItemEntity(villager.world, villager.getX(), double_1, villager.getZ(), droppedStack);
@@ -386,9 +385,8 @@ public class Inventories {
 
     private static void syncPlayerInventory(NBTSerializableValue.InventoryLocator inventory, int int_1)
     {
-        if (inventory.owner instanceof ServerPlayerEntity && !inventory.isEnder)
+        if (inventory.owner instanceof ServerPlayerEntity player && !inventory.isEnder)
         {
-            ServerPlayerEntity player = (ServerPlayerEntity) inventory.owner;
             player.networkHandler.sendPacket(new ScreenHandlerSlotUpdateS2CPacket(
                     -2, 0, // resolve mystery argument
                     int_1,

--- a/src/main/java/carpet/script/language/Functions.java
+++ b/src/main/java/carpet/script/language/Functions.java
@@ -123,9 +123,8 @@ public class Functions {
                 return (cc, tt) -> result;
             }
             Value v1 = lv1.evalValue(c, Context.SIGNATURE);
-            if (!(v1 instanceof FunctionSignatureValue))
+            if (!(v1 instanceof FunctionSignatureValue sign))
                 throw new InternalExpressionException("'->' operator requires a function signature on the LHS");
-            FunctionSignatureValue sign = (FunctionSignatureValue) v1;
             Value result = expression.createUserDefinedFunction(c, sign.getName(), e, t, sign.getArgs(), sign.getVarArgs(), sign.getGlobals(), lv2);
             return (cc, tt) -> result;
         });

--- a/src/main/java/carpet/script/language/Sys.java
+++ b/src/main/java/carpet/script/language/Sys.java
@@ -51,9 +51,8 @@ public class Sys {
 
         expression.addUnaryFunction("number", v ->
         {
-            if (v instanceof NumericValue)
+            if (v instanceof NumericValue num)
             {
-                NumericValue num = (NumericValue)v;
                 if (num.isInteger()) return new NumericValue(num.getLong());
                 return new NumericValue(num.getDouble());
             }

--- a/src/main/java/carpet/script/value/EntityValue.java
+++ b/src/main/java/carpet/script/value/EntityValue.java
@@ -530,9 +530,8 @@ public class EntityValue extends Value
             return Value.NULL;
         });
         put("spawn_point", (e, a) -> {
-            if (e instanceof ServerPlayerEntity)
+            if (e instanceof ServerPlayerEntity spe)
             {
-                ServerPlayerEntity spe = (ServerPlayerEntity)e;
                 if (spe.getSpawnPointPosition() == null) return Value.FALSE;
                 return ListValue.of(
                         ValueConversions.of(spe.getSpawnPointPosition()),
@@ -631,9 +630,8 @@ public class EntityValue extends Value
             String module = a.getString();
             MemoryModuleType<?> moduleType = Registry.MEMORY_MODULE_TYPE.get(InputValidator.identifierOf(module));
             if (moduleType == MemoryModuleType.DUMMY) return Value.NULL;
-            if (e instanceof LivingEntity)
+            if (e instanceof LivingEntity livingEntity)
             {
-                LivingEntity livingEntity = (LivingEntity)e;
                 Brain<?> brain = livingEntity.getBrain();
                 Map<MemoryModuleType<?>, Optional<? extends Memory<?>>> memories = ((BrainInterface)brain).getMobMemories();
                 Optional<? extends Memory<?>> optmemory = memories.get(moduleType);
@@ -652,9 +650,8 @@ public class EntityValue extends Value
         });
 
         put("permission_level", (e, a) -> {
-            if (e instanceof  ServerPlayerEntity)
+            if (e instanceof  ServerPlayerEntity spe)
             {
-                ServerPlayerEntity spe = (ServerPlayerEntity) e;
                 for (int i=4; i>=0; i--)
                 {
                     if (spe.hasPermissionLevel(i))
@@ -667,10 +664,9 @@ public class EntityValue extends Value
         });
 
         put("player_type", (e, a) -> {
-            if (e instanceof PlayerEntity)
+            if (e instanceof PlayerEntity p)
             {
                 if (e instanceof EntityPlayerMPFake) return new StringValue(((EntityPlayerMPFake) e).isAShadow?"shadow":"fake");
-                PlayerEntity p = (PlayerEntity)e;
                 MinecraftServer server = p.getEntityWorld().getServer();
                 if (server.isDedicated()) return new StringValue("multiplayer");
                 boolean runningLan = server.isRemote();
@@ -927,9 +923,8 @@ public class EntityValue extends Value
             e.refreshPositionAndAngles(x, y, z, yaw, pitch);
             // we were sending to players for not-living entites, that were untracked. Living entities should be tracked.
             //((ServerWorld) e.getEntityWorld()).getChunkManager().sendToNearbyPlayers(e, new EntityS2CPacket.(e));
-            if (e instanceof LivingEntity)
+            if (e instanceof LivingEntity le)
             {
-                LivingEntity le = (LivingEntity)e;
                 le.prevBodyYaw = le.prevYaw = yaw;
                 le.prevHeadYaw = le.headYaw = yaw;
                 // seems universal for:
@@ -956,9 +951,8 @@ public class EntityValue extends Value
         put("age", (e, v) -> e.age = Math.abs((int)NumericValue.asNumber(v).getLong()) );
         put("health", (e, v) -> {
             float health = (float) NumericValue.asNumber(v).getDouble();
-            if (health <= 0f && e instanceof ServerPlayerEntity)
+            if (health <= 0f && e instanceof ServerPlayerEntity player)
             {
-                ServerPlayerEntity player = (ServerPlayerEntity) e;
                 if (player.currentScreenHandler != null)
                 {
                     // if player dies with open container, then that causes NPE on the client side
@@ -1273,8 +1267,7 @@ public class EntityValue extends Value
         }); //requires mixing
 
         put("spawn_point", (e, a) -> {
-            if (!(e instanceof ServerPlayerEntity)) return;
-            ServerPlayerEntity spe = (ServerPlayerEntity)e;
+            if (!(e instanceof ServerPlayerEntity spe)) return;
             if (a == null)
             {
                 spe.setSpawnPoint(null, null, 0, false, false);
@@ -1302,9 +1295,8 @@ public class EntityValue extends Value
                 }
                 spe.setSpawnPoint(world, pos, angle, forced, false);
             }
-            else if (a instanceof BlockValue)
+            else if (a instanceof BlockValue bv)
             {
-                BlockValue bv= (BlockValue)a;
                 if (bv.getPos()==null || bv.getWorld() == null)
                     throw new InternalExpressionException("block for spawn modification should be localised in the world");
                 spe.setSpawnPoint(bv.getWorld().getRegistryKey(), bv.getPos(), e.getYaw(), true, false); // yaw
@@ -1367,8 +1359,7 @@ public class EntityValue extends Value
         });
         put("effect", (e, v) ->
         {
-            if (!(e instanceof LivingEntity)) return;
-            LivingEntity le = (LivingEntity)e;
+            if (!(e instanceof LivingEntity le)) return;
             if (v == null)
             {
                 le.clearStatusEffects();

--- a/src/main/java/carpet/script/value/NumericValue.java
+++ b/src/main/java/carpet/script/value/NumericValue.java
@@ -110,9 +110,8 @@ public class NumericValue extends Value
     @Override
     public Value add(Value v)
     {  // TODO test if definintn add(NumericVlaue) woud solve the casting
-        if (v instanceof NumericValue)
+        if (v instanceof NumericValue nv)
         {
-            NumericValue nv = (NumericValue)v;
             if (longValue != null && nv.longValue != null)
             {
                 return new NumericValue(longValue+nv.longValue);
@@ -122,9 +121,8 @@ public class NumericValue extends Value
         return super.add(v);
     }
     public Value subtract(Value v) {  // TODO test if definintn add(NumericVlaue) woud solve the casting
-        if (v instanceof NumericValue)
+        if (v instanceof NumericValue nv)
         {
-            NumericValue nv = (NumericValue)v;
             if (longValue != null && nv.longValue != null)
             {
                 return new NumericValue(longValue-nv.longValue);
@@ -135,9 +133,8 @@ public class NumericValue extends Value
     }
     public Value multiply(Value v)
     {
-        if (v instanceof NumericValue)
+        if (v instanceof NumericValue nv)
         {
-            NumericValue nv = (NumericValue)v;
             if (longValue != null && nv.longValue != null)
             {
                 return new NumericValue(longValue*nv.longValue);
@@ -173,9 +170,8 @@ public class NumericValue extends Value
         {
             return -o.compareTo(this);
         }
-        if (o instanceof NumericValue)
+        if (o instanceof NumericValue no)
         {
-            NumericValue no = (NumericValue)o;
             if (longValue != null && no.longValue != null)
                 return longValue.compareTo(no.longValue);
             return Double.compare(value, no.value);
@@ -189,9 +185,8 @@ public class NumericValue extends Value
         {
             return o.equals(this);
         }
-        if (o instanceof NumericValue)
+        if (o instanceof NumericValue no)
         {
-            NumericValue no = (NumericValue)o;
             if (longValue != null && no.longValue != null)
                 return longValue.equals(no.longValue);
             return !this.subtract(no).getBoolean();

--- a/src/main/java/carpet/script/value/ValueConversions.java
+++ b/src/main/java/carpet/script/value/ValueConversions.java
@@ -123,9 +123,8 @@ public class ValueConversions
         {
             return ((EntityValue)dimensionValue).getEntity().getEntityWorld();
         }
-        else if (dimensionValue instanceof BlockValue)
+        else if (dimensionValue instanceof BlockValue bv)
         {
-            BlockValue bv = (BlockValue)dimensionValue;
             if (bv.getWorld() != null)
             {
                 return bv.getWorld();
@@ -225,9 +224,8 @@ public class ValueConversions
 
     private static Value fromEntityMemory(Entity e, Object v)
     {
-        if (v instanceof GlobalPos)
+        if (v instanceof GlobalPos pos)
         {
-            GlobalPos pos = (GlobalPos)v;
             return of(pos);
         }
         if (v instanceof Entity)
@@ -250,9 +248,8 @@ public class ValueConversions
         {
             return ofUUID( (ServerWorld) e.getEntityWorld(), (UUID)v);
         }
-        if (v instanceof DamageSource)
+        if (v instanceof DamageSource source)
         {
-            DamageSource source = (DamageSource) v;
             return ListValue.of(
                     new StringValue(source.getName()),
                     source.getAttacker()==null?Value.NULL:new EntityValue(source.getAttacker())
@@ -278,9 +275,8 @@ public class ValueConversions
         {
             v = new ArrayList(((Set) v));
         }
-        if (v instanceof List)
+        if (v instanceof List l)
         {
-            List l = (List)v;
             if (l.isEmpty()) return ListValue.of();
             Object el = l.get(0);
             if (el instanceof Entity)


### PR DESCRIPTION
Another newer Java feature.

I've checked every non-mixin class with `instanceof` and changed those that immediately assigned a variable with a cast, other than those (one) that I thought hurt readability. Didn't touch those that only cast the existing variable later to pass it/invoke something on it, since that would add an extra field allocation etc.

Lightly tested, but shouldn't break.