### PR TITLE
Initial work on a Mixin error handler

### DIFF
--- a/src/main/java/carpet/CarpetServer.java
+++ b/src/main/java/carpet/CarpetServer.java
@@ -17,6 +17,8 @@ import carpet.commands.ScriptCommand;
 import carpet.commands.SpawnCommand;
 import carpet.commands.TestCommand;
 import carpet.commands.TickCommand;
+import carpet.compat.CarpetMixinErrorHandler;
+import carpet.compat.FabricAPIHooks;
 import carpet.network.ServerNetworkHandler;
 import carpet.helpers.HopperCounter;
 import carpet.helpers.TickSpeed;
@@ -24,7 +26,6 @@ import carpet.logging.LoggerRegistry;
 import carpet.script.CarpetScriptServer;
 import carpet.settings.SettingsManager;
 import carpet.logging.HUDController;
-import carpet.utils.FabricAPIHooks;
 import carpet.utils.MobAI;
 import carpet.utils.SpawnReporter;
 import com.mojang.brigadier.CommandDispatcher;
@@ -75,6 +76,7 @@ public class CarpetServer // static for now - easier to handle all around the co
         settingsManager.parseSettingsClass(CarpetSettings.class);
         extensions.forEach(CarpetExtension::onGameStarted);
         FabricAPIHooks.initialize();
+        CarpetMixinErrorHandler.setGameReady();
         CarpetScriptServer.parseFunctionClasses();
     }
 

--- a/src/main/java/carpet/compat/CarpetMixinErrorHandler.java
+++ b/src/main/java/carpet/compat/CarpetMixinErrorHandler.java
@@ -1,0 +1,155 @@
+package carpet.compat;
+
+import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mixins;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfig;
+import org.spongepowered.asm.mixin.extensibility.IMixinErrorHandler;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import carpet.CarpetServer;
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+/**
+ * <p>Class Handles errors when applying mixins and just disables the rule instead of crashing the game</p>
+ *
+ */
+public class CarpetMixinErrorHandler implements IMixinErrorHandler, PreLaunchEntrypoint {
+	private static final Logger LOGGER = LogManager.getLogger("Carpet Mixin Error Handler");
+	private static volatile boolean isGameReady = false;
+	private static final Set<FeatureMixin> featuresToDisable = new HashSet<>();
+	private static final MethodHandle getAnnotationNode;
+	private static final MethodHandle getAnnotationValue;
+	
+	// Called on PreLaunch
+	static {
+		// Potentially accessing mixin internals here, so we use MethodHandles just in case and catch their exceptions. If they throw, we disable this
+		MethodHandle getAnnotationNode0 = null, getAnnotationValue0 = null;
+		try {
+			Class<?> annotationsClass = Class.forName("org.spongepowered.asm.util.Annotations");
+			getAnnotationNode0 = MethodHandles.lookup().findStatic(annotationsClass, "getInvisible",
+					MethodType.methodType(AnnotationNode.class, ClassNode.class, Class.class));
+			getAnnotationValue0 = MethodHandles.lookup().findStatic(annotationsClass, "getValue",
+					MethodType.methodType(Object.class, AnnotationNode.class, String.class, Class.class));
+		} catch (Exception e) {
+			getAnnotationNode0 = null;
+			LOGGER.info("Failed to setup Carpet's Mixin Error Handler. That compatibility layer will not be available", e);
+		}
+		getAnnotationNode = getAnnotationNode0;
+		getAnnotationValue = getAnnotationValue0;
+	}
+	
+	@Override
+	public void onPreLaunch() {
+		if (getAnnotationNode == null) return; // Don't register if something failed during initialization
+		try {
+			Mixins.registerErrorHandlerClass(this.getClass().getName());
+		} catch (LinkageError err) { //I'm 99% sure this is public API, but just in case, this is here
+			LOGGER.info("Failed to setup Carpet's Mixin Error Handler. That compatibility layer will not be available", err);
+		}
+	}
+	
+	@Override
+	public ErrorAction onPrepareError(IMixinConfig config, Throwable th, IMixinInfo mixinInfo, ErrorAction action) {
+		if (action != ErrorAction.ERROR) // Ignore warns or other things that are already handled
+			return null;
+		AnnotationNode node = getFeatureAnnotationNode(mixinInfo.getClassNode(ClassReader.EXPAND_FRAMES)); //TODO is the flag needed?
+		if (!canSkipMixin(node)) {
+			return null; // Crash! It may be a mandatory mixin of ours, or just some random mixin from someone else
+		}
+		FeatureMixin feature = new VirtualFeatureMixin(node);
+		if (isGameReady) {
+			disableRule(feature);
+		} else {
+			featuresToDisable.add(feature);
+		}
+		return ErrorAction.WARN;
+	}
+	
+	@Override
+	public ErrorAction onApplyError(String targetClassName, Throwable th, IMixinInfo mixin, ErrorAction action) {
+		// Not catching apply, since the class can be in any state? (TODO: Check that's true)
+		return null;
+	}
+	
+	private static boolean canSkipMixin(AnnotationNode node) {
+		return node != null; // Anything annotated with FeatureMixin can be skipped atm, the rule will just be disabled
+	}
+	
+	private static void disableRule(FeatureMixin feature) {
+		String rule = feature.value();
+		if (!feature.settingsManager().equals("carpet")) {
+			throw new NotImplementedException("Disabling rules from other extensions in Mixin errors is not implemented!");
+		}
+		CarpetServer.settingsManager.getRule(rule);
+	}
+	
+	/**
+	 * <p>Marks that the game is ready to be referenced and disables all rules scheduled to be disabled.</p>
+	 */
+	public static void setGameReady() {
+		if (isGameReady) throw new IllegalStateException("Game has already been declared as ready!");
+		isGameReady = true;
+		for (FeatureMixin feature : featuresToDisable) {
+			disableRule(feature);
+		}
+		featuresToDisable.clear();
+	}
+	
+	private static AnnotationNode getFeatureAnnotationNode(ClassNode node) {
+		try {
+			return (AnnotationNode) getAnnotationNode.invokeExact(node, FeatureMixin.class);
+		} catch (Throwable e) {
+			if (e instanceof Error)
+				throw (Error) e;
+			throw (RuntimeException) e; // Doesn't throw checked
+		}
+	}
+	
+	private static <T> T getValue(AnnotationNode annotation, String key, Class<? extends Annotation> annotationType) {
+		try {
+			return (T) getAnnotationValue.invokeExact(annotation, key, Mixin.class);
+		} catch (Throwable e) {
+			if (e instanceof Error)
+				throw (Error) e;
+			throw (RuntimeException) e; // Doesn't throw checked
+		}
+	}
+
+	/**
+	 * <p>A fake FeatureMixin annotation, since we can't get the actual annotation because Mixin classes are not thought to
+	 * be loaded by the JVM, and trying to get the annotation would load the class by referencing it.</p>
+	 * 
+	 * <p>Record so it implements {@link #equals(Object)} and {@link #hashCode()} easily</p>
+	 */
+	static record VirtualFeatureMixin(String value, String settingsManager) implements FeatureMixin {
+		/**
+		 * Constructs a new VirtualFeatureMixin from the data in the given {@link AnnotationNode}
+		 * @param node An {@link AnnotationNode} corresponding to a FeatureMixin annotation
+		 */
+		public VirtualFeatureMixin(AnnotationNode node) {
+			this(
+				/* value = */ getValue(node, "value", FeatureMixin.class),
+				/* settingsManager = */ getValue(node, "settingsManager", FeatureMixin.class)
+			);
+		}
+
+		@Override
+		public Class<? extends Annotation> annotationType() {
+			return FeatureMixin.class;
+		}
+		
+	}
+}

--- a/src/main/java/carpet/compat/FabricAPIHooks.java
+++ b/src/main/java/carpet/compat/FabricAPIHooks.java
@@ -1,4 +1,4 @@
-package carpet.utils;
+package carpet.compat;
 
 import carpet.network.CarpetClient;
 import com.mojang.blaze3d.systems.RenderSystem;

--- a/src/main/java/carpet/compat/FeatureMixin.java
+++ b/src/main/java/carpet/compat/FeatureMixin.java
@@ -1,0 +1,40 @@
+package carpet.compat;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import carpet.settings.SettingsManager;
+
+
+/**
+ * <p>Marks that this {@link Mixin} is completely related to a specific feature, and is not required for the rest of Carpet to work.</p> 
+ *
+ * <p>This allows errors regarding this {@link Mixin} to be converted into a warn in exchange of that feature not being available in the game.</p>
+ * 
+ * <p>If a Mixin is just not necessary even for that feature, consider marking it as {@code require = 0} instead, as this will disable the feature</p>
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface FeatureMixin {
+	
+	/**
+	 * <p>The name of the rule this {@link Mixin} is for. It will be used to disable it if the Mixin fails.</p>
+	 */
+	public String value();
+	
+	/**
+	 * <p>Defines the {@link SettingsManager} this Mixin's rules are related available into.</p>
+	 * 
+	 * <p>Defaults to Carpet's, but can be changed for extensions to use this system.</p>
+	 * 
+	 * <p><b>THIS FUNCTIONALITY IS NOT IMPLEMENTED YET</b></p>
+	 */
+	String settingsManager() default "carpet";
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,6 +24,9 @@
     ],
     "server": [
       "carpet.CarpetServer::SERVER_INITIALIZER"
+    ],
+    "preLaunch": [ 
+      "carpet.compat.CarpetMixinErrorHandler"
     ]
   },
   "mixins": [


### PR DESCRIPTION
This is thought to handle mixin conflicts of _specific_ (not important) features and instead of crashing the game, printing a warning and disabling the rule from being changed (not sure how to handle `carpet.conf` having it already set yet).

Why? Because Carpet (and extensions, official or community) have many, many rules, and most people will not use them all. This allows them to play with some Carpet features and mods that conflict with the features that they don't use.

Current progress is the actual errorhandler, an annotation to specify the rule to disable and the entrypoint to set it up.

What's missing is actually disabling the rule, absolutely any testing, and any other TODOs I've left in the code. Maybe also a MixinConfig to stop applying extra mixins for a disabled feature, but not sure if worth it (feels unnecessary as long as all mixin'd features have proper checks against rules). Also now that I think about it this should be disabled in a dev environment.

Also moves FabricAPIHooks into a new `compat` package with this.

What do you think about the concept? Is it a good idea or should I leave it? (ignore the implementation for now, most of it could probably be better, mostly the access of some Mixin internals could be replaced with its API and some asm, but I don't really know ASM atm, so it's for convenience).