### PR TITLE
Added Non Movable Block List check

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -24,7 +24,9 @@ import net.minecraft.world.World;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -331,7 +333,34 @@ public class CarpetSettings
 
     @Rule( desc = "Pistons can push block entities, like hoppers, chests etc.", category = {EXPERIMENTAL, FEATURE} )
     public static boolean movableBlockEntities = false;
-
+    
+    @Rule(
+    		desc = "Changes the blocks in the Non Movable Block List",
+    		options = {"minecraft:chest", "minecraft:hopper", "minecraft:dropper", "minecraft:dispenser", "minecraft:grindstone"},
+    		category = CREATIVE,
+    		validate = NonMovableBlockValidator.class,
+    		strict = false
+    )
+	public static String nonMovableBlocks = "minecraft:ender_chest,minecraft:enchanting_table,minecraft:end_gateway,minecraft:end_portal,minecraft:moving_piston,minecraft:spawner";
+	public static List<Block> nonMovableBlocksList = new ArrayList<>();
+	
+	public static class NonMovableBlockValidator extends Validator<String> {
+		@Override
+		public String validate(ServerCommandSource source, ParsedRule<String> currentRule, String newValue,
+				String string) {
+			nonMovableBlocksList.clear();
+			String[] stringList = newValue.split(",");
+			for(String s : stringList) {
+				Optional<Block> block = Registry.BLOCK.getOrEmpty(Identifier.tryParse(s.trim()));
+				if (!block.isPresent()) {
+					Messenger.m(source, "r Unknown block '" + s.trim() + "'.");
+				} else {
+					nonMovableBlocksList.add(block.get());
+				}
+			}
+			return newValue;
+		}
+	}
 
     private static class ChainStoneSetting extends Validator<String> {
         @Override public String validate(ServerCommandSource source, ParsedRule<String> currentRule, String newValue, String string) {

--- a/src/main/java/carpet/mixins/PistonBlock_movableTEMixin.java
+++ b/src/main/java/carpet/mixins/PistonBlock_movableTEMixin.java
@@ -42,14 +42,6 @@ public abstract class PistonBlock_movableTEMixin extends FacingBlock
         }
     }
     
-    private static boolean isPushableBlockEntity(Block block)
-    {
-        //Making PISTON_EXTENSION (BlockPistonMoving) pushable would not work as its createNewTileEntity()-method returns null
-        return block != Blocks.ENDER_CHEST && block != Blocks.ENCHANTING_TABLE &&
-                       block != Blocks.END_GATEWAY && block != Blocks.END_PORTAL && block != Blocks.MOVING_PISTON  &&
-                       block != Blocks.SPAWNER;
-    }
-    
     @Redirect(method = "isMovable", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;hasBlockEntity()Z"))
     private static boolean ifHasBlockEntity(BlockState blockState)
     {
@@ -59,7 +51,7 @@ public abstract class PistonBlock_movableTEMixin extends FacingBlock
         }
         else
         {
-            return !(CarpetSettings.movableBlockEntities && isPushableBlockEntity(blockState.getBlock()));
+            return !(CarpetSettings.movableBlockEntities && !CarpetSettings.nonMovableBlocksList.contains(blockState.getBlock()));
         }
     }
 
@@ -69,7 +61,7 @@ public abstract class PistonBlock_movableTEMixin extends FacingBlock
     ))
     private static PistonBehavior moveGrindstones(BlockState blockState)
     {
-        if (CarpetSettings.movableBlockEntities && blockState.getBlock() == Blocks.GRINDSTONE) return PistonBehavior.NORMAL;
+        if (CarpetSettings.movableBlockEntities && blockState.getBlock() == Blocks.GRINDSTONE && !CarpetSettings.nonMovableBlocksList.contains(blockState.getBlock())) return PistonBehavior.NORMAL;
         return blockState.getPistonBehavior();
     }
 


### PR DESCRIPTION
This patch was designed to fix #1096 but it technically could be easily extended to prevent any sort of block from being pushed by a piston. Im not really sure if that would be a very useful feature so I just went with the original patch of just adding a way to configure which tile entities could be moved. I was also not completely sure about the implementaiton I should go with for saving a list in the configuration file since I couldn't find any anyone else using a list. I just went with a really basic comma seperated list since it was pretty simple and I thought it would be be easily understood in the config.