### PR TITLE
Make ErrorSnooper report values for locals in the stacktrace

### DIFF
--- a/src/main/java/carpet/script/CarpetScriptHost.java
+++ b/src/main/java/carpet/script/CarpetScriptHost.java
@@ -1104,8 +1104,14 @@ public class CarpetScriptHost extends ScriptHost
                 continue;
             stringsToFormat.add(format + line.substring(lastPos, foundLocal.getKey()));
             stringsToFormat.add(format + foundLocal.getValue());
+            String value;
+            try {
+                value = context.variables.get(foundLocal.getValue()).evalValue(context).getPrettyString();
+            } catch (StackOverflowError e) {
+                value = "Exception while rendering variable, there seems to be a recursive reference in there";
+            }
             stringsToFormat.add("^ Value of '" + foundLocal.getValue() + "' at position: \n"
-                        + context.variables.get(foundLocal.getValue()).evalValue(context).getPrettyString()); // can this throw? Should this have a catch?
+                        + value);
             lastPos = foundLocal.getKey() + foundLocal.getValue().length();
         }
         if (line.length() != lastPos)

--- a/src/main/java/carpet/script/ScriptHost.java
+++ b/src/main/java/carpet/script/ScriptHost.java
@@ -108,7 +108,7 @@ public abstract class ScriptHost
     @FunctionalInterface
     public interface ErrorSnooper
     {
-        List<String> apply(Expression expression, Tokenizer.Token token, String message);
+        List<String> apply(Expression expression, Tokenizer.Token token, Context context, String message);
     }
     public ErrorSnooper errorSnooper = null;
 

--- a/src/main/java/carpet/script/exception/ExpressionException.java
+++ b/src/main/java/carpet/script/exception/ExpressionException.java
@@ -74,8 +74,8 @@ public class ExpressionException extends RuntimeException implements ResolvedExc
     {
         if (c.getErrorSnooper() != null)
         {
-            List<String> alternative = c.getErrorSnooper().apply(e, t, message);
-            if (alternative!= null)
+            List<String> alternative = c.getErrorSnooper().apply(e, t, c, message);
+            if (alternative != null)
             {
                 return String.join("\n", alternative);
             }


### PR DESCRIPTION
Resolves #1051.

This PR adds a hover over tooltip for references to locals in the exception's stacktrace. It does so by trying to find the variables in the Strings directly, so there can be false positives (though _many_ of those that cause actual variables to not be available should be handled by the logic).

Things I'm not sure about: Should ErrorSnooper instead ask for the entire `ExpressionException`, since it uses most of it anyway? Should the color of the tooltip be changed to gray (or some other color)? Should the `evalValue` for locals be inside a try-catch in case there's a possibility for another exception to be thrown in there?