### PR TITLE
Move some functions into `system_info`

### DIFF
--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -540,6 +540,8 @@ Returns server tick counter. Can be used to run certain operations every n-th ti
 
 ### `world_time()`
 
+_**Deprecated**. Use `system_info('world_time')` instead._
+
 Returns dimension-specific tick counter.
 
 ### `day_time(new_time?)`
@@ -548,6 +550,8 @@ Returns current daytime clock value. If `new_time` is specified, sets a new cloc
 to that value. Daytime clocks are shared between all dimensions.
 
 ### `last_tick_times()`
+
+_**Deprecated**. Use `system_info('server_last_tick_times')` instead._
 
 Returns a 100-long array of recent tick times, in milliseconds. First item on the list is the most recent tick
 If called outside of the main tick (either throgh scheduled tasks, or async execution), then the first item on the
@@ -600,6 +604,9 @@ world-localized block, so not `block('stone')`, or a string representing a dimen
 Throws `unknown_dimension` if provided dimension can't be found.
  
 ### `view_distance()`
+
+_**Deprecated**. Use `system_info('server_view_distance')` instead._
+
 Returns the view distance of the server.
 
 ### `get_mob_counts()`, `get_mob_counts(category)` 1.16+

--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -21,6 +21,7 @@ import carpet.script.exception.InternalExpressionException;
 import carpet.script.exception.ThrowStatement;
 import carpet.script.exception.Throwables;
 import carpet.script.utils.SnoopyCommandSource;
+import carpet.script.utils.SystemInfo;
 import carpet.script.utils.InputValidator;
 import carpet.script.utils.ScarpetJsonDeserializer;
 import carpet.script.utils.ShapeDispatcher;
@@ -655,8 +656,10 @@ public class Auxiliary {
         expression.addContextFunction("tick_time", 0, (c, t, lv) ->
                 new NumericValue(((CarpetContext) c).s.getServer().getTicks()));
 
-        expression.addContextFunction("world_time", 0, (c, t, lv) ->
-                new NumericValue(((CarpetContext) c).s.getWorld().getTime()));
+        expression.addContextFunction("world_time", 0, (c, t, lv) -> {
+            c.host.issueDeprecation("world_time()");
+            return new NumericValue(((CarpetContext) c).s.getWorld().getTime());
+        });
 
         expression.addContextFunction("day_time", -1, (c, t, lv) ->
         {
@@ -672,16 +675,8 @@ public class Auxiliary {
 
         expression.addContextFunction("last_tick_times", -1, (c, t, lv) ->
         {
-            //assuming we are in the tick world section
-            // might be off one tick when run in the off tasks or asynchronously.
-            int currentReportedTick = ((CarpetContext) c).s.getServer().getTicks()-1;
-            List<Value> ticks = new ArrayList<>(100);
-            final long[] tickArray = ((CarpetContext) c).s.getServer().lastTickLengths;
-            for (int i=currentReportedTick+100; i > currentReportedTick; i--)
-            {
-                ticks.add(new NumericValue(((double)tickArray[i % 100])/1000000.0));
-            }
-            return ListValue.wrap(ticks);
+            c.host.issueDeprecation("last_tick_times()");
+            return SystemInfo.get("last_tick_times", (CarpetContext)c);
         });
 
 
@@ -742,8 +737,10 @@ public class Auxiliary {
         expression.addContextFunction("current_dimension", 0, (c, t, lv) ->
                 ValueConversions.of( ((CarpetContext)c).s.getWorld()));
 
-        expression.addContextFunction("view_distance", 0, (c, t, lv) ->
-                new NumericValue(((CarpetContext)c).s.getServer().getPlayerManager().getViewDistance()));
+        expression.addContextFunction("view_distance", 0, (c, t, lv) -> {
+            c.host.issueDeprecation("view_distance()");
+            return new NumericValue(((CarpetContext)c).s.getServer().getPlayerManager().getViewDistance());
+        });
 
         // lazy due to passthrough and context changing ability
         expression.addLazyFunction("in_dimension", 2, (c, t, lv) -> {

--- a/src/main/java/carpet/script/utils/SystemInfo.java
+++ b/src/main/java/carpet/script/utils/SystemInfo.java
@@ -23,9 +23,11 @@ import net.minecraft.world.WorldProperties;
 
 import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -58,6 +60,7 @@ public class SystemInfo {
             WorldProperties prop = c.s.getServer().getOverworld().getLevelProperties();
             return ListValue.of(NumericValue.of(prop.getSpawnX()), NumericValue.of(prop.getSpawnY()), NumericValue.of(prop.getSpawnZ()));
         });
+        put("world_time", c -> new NumericValue(c.s.getWorld().getTime()));
 
         put("game_difficulty", c -> StringValue.of(c.s.getServer().getSaveProperties().getDifficulty().getName()));
         put("game_hardcore", c -> BooleanValue.of(c.s.getServer().getSaveProperties().isHardcore()));
@@ -113,6 +116,18 @@ public class SystemInfo {
             for (ModContainer mod : FabricLoader.getInstance().getAllMods())
                 ret.put(new StringValue(mod.getMetadata().getName()), new StringValue(mod.getMetadata().getVersion().getFriendlyString()));
             return MapValue.wrap(ret);
+        });
+        put("server_last_tick_times", c -> {
+        	//assuming we are in the tick world section
+            // might be off one tick when run in the off tasks or asynchronously.
+            int currentReportedTick = c.s.getServer().getTicks()-1;
+            List<Value> ticks = new ArrayList<>(100);
+            final long[] tickArray = c.s.getServer().lastTickLengths;
+            for (int i=currentReportedTick+100; i > currentReportedTick; i--)
+            {
+                ticks.add(new NumericValue(((double)tickArray[i % 100])/1000000.0));
+            }
+            return ListValue.wrap(ticks);
         });
 
         put("java_max_memory", c -> new NumericValue(Runtime.getRuntime().maxMemory()));


### PR DESCRIPTION
Moves the functions accepted to be moved in #560 into `system_info()`, and deprecates their current variants.

Affected functions are:
- [`view_distance()`](https://github.com/gnembon/fabric-carpet/blob/master/docs/scarpet/api/Auxiliary.md#system_info-system_infoproperty) -> `system_info('game_view_distance')`, that was already on `system_info()` so it has only been deprecated
- [`world_time()`](https://github.com/gnembon/fabric-carpet/blob/master/docs/scarpet/Full.md#world_time) -> `system_info('world_time')`
- [`last_tick_times()`](https://github.com/gnembon/fabric-carpet/blob/master/docs/scarpet/Full.md#last_tick_times) -> `system_info('server_last_tick_times')`