### PR TITLE
Report exception stack traces through the logger

### DIFF
--- a/src/main/java/carpet/mixins/ServerPlayerEntityMixin.java
+++ b/src/main/java/carpet/mixins/ServerPlayerEntityMixin.java
@@ -6,9 +6,9 @@ import carpet.helpers.EntityPlayerActionPack;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.server.network.ServerPlayerInteractionManager;
 import net.minecraft.server.world.ServerWorld;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -16,7 +16,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ServerPlayerEntity.class)
 public abstract class ServerPlayerEntityMixin implements ServerPlayerEntityInterface
 {
+    @Unique
     public EntityPlayerActionPack actionPack;
+    @Override
     public EntityPlayerActionPack getActionPack()
     {
         return actionPack;
@@ -41,15 +43,11 @@ public abstract class ServerPlayerEntityMixin implements ServerPlayerEntityInter
         }
         catch (StackOverflowError soe)
         {
-            CarpetSettings.LOG.fatal("Caused stack overflow when performing player action");
+            CarpetSettings.LOG.fatal("Caused stack overflow when performing player action", soe);
         }
         catch (Throwable exc)
         {
-            CarpetSettings.LOG.fatal("Error executing player tasks "+ exc.getMessage());
-            exc.printStackTrace();
+            CarpetSettings.LOG.fatal("Error executing player tasks", exc);
         }
     }
-
-
-
 }

--- a/src/main/java/carpet/mixins/StructureFeatureMixin.java
+++ b/src/main/java/carpet/mixins/StructureFeatureMixin.java
@@ -74,8 +74,7 @@ public abstract class StructureFeatureMixin<C extends FeatureConfig> implements 
         }
         catch (Exception booboo)
         {
-            CarpetSettings.LOG.error("Unknown Exception while plopping structure: "+booboo);
-            booboo.printStackTrace();
+            CarpetSettings.LOG.error("Unknown Exception while plopping structure: "+booboo, booboo);
             return false;
         }
         finally

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -1172,7 +1172,7 @@ public class CarpetEventServer
         }
         catch (NullPointerException | InvalidCallbackException | IntegrityException error)
         {
-            CarpetScriptServer.LOG.error("Got exception: "+error.getMessage());
+            CarpetScriptServer.LOG.error("Got exception when running event call ", error);
             return CallbackResult.FAIL;
         }
     }

--- a/src/main/java/carpet/script/Expression.java
+++ b/src/main/java/carpet/script/Expression.java
@@ -377,7 +377,7 @@ public class Expression
         if (exc instanceof ResolvedException)
             return exc;
         // unexpected really - should be caught earlier and converted to InternalExpressionException
-        exc.printStackTrace();
+        CarpetSettings.LOG.error("Unexpected exception while running Scarpet code", exc);
         return new ExpressionException(c, e, token, "Error while evaluating expression: "+exc);
     }
 

--- a/src/main/java/carpet/script/value/Value.java
+++ b/src/main/java/carpet/script/value/Value.java
@@ -1,5 +1,6 @@
 package carpet.script.value;
 
+import carpet.CarpetSettings;
 import carpet.script.exception.InternalExpressionException;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
@@ -42,7 +43,7 @@ public abstract class Value implements Comparable<Value>, Cloneable
         catch (CloneNotSupportedException e)
         {
             // should not happen
-            e.printStackTrace();
+            CarpetSettings.LOG.catching(e);
             throw new InternalExpressionException("Variable of type "+getTypeString()+" is not cloneable. Tell gnembon about it, this shoudn't happen");
         }
         copy.boundVariable = var;

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -315,8 +315,7 @@ public class SettingsManager
         }
         catch (IOException e)
         {
-            e.printStackTrace();
-            CarpetSettings.LOG.error("[CM]: failed write "+identifier+".conf config file");
+            CarpetSettings.LOG.error("[CM]: failed write "+identifier+".conf config file", e);
         }
         ///todo is it really needed? resendCommandTree();
     }
@@ -474,7 +473,7 @@ public class SettingsManager
         }
         catch (IOException e)
         {
-            e.printStackTrace();
+            CarpetSettings.LOG.error("Exception while loading Carpet rules from config", e);
             return new ConfigReadResult(new HashMap<>(), false);
         }
     }

--- a/src/main/java/carpet/utils/SpawnReporter.java
+++ b/src/main/java/carpet/utils/SpawnReporter.java
@@ -33,6 +33,8 @@ import net.minecraft.world.gen.chunk.ChunkGenerator;
 import net.minecraft.world.gen.feature.StructureFeature;
 import org.apache.commons.lang3.tuple.Pair;
 
+import carpet.CarpetSettings;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -454,7 +456,7 @@ public class SpawnReporter
                     }
                     catch (Exception exception)
                     {
-                        exception.printStackTrace();
+                        CarpetSettings.LOG.warn("Exception while creating mob for spawn reporter", exception);
                         return rep;
                     }
                     
@@ -511,7 +513,7 @@ public class SpawnReporter
                             }
                             catch (Exception exception)
                             {
-                                exception.printStackTrace();
+                                CarpetSettings.LOG.warn("Exception while creating mob for spawn reporter", exception);
                                 return rep;
                             }
                         }


### PR DESCRIPTION
Makes exceptions report their stack traces through the Carpet logger.

Else Java prints them to `System.out` (or `System.err`, not sure), which is replaced by the game and doesn't handle it as an exception, but prints every single line separately and makes a bit of a mess.