### PR TITLE
added more customizability to renewableCoral

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -768,7 +768,7 @@ public class CarpetSettings
     }
     @Rule(
             desc = "Coral structures will grow with bonemeal from coral plants",
-            extra = "Expanded also allows growing from coral fans for easier farming",
+            extra = "Expanded also allows growing from coral fans for sustainable farming outside of warm oceans",
             category = FEATURE
     )
     public static RenewableCoralMode renewableCoral = RenewableCoralMode.FALSE;

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -18,9 +18,7 @@ import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Box;
 import net.minecraft.util.math.ChunkPos;
-import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 import org.apache.logging.log4j.LogManager;
@@ -763,12 +761,17 @@ public class CarpetSettings
     )
     public static int lightEngineMaxBatchSize = 5;
 
+    public enum RenewableCoralMode {
+        FALSE,
+        CORAL_ONLY,
+        FAN_ONLY,
+        TRUE;
+    }
     @Rule(
             desc = "Coral structures will grow with bonemeal from coral plants/coral fans",
-            options = {"disabled", "coral_only", "fan_only", "enabled"},
             category = FEATURE
     )
-    public static String renewableCoral = "disabled";
+    public static RenewableCoralMode renewableCoral = RenewableCoralMode.FALSE;
 
     @Rule(
             desc = "Nether basalt generator without soul sand below ",

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -762,9 +762,13 @@ public class CarpetSettings
             validate = LightBatchValidator.class
     )
     public static int lightEngineMaxBatchSize = 5;
-    
-    @Rule(desc = "Coral structures will grow with bonemeal from coral plants", category = FEATURE)
-    public static boolean renewableCoral = false;
+
+    @Rule(
+            desc = "Coral structures will grow with bonemeal from coral plants/coral fans",
+            options = {"disabled", "coral_only", "fan_only", "enabled"},
+            category = FEATURE
+    )
+    public static String renewableCoral = "disabled";
 
     @Rule(
             desc = "Nether basalt generator without soul sand below ",

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -763,12 +763,12 @@ public class CarpetSettings
 
     public enum RenewableCoralMode {
         FALSE,
-        CORAL_ONLY,
-        FAN_ONLY,
+        EXPANDED,
         TRUE;
     }
     @Rule(
-            desc = "Coral structures will grow with bonemeal from coral plants/coral fans",
+            desc = "Coral structures will grow with bonemeal from coral plants",
+            extra = "Expanded also allows growing from coral fans for easier farming",
             category = FEATURE
     )
     public static RenewableCoralMode renewableCoral = RenewableCoralMode.FALSE;

--- a/src/main/java/carpet/mixins/CoralBlockMixin.java
+++ b/src/main/java/carpet/mixins/CoralBlockMixin.java
@@ -29,8 +29,8 @@ public abstract class CoralBlockMixin implements Fertilizable
 {
     public boolean isFertilizable(BlockView var1, BlockPos var2, BlockState var3, boolean var4)
     {
-        return CarpetSettings.renewableCoral.equals("coral_only")
-                || CarpetSettings.renewableCoral.equals("enabled")
+        return CarpetSettings.renewableCoral == CarpetSettings.RenewableCoralMode.CORAL_ONLY
+                || CarpetSettings.renewableCoral == CarpetSettings.RenewableCoralMode.TRUE
                 && var3.get(CoralParentBlock.WATERLOGGED)
                 && var1.getFluidState(var2.up()).isIn(FluidTags.WATER);
     }

--- a/src/main/java/carpet/mixins/CoralBlockMixin.java
+++ b/src/main/java/carpet/mixins/CoralBlockMixin.java
@@ -29,7 +29,7 @@ public abstract class CoralBlockMixin implements Fertilizable
 {
     public boolean isFertilizable(BlockView var1, BlockPos var2, BlockState var3, boolean var4)
     {
-        return CarpetSettings.renewableCoral == CarpetSettings.RenewableCoralMode.CORAL_ONLY
+        return CarpetSettings.renewableCoral == CarpetSettings.RenewableCoralMode.EXPANDED
                 || CarpetSettings.renewableCoral == CarpetSettings.RenewableCoralMode.TRUE
                 && var3.get(CoralParentBlock.WATERLOGGED)
                 && var1.getFluidState(var2.up()).isIn(FluidTags.WATER);

--- a/src/main/java/carpet/mixins/CoralBlockMixin.java
+++ b/src/main/java/carpet/mixins/CoralBlockMixin.java
@@ -29,7 +29,10 @@ public abstract class CoralBlockMixin implements Fertilizable
 {
     public boolean isFertilizable(BlockView var1, BlockPos var2, BlockState var3, boolean var4)
     {
-        return CarpetSettings.renewableCoral && var3.get(CoralParentBlock.WATERLOGGED) && var1.getFluidState(var2.up()).isIn(FluidTags.WATER);
+        return CarpetSettings.renewableCoral.equals("coral_only")
+                || CarpetSettings.renewableCoral.equals("enabled")
+                && var3.get(CoralParentBlock.WATERLOGGED)
+                && var1.getFluidState(var2.up()).isIn(FluidTags.WATER);
     }
 
     public boolean canGrow(World var1, Random var2, BlockPos var3, BlockState var4)

--- a/src/main/java/carpet/mixins/CoralFanBlockMixin.java
+++ b/src/main/java/carpet/mixins/CoralFanBlockMixin.java
@@ -19,8 +19,7 @@ public abstract class CoralFanBlockMixin implements Fertilizable
 {
     public boolean isFertilizable(BlockView var1, BlockPos var2, BlockState var3, boolean var4)
     {
-        return CarpetSettings.renewableCoral == CarpetSettings.RenewableCoralMode.FAN_ONLY
-                || CarpetSettings.renewableCoral == CarpetSettings.RenewableCoralMode.TRUE
+        return CarpetSettings.renewableCoral == CarpetSettings.RenewableCoralMode.EXPANDED
                 && var3.get(CoralParentBlock.WATERLOGGED)
                 && var1.getFluidState(var2.up()).isIn(FluidTags.WATER);
     }

--- a/src/main/java/carpet/mixins/CoralFanBlockMixin.java
+++ b/src/main/java/carpet/mixins/CoralFanBlockMixin.java
@@ -19,8 +19,8 @@ public abstract class CoralFanBlockMixin implements Fertilizable
 {
     public boolean isFertilizable(BlockView var1, BlockPos var2, BlockState var3, boolean var4)
     {
-        return CarpetSettings.renewableCoral.equals("fan_only")
-                || CarpetSettings.renewableCoral.equals("enabled")
+        return CarpetSettings.renewableCoral == CarpetSettings.RenewableCoralMode.FAN_ONLY
+                || CarpetSettings.renewableCoral == CarpetSettings.RenewableCoralMode.TRUE
                 && var3.get(CoralParentBlock.WATERLOGGED)
                 && var1.getFluidState(var2.up()).isIn(FluidTags.WATER);
     }

--- a/src/main/java/carpet/mixins/CoralFanBlockMixin.java
+++ b/src/main/java/carpet/mixins/CoralFanBlockMixin.java
@@ -1,0 +1,73 @@
+package carpet.mixins;
+
+import carpet.CarpetSettings;
+import carpet.fakes.CoralFeatureInterface;
+import net.minecraft.block.*;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.tag.BlockTags;
+import net.minecraft.tag.FluidTags;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.*;
+import org.spongepowered.asm.mixin.Mixin;
+
+import java.util.Random;
+
+@Mixin(CoralFanBlock.class)
+public abstract class CoralFanBlockMixin implements Fertilizable
+{
+    public boolean isFertilizable(BlockView var1, BlockPos var2, BlockState var3, boolean var4)
+    {
+        return CarpetSettings.renewableCoral.equals("fan_only")
+                || CarpetSettings.renewableCoral.equals("enabled")
+                && var3.get(CoralParentBlock.WATERLOGGED)
+                && var1.getFluidState(var2.up()).isIn(FluidTags.WATER);
+    }
+
+    public boolean canGrow(World var1, Random var2, BlockPos var3, BlockState var4)
+    {
+        return (double)var1.random.nextFloat() < 0.15D;
+    }
+
+    public void grow(ServerWorld worldIn, Random random, BlockPos pos, BlockState blockUnder)
+    {
+
+        CoralFeature coral;
+        int variant = random.nextInt(3);
+        if (variant == 0)
+            coral = new CoralClawFeature(DefaultFeatureConfig.CODEC);
+        else if (variant == 1)
+            coral = new CoralTreeFeature(DefaultFeatureConfig.CODEC);
+        else
+            coral = new CoralMushroomFeature(DefaultFeatureConfig.CODEC);
+
+        MapColor color = blockUnder.getMapColor(worldIn, pos);
+        BlockState proper_block = blockUnder;
+        for (Block block: BlockTags.CORAL_BLOCKS.values())
+        {
+            proper_block = block.getDefaultState();
+            if (proper_block.getMapColor(worldIn,pos) == color)
+            {
+                break;
+            }
+        }
+        worldIn.setBlockState(pos, Blocks.WATER.getDefaultState(), 4);
+
+        if (!((CoralFeatureInterface)coral).growSpecific(worldIn, random, pos, proper_block))
+        {
+            worldIn.setBlockState(pos, blockUnder, 3);
+        }
+        else
+        {
+            if (worldIn.random.nextInt(10)==0)
+            {
+                BlockPos randomPos = pos.add(worldIn.random.nextInt(16)-8,worldIn.random.nextInt(8),worldIn.random.nextInt(16)-8  );
+                if (BlockTags.CORAL_BLOCKS.contains(worldIn.getBlockState(randomPos).getBlock()))
+                {
+                    worldIn.setBlockState(randomPos, Blocks.WET_SPONGE.getDefaultState(), 3);
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -90,6 +90,7 @@
     "LivingEntity_maxCollisionsMixin",
     "ServerWorld_onePlayerSleepingMixin",
     "CoralBlockMixin",
+    "CoralFanBlockMixin",
     "CoralFeatureMixin",
     "BuddingAmethystBlock_movableAmethystMixin",
     "FluidBlock_renewableBlackstoneMixin",


### PR DESCRIPTION
allows you to switch between disabled, coral_only, fan_only and enabled-mode to allow you to also disable/enable growing corals from coral-fans to make them easier to farm.