### PR TITLE
allow specifying default game modes of /player spawned players

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -20,6 +20,7 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.registry.Registry;
+import net.minecraft.world.GameMode;
 import net.minecraft.world.World;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -957,6 +958,12 @@ public class CarpetSettings
             validate = updateSuppressionBlockModes.class
     )
     public static String updateSuppressionBlock = "false";
+
+    @Rule(
+            desc = "Define the default game mode of /player spawn players when Carpet fails to obtain the current game mode of the calling player.",
+            category = COMMAND
+    )
+    public static GameMode playerCommandDefaultGameMode = GameMode.CREATIVE;
 
     public static int getInteger(String s) {
         try {

--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -264,7 +264,7 @@ public class PlayerCommand
                 () -> DimensionArgumentType.getDimensionArgument(context, "dimension").getRegistryKey(),
                 () -> source.getWorld().getRegistryKey() // dimension.getType()
         );
-        GameMode mode = GameMode.CREATIVE;
+        GameMode mode = CarpetSettings.playerCommandDefaultGameMode;
         boolean flying = false;
         try
         {


### PR DESCRIPTION
Our survival server is using rcon to spawn bot players. However, currently Carpet sets their game modes to creative if the spawn command is not from a player. This behaviour causes troubles in a survival server. The best solution is to allow administrators to specify the default game mode of bots.