### PR TITLE
Settings rework and encapsulation

### DIFF
--- a/src/main/java/carpet/CarpetExtension.java
+++ b/src/main/java/carpet/CarpetExtension.java
@@ -7,6 +7,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 
+import java.util.Collections;
 import java.util.Map;
 
 public interface CarpetExtension
@@ -115,10 +116,10 @@ public interface CarpetExtension
      * 
      * @param lang A {@link String} being the language id selected by the user
      * @return A {@link Map<String, String>} containing the string key with it's 
-     *         respective translation {@link String} or {@link null} if not available
+     *         respective translation {@link String} or an empty map if not available
      * 
      */
-    default Map<String, String> canHasTranslations(String lang) { return null;}
+    default Map<String, String> canHasTranslations(String lang) { return Collections.emptyMap();}
 
     /**
      * Handles each call that creates / parses the scarpet expression.

--- a/src/main/java/carpet/CarpetServer.java
+++ b/src/main/java/carpet/CarpetServer.java
@@ -115,10 +115,6 @@ public class CarpetServer // static for now - easier to handle all around the co
         extensions.forEach(e -> e.onTick(server));
     }
 
-    @Deprecated
-    public static void registerCarpetCommands(CommandDispatcher<ServerCommandSource> dispatcher) {
-    }
-
     public static void registerCarpetCommands(CommandDispatcher<ServerCommandSource> dispatcher, CommandManager.RegistrationEnvironment environment)
     {
         settingsManager.registerCommand(dispatcher);

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -332,9 +332,9 @@ public class CarpetSettings
 
     public static enum ChainStoneSetting {
         TRUE, FALSE, STICK_TO_ALL;
-    	public boolean doChainStone() {
-    		return this != FALSE;
-    	}
+        public boolean doChainStone() {
+            return this != FALSE;
+        }
     }
 
     @Rule(

--- a/src/main/java/carpet/mixins/CommandManagerMixin.java
+++ b/src/main/java/carpet/mixins/CommandManagerMixin.java
@@ -25,9 +25,8 @@ public abstract class CommandManagerMixin
     private CommandDispatcher<ServerCommandSource> dispatcher;
 
     @Inject(method = "<init>", at = @At("RETURN"))
-    private void onRegister(CommandManager.RegistrationEnvironment arg, CallbackInfo ci) {
-        CarpetServer.registerCarpetCommands(this.dispatcher);
-        CarpetServer.registerCarpetCommands(this.dispatcher, arg);
+    private void onRegister(CommandManager.RegistrationEnvironment env, CallbackInfo ci) {
+        CarpetServer.registerCarpetCommands(this.dispatcher, env);
     }
 
     @Inject(method = "execute", at = @At("HEAD"))

--- a/src/main/java/carpet/mixins/MinecraftServer_coreMixin.java
+++ b/src/main/java/carpet/mixins/MinecraftServer_coreMixin.java
@@ -62,6 +62,6 @@ public abstract class MinecraftServer_coreMixin
         if (CarpetSettings.spawnChunksSize != 11)
             CarpetSettings.ChangeSpawnChunksValidator.changeSpawnSize(CarpetSettings.spawnChunksSize);
         
-        CarpetSettings.LightBatchValidator.applyLightBatchSizes();
+        CarpetSettings.LightBatchValidator.applyLightBatchSizes(CarpetSettings.lightEngineMaxBatchSize);
     }
 }

--- a/src/main/java/carpet/mixins/PistonHandler_customStickyMixin.java
+++ b/src/main/java/carpet/mixins/PistonHandler_customStickyMixin.java
@@ -88,7 +88,7 @@ public abstract class PistonHandler_customStickyMixin
             //if(block == Blocks.STICKY_PISTON)
             //    return blockState.get(FacingBlock.FACING) == motionDirection;
         }
-        if (CarpetSettings.doChainStone && blockState.getBlock() == Blocks.CHAIN)
+        if (CarpetSettings.chainStone.doChainStone() && blockState.getBlock() == Blocks.CHAIN)
         {
             return isChainOnAxis(currentState, motionDirection);
         }
@@ -109,12 +109,12 @@ public abstract class PistonHandler_customStickyMixin
     )
     private boolean isDraggingPreviousBlockBehind(BlockState previous, BlockState next)
     {
-        if (CarpetSettings.doChainStone)
+        if (CarpetSettings.chainStone.doChainStone())
         {
             if (previous.getBlock() == Blocks.CHAIN && isChainOnAxis(previous, motionDirection))
             {
                 if ( (next.getBlock() == Blocks.CHAIN && isChainOnAxis(next, motionDirection))
-                        || CarpetSettings.chainStoneStickToAll
+                        || CarpetSettings.chainStone == CarpetSettings.ChainStoneSetting.STICK_TO_ALL
                         || isEndRodOnAxis(next, motionDirection.getAxis())
                         || Block.sideCoversSmallSquare(world, currentPos, motionDirection))
                 {
@@ -163,7 +163,7 @@ public abstract class PistonHandler_customStickyMixin
             }
         }
 
-        if (CarpetSettings.doChainStone)
+        if (CarpetSettings.chainStone.doChainStone())
         {
             BlockPos pos = this.movedBlocks.get(int_1);
             BlockState chainState = world.getBlockState(pos);
@@ -214,7 +214,7 @@ public abstract class PistonHandler_customStickyMixin
     private void redirectIsStickyBlock(BlockPos pos, Direction dir, CallbackInfoReturnable<Boolean> cir,
                                        BlockState blockState, int i, int j, int l, BlockPos blockPos2, int m, int n, BlockPos blockPos3)
     {
-        if (CarpetSettings.doChainStone)
+        if (CarpetSettings.chainStone.doChainStone())
         {
             BlockState chainState = world.getBlockState(blockPos3);
             if (chainState.getBlock() == Blocks.CHAIN && !isChainOnAxis(chainState, motionDirection) && !tryMoveAdjacentBlock(blockPos3))
@@ -236,13 +236,13 @@ public abstract class PistonHandler_customStickyMixin
     private void otherSideStickyCases(BlockPos pos, CallbackInfoReturnable<Boolean> cir,
                                       BlockState blockState, Direction var3[], int var4, int var5, Direction direction, BlockPos blockPos, BlockState blockState2)
     {
-        if (CarpetSettings.doChainStone)
+        if (CarpetSettings.chainStone.doChainStone())
         {
             if (blockState.getBlock() == Blocks.CHAIN && isChainOnAxis(blockState, direction) && !blockState2.isAir())
             {
                 Block otherBlock = blockState2.getBlock();
                 if ((otherBlock == Blocks.CHAIN && (blockState.get(ChainBlock.AXIS) == blockState2.get(ChainBlock.AXIS)))
-                        || CarpetSettings.chainStoneStickToAll
+                        || CarpetSettings.chainStone == CarpetSettings.ChainStoneSetting.STICK_TO_ALL
                         || isEndRodOnAxis(blockState2, blockState.get(ChainBlock.AXIS))
                         || otherBlock == Blocks.HONEY_BLOCK
                         || Block.sideCoversSmallSquare(world, blockPos, direction.getOpposite()))

--- a/src/main/java/carpet/network/ClientNetworkHandler.java
+++ b/src/main/java/carpet/network/ClientNetworkHandler.java
@@ -4,7 +4,8 @@ import carpet.CarpetServer;
 import carpet.CarpetExtension;
 import carpet.CarpetSettings;
 import carpet.helpers.TickSpeed;
-import carpet.settings.ParsedRule;
+import carpet.settings.CarpetRule;
+import carpet.settings.InvalidRuleValueException;
 import carpet.settings.SettingsManager;
 import io.netty.buffer.Unpooled;
 import net.minecraft.client.network.ClientPlayerEntity;
@@ -22,7 +23,7 @@ import java.util.function.BiConsumer;
 
 public class ClientNetworkHandler
 {
-    private static final Map<String, BiConsumer<ClientPlayerEntity, NbtElement>> dataHandlers = new HashMap<String, BiConsumer<ClientPlayerEntity, NbtElement>>();
+    private static final Map<String, BiConsumer<ClientPlayerEntity, NbtElement>> dataHandlers = new HashMap<>();
     static
     {
         dataHandlers.put("Rules", (p, t) -> {
@@ -57,11 +58,11 @@ public class ClientNetworkHandler
                     manager = CarpetServer.settingsManager;
                     ruleName = ruleKey;
                 }
-                ParsedRule<?> rule = (manager != null) ? manager.getRule(ruleName) : null;
+                CarpetRule<?> rule = (manager != null) ? manager.getCarpetRule(ruleName) : null;
                 if (rule != null)
                 {
                     String value = ruleNBT.getString("Value");
-                    try { rule.set(null, value); } catch (Exception ignored) { }
+                    try { rule.set(null, value); } catch (InvalidRuleValueException ignored) { }
                 }
             }
         });

--- a/src/main/java/carpet/network/ServerNetworkHandler.java
+++ b/src/main/java/carpet/network/ServerNetworkHandler.java
@@ -4,7 +4,8 @@ import carpet.CarpetServer;
 import carpet.CarpetSettings;
 import carpet.helpers.TickSpeed;
 import carpet.script.utils.SnoopyCommandSource;
-import carpet.settings.ParsedRule;
+import carpet.settings.CarpetRule;
+import carpet.settings.RuleHelper;
 import carpet.settings.SettingsManager;
 import io.netty.buffer.Unpooled;
 import net.minecraft.nbt.NbtCompound;
@@ -78,11 +79,11 @@ public class ServerNetworkHandler
         else
             CarpetSettings.LOG.warn("Player "+playerEntity.getName().getString()+" joined with another carpet version: "+clientVersion);
         DataBuilder data = DataBuilder.create().withTickRate().withFrozenState().withTickPlayerActiveTimeout(); // .withSuperHotState()
-        CarpetServer.settingsManager.getRules().forEach(data::withRule);
+        CarpetServer.settingsManager.getCarpetRules().forEach(data::withRule);
         CarpetServer.extensions.forEach(e -> {
             SettingsManager eManager = e.customSettingsManager();
             if (eManager != null) {
-                eManager.getRules().forEach(data::withRule);
+                eManager.getCarpetRules().forEach(data::withRule);
             }
         });
         playerEntity.networkHandler.sendPacket(new CustomPayloadS2CPacket(CarpetClient.CARPET_CHANNEL, data.build() ));
@@ -133,7 +134,7 @@ public class ServerNetworkHandler
         }
     }
 
-    public static void updateRuleWithConnectedClients(ParsedRule<?> rule)
+    public static void updateRuleWithConnectedClients(CarpetRule<?> rule)
     {
         if (CarpetSettings.superSecretSetting) return;
         for (ServerPlayerEntity player : remoteCarpetPlayers.keySet())
@@ -278,7 +279,7 @@ public class ServerNetworkHandler
             tag.putInt("TickPlayerActiveTimeout", TickSpeed.player_active_timeout);
             return this;
         }
-        private DataBuilder withRule(ParsedRule<?> rule)
+        private DataBuilder withRule(CarpetRule<?> rule)
         {
             NbtCompound rules = (NbtCompound) tag.get("Rules");
             if (rules == null)
@@ -286,13 +287,13 @@ public class ServerNetworkHandler
                 rules = new NbtCompound();
                 tag.put("Rules", rules);
             }
-            String identifier = rule.settingsManager.getIdentifier();
-            String key = rule.name;
+            String identifier = rule.settingsManager().getIdentifier();
+            String key = rule.name();
             while (rules.contains(key)) { key = key+"2";}
             NbtCompound ruleNBT = new NbtCompound();
-            ruleNBT.putString("Value", rule.getAsString());
-            ruleNBT.putString("Manager",identifier);
-            ruleNBT.putString("Rule",rule.name);
+            ruleNBT.putString("Value", RuleHelper.toRuleString(rule.value()));
+            ruleNBT.putString("Manager", identifier);
+            ruleNBT.putString("Rule", rule.name());
             rules.put(key, ruleNBT);
             return this;
         }

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -16,7 +16,8 @@ import carpet.script.value.NumericValue;
 import carpet.script.value.StringValue;
 import carpet.script.value.Value;
 import carpet.script.value.ValueConversions;
-import carpet.settings.ParsedRule;
+import carpet.settings.CarpetRule;
+import carpet.settings.RuleHelper;
 import carpet.utils.CarpetProfiler;
 import carpet.utils.Messenger;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
@@ -855,9 +856,9 @@ public class CarpetEventServer
         public static final Event CARPET_RULE_CHANGES = new Event("carpet_rule_changes", 2, true)
         {
             @Override
-            public void onCarpetRuleChanges(ParsedRule<?> rule, ServerCommandSource source)
+            public void onCarpetRuleChanges(CarpetRule<?> rule, ServerCommandSource source)
             {
-                String identifier = rule.settingsManager.getIdentifier();
+                String identifier = rule.settingsManager().getIdentifier();
                 final String namespace;
                 if (!identifier.equals("carpet")) 
                 {
@@ -865,8 +866,8 @@ public class CarpetEventServer
                 } else { namespace = "";}
                 handler.call(
                         () -> Arrays.asList(
-                                new StringValue(namespace+rule.name),
-                                new StringValue(rule.getAsString())
+                                new StringValue(namespace+rule.name()),
+                                new StringValue(RuleHelper.toRuleString(rule.value()))
                         ), () -> source
                 );
             }
@@ -1070,7 +1071,7 @@ public class CarpetEventServer
         public void onExplosion(ServerWorld world, Entity e,  Supplier<LivingEntity> attacker, double x, double y, double z, float power, boolean createFire, List<BlockPos> affectedBlocks, List<Entity> affectedEntities, Explosion.DestructionType type) { }
         public void onWorldEvent(ServerWorld world, BlockPos pos) { }
         public void onWorldEventFlag(ServerWorld world, BlockPos pos, int flag) { }
-        public void onCarpetRuleChanges(ParsedRule<?> rule, ServerCommandSource source) { }
+        public void onCarpetRuleChanges(CarpetRule<?> rule, ServerCommandSource source) { }
         public void onCustomPlayerEvent(ServerPlayerEntity player, Object ... args)
         {
             if (handler.reqArgs != (args.length+1))

--- a/src/main/java/carpet/script/utils/AppStoreManager.java
+++ b/src/main/java/carpet/script/utils/AppStoreManager.java
@@ -7,7 +7,7 @@ import carpet.script.exception.InternalExpressionException;
 import carpet.script.value.MapValue;
 import carpet.script.value.StringValue;
 import carpet.script.value.Value;
-import carpet.settings.ParsedRule;
+import carpet.settings.CarpetRule;
 import carpet.settings.Validator;
 import carpet.utils.Messenger;
 import com.google.gson.JsonArray;
@@ -58,7 +58,7 @@ public class AppStoreManager
 
     public static class ScarpetAppStoreValidator extends Validator<String>
     {
-        @Override public String validate(ServerCommandSource source, ParsedRule<String> currentRule, String newValue, String string)
+        @Override public String validate(ServerCommandSource source, CarpetRule<String> currentRule, String newValue, String string)
         {
             APP_STORE_ROOT.sealed = false;
             APP_STORE_ROOT.children = new HashMap<>();

--- a/src/main/java/carpet/settings/CarpetRule.java
+++ b/src/main/java/carpet/settings/CarpetRule.java
@@ -1,0 +1,128 @@
+package carpet.settings;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.commons.lang3.ClassUtils;
+
+import carpet.network.ServerNetworkHandler;
+import net.minecraft.server.command.ServerCommandSource;
+
+/**
+ * <p>A Carpet rule, that can return its required properties and stores a value.</p>
+ * 
+ * @param <T> The value's type
+ */
+public interface CarpetRule<T> extends Comparable<CarpetRule<?>> {
+	/**
+	 * <p>Returns this rule's name</p>
+	 */
+	String name();
+	
+	/**
+	 * <p>Returns this rule's description</p>
+	 */
+	String description();
+	
+	/**
+	 * <p>Returns an immutable {@link List} of {@link String strings} with extra information about this rule, that is,
+	 * the lines after the rule's description.</p>
+	 */
+	List<String> extraInfo();
+	
+	/**
+	 * Returns an immutable {@link Collection} of categories this rule is on.
+	 */
+	Collection<String> categories();
+	
+	/**
+	 * <p>Returns an immutable {@link Collection} of suggestions for values that this rule will be able
+	 * to accept as Strings. The rule must be able to accept all of the suggestions in the returned {@link Collection} as a value,
+	 * though it may have requirements for those to be applicable.</p>
+	 */
+	Collection<String> suggestions();
+	
+	/**
+	 * <p>Returns the {@link SettingsManager} this rule is in.</p>
+	 * 
+	 * <p>This method may be removed or changed in the future, and is not part of the contract, but it's needed to sync
+	 * the rule with clients.</p>
+	 */
+	SettingsManager settingsManager();
+	
+	/**
+	 * <p>Returns this rule's value</p>
+	 */
+	T value();
+	
+	/**
+	 * <p>Returns whether this rule can be toggled in the client-side when not connected to a
+	 * Carpet server.</p>
+	 * 
+	 * <p>In the default implementation, this is the case when {@link #categories()} contains {@link RuleCategory#CLIENT} </p>
+	 */
+	boolean canBeToggledClientSide();
+	
+	/**
+	 * <p>Returns the type of this rule's value.</p>
+	 * 
+	 * <p>If this rule's type is primitive, it returns a wrapped version of it (such as the result of running
+	 * {@link ClassUtils#primitiveToWrapper(Class)} on it) </p>
+	 */
+	Class<T> type();
+	
+	/**
+	 * <p>Returns this rule's default value.</p>
+	 * 
+	 * <p>This value will never be {@code null}, and will always be a valid value for {@link #set(ServerCommandSource, Object)}.</p>
+	 */
+	T defaultValue();
+	
+	/**
+	 * <p>Sets this rule's value to the provided {@link String}, after first converting the {@link String} into a suitable type.</p>
+	 * 
+	 * <p>This methods run any required validation on the value first, and throws {@link InvalidRuleValueException} if the value is not suitable
+	 * for this rule, regardless of whether it was impossible to convert the value to the required type, the rule doesn't accept the
+	 * value, or the rule is immutable.</p>
+	 * 
+	 * <p>Implementations of this method must notify their {@link SettingsManager} by calling
+	 * {@link SettingsManager#notifyRuleChanged(ServerCommandSource, CarpetRule)} , and are responsible for
+	 * notifying the {@link ServerNetworkHandler} (if the rule isn't restricted from being synchronized with clients)
+	 * and the {@link CarpetEventServer.Event#CARPET_RULE_CHANGES#onCarpetRuleChanges(CarpetRule, ServerCommandSource)} Scarpet event
+	 * in case the value of the rule was changed because of the invocation.</p>
+	 * 
+	 * @param source The {@link ServerCommandSource} to notify about the result of this rule change or {@code null} in order to not notify
+	 * @param value The new value for this rule as a {@link String}
+	 * @throws InvalidRuleValueException if the value passed to the method was not valid as a value to this rule, either because of incompatible type,
+	 *                                   because the rule can't accept that value or because there was some requirement missing for that value to be allowed
+	 */
+	void set(ServerCommandSource source, String value) throws InvalidRuleValueException;
+	
+	/**
+	 * <p>This method follows the same contract as {@link #set(ServerCommandSource, String)}, but accepts a value already parsed (though not verified).</p>
+	 * @see #set(ServerCommandSource, String)
+	 */
+	void set(ServerCommandSource source, T value) throws InvalidRuleValueException; //TODO doesn't work with T = String smh
+	
+	/**
+	 * <p>Compares this {@link CarpetRule} against another one, without taking the current value into account.</p>
+	 * 
+	 * <p>In the default {@link SettingsManager} implementation, this is used to sort the rules before displaying them.</p>
+	 * 
+	 * <p>The default comparison method depends only on the rule's name.</p>
+	 * 
+	 * <h1>int compareTo(CarpetRule<?> o)</h1>
+	 * 
+	 * {@inheritDoc}
+	 */
+	@Override
+	default int compareTo(CarpetRule<?> o) {
+		return this.name().compareTo(o.name());
+	}
+	
+	@Override
+	boolean equals(Object o);
+	
+	@Override
+	int hashCode();
+}

--- a/src/main/java/carpet/settings/InvalidRuleValueException.java
+++ b/src/main/java/carpet/settings/InvalidRuleValueException.java
@@ -1,0 +1,36 @@
+package carpet.settings;
+
+import carpet.utils.Messenger;
+import net.minecraft.server.command.ServerCommandSource;
+
+/**
+ * <p>An {@link Exception} thrown when the value given for a {@link CarpetRule} is invalid.</p>
+ * 
+ * <p>It can hold a message to be sent to the executing source.</p>
+ */
+public class InvalidRuleValueException extends Exception {
+
+	/**
+	 * <p>Constructs a new {@link InvalidRuleValueException} with a message that will be passed to the executing source</p>
+	 * @param cause The cause of the exception
+	 */
+	public InvalidRuleValueException(String cause) {
+		super(cause);
+	}
+	
+	/**
+	 * <p>Constructs a new {@link InvalidRuleValueException} with no detail message, that therefore should not notify the source</p>
+	 */
+	public InvalidRuleValueException() {
+		super();
+	}
+	
+	/**
+	 * <p>Notifies the given source with the exception's message if it exists, does nothing if it doesn't exist or it is {@code null}</p>
+	 * @param source The source to notify
+	 */
+	public void notifySource(ServerCommandSource source) {
+		if (getMessage() != null)
+			Messenger.m(source, "r " + getMessage());
+	}
+}

--- a/src/main/java/carpet/settings/ParsedRule.java
+++ b/src/main/java/carpet/settings/ParsedRule.java
@@ -1,93 +1,190 @@
 package carpet.settings;
 
-import carpet.utils.Translations;
-import carpet.utils.Messenger;
+import carpet.utils.TypedField;
 import net.minecraft.server.command.ServerCommandSource;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.ClassUtils;
-
-import static carpet.utils.Translations.tr;
+import java.util.stream.Stream;
 
 /**
- * A parsed Carpet rule, with its field, name, value, and other useful stuff.
+ * A Carpet rule parsed from a field, with its name, value, and other useful stuff.
  * 
- * It is generated from the fields with the {@link Rule} annotation
+ * It is used for the fields with the {@link Rule} annotation
  * when being parsed by {@link SettingsManager#parseSettingsClass(Class)}.
  *
- * @param <T> The field's type
+ * @param <T> The field's (and rule's) type
+ * @deprecated Use the type {@link CarpetRule} instead, since it's not implementation specific
  */
-public final class ParsedRule<T> implements Comparable<ParsedRule> {
+@Deprecated(forRemoval = true) // to package private
+public final class ParsedRule<T> implements CarpetRule<T> {
+    private static final Map<Class<?>, FromStringConverter<?>> CONVERTER_MAP = Map.ofEntries(
+            Map.entry(String.class, str -> str),
+            Map.entry(Boolean.class, str -> {
+                return switch (str) {
+                    case "true" -> true;
+                    case "false" -> false;
+                    default -> throw new InvalidRuleValueException("Invalid boolean value");
+                };
+            }),
+            numericalConverter(Integer.class, Integer::parseInt),
+            numericalConverter(Double.class, Double::parseDouble),
+            numericalConverter(Long.class, Long::parseLong),
+            numericalConverter(Float.class, Float::parseFloat)
+        );
+    /**
+     * @deprecated No replacement for this, since a {@link CarpetRule} may not always use a {@link Field}.
+     *             Use {@link #value()} to access the rule's value
+     */
+    @Deprecated(forRemoval = true) // to remove
     public final Field field;
+    /**
+     * @deprecated Use {@link CarpetRule#name()}
+     */
+    @Deprecated(forRemoval = true) // to private
     public final String name;
+    /**
+     * @deprecated Use {@link CarpetRule#description}
+     */
+    @Deprecated(forRemoval = true) // to private
     public final String description;
-    public final String scarpetApp;
+    /**
+     * @deprecated Use {@link CarpetRule#extraInfo()}
+     */
+    @Deprecated(forRemoval = true) // to private
     public final List<String> extraInfo;
+    /**
+     * @deprecated Use {@link CarpetRule#categories()}
+     */
+    @Deprecated(forRemoval = true) // to private
     public final List<String> categories;
+    /**
+     * @deprecated Use {@link CarpetRule#suggestions()} instead
+     */
+    @Deprecated(forRemoval = true) // to private (and rename?)
     public final List<String> options;
+    /**
+     * @deprecated No replacement for this
+     */
+    @Deprecated(forRemoval = true) // to pckg private (for printRulesToLog, or get a different way)
     public boolean isStrict;
+    /**
+     * @deprecated Use {@link CarpetRule#canBeToggledClientSide()}
+     */
+    @Deprecated(forRemoval = true) // to private (and maybe rename?)
     public boolean isClient;
+    /**
+     * @deprecated Use {@link CarpetRule#type()}
+     */
+    @Deprecated(forRemoval = true) // to private (or remove and delegate to typedfield?)
     public final Class<T> type;
-    public final List<Validator<T>> validators;
+    /**
+     * @deprecated Use {@link CarpetRule#defaultValue()}
+     */
+    @Deprecated(forRemoval = true) // to private
     public final T defaultValue;
-    public final String defaultAsString;
+    /**
+     * @deprecated Use {@link CarpetRule#settingsManager()}
+     */
+    @Deprecated(forRemoval = true) // to private
     public final SettingsManager settingsManager;
+    /**
+     * @deprecated No replacement for this. A Carpet rule may not use {@link Validator}
+     */
+    @Deprecated(forRemoval = true) // to pckg private (for printRulesToLog)
+    public final List<Validator<T>> validators;
+    /**
+     * @deprecated Use {@link CarpetRule#defaultValue()} and pass it to {@link RuleHelper#toRuleString(Object)}
+     */
+    @Deprecated(forRemoval = true) // to remove
+    public final String defaultAsString;
+    /**
+     * @deprecated No replacement for this, Scarpet Rules should be managed by the rule implementation 
+     */
+    @Deprecated(forRemoval = true) // to private/subclass
+    public final String scarpetApp;
+    private final FromStringConverter<T> converter;
+    private final TypedField<T> typedField; // to rename to field
+    
+    @FunctionalInterface
+    interface FromStringConverter<T> {
+        T convert(String value) throws InvalidRuleValueException;
+    }
 
-    ParsedRule(Field field, Rule rule, SettingsManager settingsManager)
+    // More flexible than a constructor, since it can return subclasses (doesn't do that yet) and null
+    static <T> ParsedRule<T> of(Field field, Rule rule, SettingsManager settingsManager) {
+        return new ParsedRule<>(field, rule, settingsManager);
+    }
+
+    private ParsedRule(Field field, Rule rule, SettingsManager settingsManager)
     {
-        this.field = field;
         this.name = rule.name().isEmpty() ? field.getName() : rule.name();
-        this.type = (Class<T>) field.getType();
+        try {
+            this.typedField = new TypedField<>(field);
+        } catch (IllegalAccessException e) {
+            throw new IllegalArgumentException("Couldn't access given field", e);
+        }
+        this.type = typedField.type();
         this.description = rule.desc();
         this.isStrict = rule.strict();
         this.extraInfo = List.of(rule.extra());
         this.categories = List.of(rule.category());
         this.scarpetApp = rule.appSource();
         this.settingsManager = settingsManager;
-        this.validators = new ArrayList<>();
-        for (Class v : rule.validate())
-            this.validators.add((Validator<T>) callConstructor(v));
+        this.validators = Stream.of(rule.validate()).map(this::instantiateValidator).collect(Collectors.toList());
+        this.defaultValue = value();
+        FromStringConverter<T> converter0 = null;
+        
         if (categories.contains(RuleCategory.COMMAND))
         {
-            this.validators.add(callConstructor(Validator._COMMAND.class));
+            this.validators.add(new Validator._COMMAND<T>());
             if (this.type == String.class)
             {
-                this.isStrict = false;
-                this.validators.add((Validator<T>) callConstructor(Validator._COMMAND_LEVEL_VALIDATOR.class));
+                this.validators.add(instantiateValidator(Validator._COMMAND_LEVEL_VALIDATOR.class));
             }
         }
-        if (!scarpetApp.isEmpty())
-        {
-            this.validators.add((Validator<T>) callConstructor(Validator._SCARPET.class));
-        }
+        
         this.isClient = categories.contains(RuleCategory.CLIENT);
         if (this.isClient)
         {
-            this.validators.add(callConstructor(Validator._CLIENT.class));
+            this.validators.add(new Validator._CLIENT<>());
         }
-        this.defaultValue = get();
-        this.defaultAsString = convertToString(this.defaultValue);
+        
+        if (!scarpetApp.isEmpty())
+        {
+            this.validators.add(new Validator._SCARPET<>());
+        }
+        
         if (rule.options().length > 0)
         {
             this.options = List.of(rule.options());
         }
-        else if (this.type == boolean.class){
-            this.options = List.of("true","false");
+        else if (this.type == Boolean.class) {
+            this.options = List.of("true", "false");
         }
-        else if(this.type == String.class && categories.contains(RuleCategory.COMMAND))
+        else if (this.type == String.class && categories.contains(RuleCategory.COMMAND))
         {
-            this.options = List.of("true", "false", "ops");
+            this.options = Validator._COMMAND_LEVEL_VALIDATOR.OPTIONS;
         }
         else if (this.type.isEnum())
         {
-            this.options = Arrays.stream(this.type.getEnumConstants()).map(e -> ((Enum) e).name().toLowerCase(Locale.ROOT)).collect(Collectors.toUnmodifiableList());
+            this.options = Arrays.stream(this.type.getEnumConstants()).map(e -> ((Enum<?>) e).name().toLowerCase(Locale.ROOT)).collect(Collectors.toUnmodifiableList());
+            converter0 = str -> {
+                try {
+                    @SuppressWarnings({"unchecked", "rawtypes"}) // Raw necessary because of signature. Unchecked because compiler doesn't know T extends Enum
+                    T ret = (T)Enum.valueOf((Class<? extends Enum>) type, str.toUpperCase(Locale.ROOT));
+                    return ret;
+                } catch (IllegalArgumentException e) {
+                    throw new InvalidRuleValueException("Invalid value for rule. Valid ones are: " + this.options);
+                }
+            };
         }
         else
         {
@@ -95,157 +192,63 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
         }
         if (isStrict && !this.options.isEmpty())
         {
-            if (this.type == boolean.class || this.type == int.class || this.type == double.class || this.type == float.class)
-            {
-                this.validators.add(callConstructor(Validator._STRICT_IGNORECASE.class));
-            }
-            else
-            {
-                this.validators.add(callConstructor(Validator._STRICT.class));
-            }
+            this.validators.add(new Validator._STRICT<>());
         }
+        if (converter0 == null) {
+            @SuppressWarnings("unchecked")
+            FromStringConverter<T> converterFromMap = (FromStringConverter<T>)CONVERTER_MAP.get(type);
+            if (converterFromMap == null) throw new UnsupportedOperationException("Unsupported type for ParsedRule" + type);
+            converter0 = converterFromMap;
+        }
+        this.converter = converter0;
+        
+        // to remove
+        this.defaultAsString = RuleHelper.toRuleString(this.defaultValue);
+        this.field = field;
     }
 
-    private <T> T callConstructor(Class<T> cls)
+    @SuppressWarnings({"unchecked", "rawtypes"}) // Needed because of the annotation
+    private Validator<T> instantiateValidator(Class<? extends Validator> cls)
     {
         try
         {
-            Constructor<T> constr = cls.getDeclaredConstructor();
+            Constructor<? extends Validator> constr = cls.getDeclaredConstructor();
             constr.setAccessible(true);
             return constr.newInstance();
         }
         catch (ReflectiveOperationException e)
         {
-            throw new RuntimeException(e);
+            throw new IllegalArgumentException(e);
         }
     }
 
-    public ParsedRule<T> set(ServerCommandSource source, String value)
+    public void set(ServerCommandSource source, String value) throws InvalidRuleValueException
     {
-        if (settingsManager != null && settingsManager.locked)
-            return null;
-        if (type == String.class)
-        {
-            return set(source, (T) value, value);
-        }
-        else if (type == boolean.class)
-        {
-            return set(source, (T) (Object) Boolean.parseBoolean(value), value);
-        }
-        else if (type == int.class)
-        {
-            return set(source, (T) (Object) Integer.parseInt(value), value);
-        }
-        else if (type == double.class)
-        {
-            return set(source, (T) (Object) Double.parseDouble(value), value);
-        }
-        else if (type.isEnum())
-        {
-            String ucValue = value.toUpperCase(Locale.ROOT);
-            return set(source, (T) (Object) Enum.valueOf((Class<? extends Enum>) type, ucValue), value);
-        }
-        else
-        {
-            Messenger.m(source, "r Unknown type " + type.getSimpleName());
-            return null;
-        }
+        set(source, converter.convert(value), value);
     }
 
-    ParsedRule<T> set(ServerCommandSource source, T value, String stringValue)
+    private void set(ServerCommandSource source, T value, String stringValue) throws InvalidRuleValueException
     {
-        try
+        for (Validator<T> validator : this.validators)
         {
-            for (Validator<T> validator : this.validators)
-            {
-                value = validator.validate(source, this, value, stringValue);
-                if (value == null)
-                {
-                    if (source != null)
-                    {
-                        validator.notifyFailure(source, this, stringValue);
-                        if (validator.description() != null)
-                            Messenger.m(source, "r " + validator.description());
-                    }
-                    return null;
-                }
-            }
-            if (!value.equals(get()) || source == null)
-            {
-                this.field.set(null, value);
-                if (source != null) settingsManager.notifyRuleChanged(source, this, stringValue);
+            stringValue = RuleHelper.toRuleString(value);
+            value = validator.validate(source, (CarpetRule<T>)this, value, stringValue);
+            if (value == null) {
+                if (source != null) validator.notifyFailure(source, this, stringValue);
+                throw new InvalidRuleValueException();
             }
         }
-        catch (IllegalAccessException e)
+        if (!value.equals(value()) || source == null)
         {
-            Messenger.m(source, "r Unable to access setting for  "+name);
-            return null;
+            this.typedField.setStatic(value);
+            if (source != null) settingsManager.notifyRuleChanged(source, this);
         }
-        return this;
-    }
-
-    /**
-     * @return The value of this {@link ParsedRule}, in its type
-     */
-    public T get()
-    {
-        try
-        {
-            return (T) this.field.get(null);
-        }
-        catch (IllegalAccessException e)
-        {
-            throw new IllegalStateException(e);
-        }
-    }
-
-    /**
-     * @return The value of this {@link ParsedRule}, as a {@link String}
-     */
-    public String getAsString()
-    {
-        return convertToString(get());
-    }
-
-    /**
-     * @return The value of this {@link ParsedRule}, converted to a {@link boolean}.
-     *         It will only return {@link true} if it's a true {@link boolean} or
-     *         a number greater than zero.
-     */
-    public boolean getBoolValue()
-    {
-        if (type == boolean.class) return (Boolean) get();
-        if (ClassUtils.primitiveToWrapper(type).isAssignableFrom(Number.class)) return ((Number) get()).doubleValue() > 0;
-        return false;
-    }
-
-    /**
-     * @return Wether or not this {@link ParsedRule} is in its default value
-     */
-    public boolean isDefault()
-    {
-        return defaultValue.equals(get());
-    }
-
-    /**
-     * Resets this rule to its default value
-     */
-    public void resetToDefault(ServerCommandSource source)
-    {
-        set(source, defaultValue, defaultAsString);
-    }
-
-
-    private static String convertToString(Object value)
-    {
-        if (value instanceof Enum) return ((Enum) value).name().toLowerCase(Locale.ROOT);
-        return value.toString();
     }
 
     @Override
     public boolean equals(Object obj)
     {
-        return obj.getClass() == ParsedRule.class && ((ParsedRule) obj).name.equals(this.name);
+        return obj instanceof ParsedRule && ((ParsedRule<?>) obj).name.equals(this.name);
     }
 
     @Override
@@ -255,55 +258,155 @@ public final class ParsedRule<T> implements Comparable<ParsedRule> {
     }
 
     @Override
-    public int compareTo(ParsedRule o)
+    public String toString()
     {
-        return this.name.compareTo(o.name);
+        return this.name + ": " + RuleHelper.toRuleString(value());
     }
 
     @Override
-    public String toString()
-    {
-        return this.name + ": " + getAsString();
+    public String name() {
+        return name;
     }
 
-    private String translationKey()
+    @Override
+    public String description() {
+        return description;
+    }
+
+    @Override
+    public List<String> extraInfo() {
+        return extraInfo;
+    }
+
+    @Override
+    public Collection<String> categories() {
+        return categories;
+    }
+
+    @Override
+    public Collection<String> suggestions() {
+        return options;
+    }
+    
+    @Override
+    public SettingsManager settingsManager() {
+        return settingsManager;
+    }
+
+    @Override
+    public T value() {
+        return typedField.getStatic();
+    }
+
+    @Override
+    public boolean canBeToggledClientSide() {
+        return isClient;
+    }
+
+    @Override
+    public Class<T> type() {
+        return type;
+    }
+
+    @Override
+    public T defaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public void set(ServerCommandSource source, T value) throws InvalidRuleValueException {
+        set(source, value, RuleHelper.toRuleString(value));
+    }
+
+    private static <T> Map.Entry<Class<T>, FromStringConverter<T>> numericalConverter(Class<T> outputClass, Function<String, T> converter) {
+        return Map.entry(outputClass, str -> {
+            try {
+                return converter.apply(str);
+            } catch (NumberFormatException e) {
+                throw new InvalidRuleValueException("Invalid number for rule");
+            }
+        });
+    }
+    
+    //TO REMOVE
+    
+    /**
+     * @deprecated Use {@link CarpetRule#value()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public T get()
     {
-        return String.format("rule.%s.name", name);
+        return value();
+    }
+
+    /**
+     * @deprecated Use {@link RuleHelper#toRuleString(Object) RuleHelper.convertToRuleString(rule.value())}
+     */
+    @Deprecated(forRemoval = true)
+    public String getAsString()
+    {
+        return RuleHelper.toRuleString(value());
+    }
+
+    /**
+     * @return The value of this {@link ParsedRule}, converted to a {@link boolean}.
+     *         It will only return {@link true} if it's a true {@link boolean} or
+     *         a number greater than zero.
+     * @deprecated Use {@link RuleHelper#getBooleanValue(CarpetRule)}
+     */
+    @Deprecated(forRemoval = true)
+    public boolean getBoolValue()
+    {
+        return RuleHelper.getBooleanValue(this);
+    }
+
+    /**
+     * @deprecated Use {@link RuleHelper#isInDefaultValue(CarpetRule)}
+     */
+    @Deprecated(forRemoval = true)
+    public boolean isDefault()
+    {
+        return RuleHelper.isInDefaultValue(this);
+    }
+
+    /**
+     * @deprecated Use {@link RuleHelper#resetToDefault(CarpetRule, ServerCommandSource)}
+     */
+    @Deprecated(forRemoval = true)
+    public void resetToDefault(ServerCommandSource source)
+    {
+        RuleHelper.resetToDefault(this, source);
     }
 
     /**
      * @return A {@link String} being the translated {@link ParsedRule#name} of this rule,
      *                          in Carpet's configured language.
+     * @deprecated Use {@link RuleHelper#translatedName(CarpetRule)} instead
      */
-    public String translatedName(){
-        String key = translationKey();
-        return Translations.hasTranslation(key) ? tr(key) + String.format(" (%s)", name): name;
+    @Deprecated(forRemoval = true)
+    public String translatedName() {
+        return RuleHelper.translatedName(this);
     }
 
     /**
-     * @return A {@link String} being the translated {@link ParsedRule#description} of this rule,
+     * @return A {@link String} being the translated {@link ParsedRule#description description} of this rule,
      *                          in Carpet's configured language.
+     * @deprecated Use {@link RuleHelper#translatedDescription(CarpetRule)} instead
      */
+    @Deprecated(forRemoval = true)
     public String translatedDescription()
     {
-        return tr(String.format("rule.%s.desc", (name)), description);
+        return RuleHelper.translatedDescription(this);
     }
 
     /**
-     * @return A {@link String} being the translated {@link ParsedRule#extraInfo} of this 
-     * 	                        {@link ParsedRule}, in Carpet's configured language.
+     * @return A {@link String} being the translated {@link ParsedRule#extraInfo extraInfo} of this 
+     *                             {@link ParsedRule}, in Carpet's configured language.
+     * @deprecated Use {@link RuleHelper#translatedExtras(CarpetRule)} instead
      */
+    @Deprecated(forRemoval = true)
     public List<String> translatedExtras()
     {
-        if (!Translations.hasTranslations()) return extraInfo;
-        String keyBase = String.format("rule.%s.extra.", name);
-        List<String> extras = new ArrayList<>();
-        int i = 0;
-        while (Translations.hasTranslation(keyBase+i))
-        {
-            extras.add(Translations.tr(keyBase+i));
-            i++;
-        }
-        return (extras.isEmpty()) ? extraInfo : extras;
+        return RuleHelper.translatedExtras(this);
     }
 }

--- a/src/main/java/carpet/settings/Rule.java
+++ b/src/main/java/carpet/settings/Rule.java
@@ -6,12 +6,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Any field in this class annotated with this class is interpreted as a carpet rule.
+ * Any field in a settings class annotated with this class will be interpreted as a {@link CarpetRule} (implemented by {@link ParsedRule}).
  * The field must be static and have a type of one of:
  * - boolean
  * - int
  * - double
  * - String
+ * - long
+ * - float
  * - a subclass of Enum
  * The default value of the rule will be the initial value of the field.
  */
@@ -22,7 +24,7 @@ public @interface Rule
     /**
      * The rule name, by default the same as the field name
      */
-    String name() default ""; // default same as field name
+    String name() default "";
 
     /**
      * A description of the rule
@@ -55,8 +57,6 @@ public @interface Rule
     /**
      * If specified, the rule will automatically enable or disable 
      * a builtin Scarpet Rule App with this name.
-     * Consider telling the rule name so users can edit globals
-     * (in case there are relevant globals to edit ofc)
      */
     String appSource() default "";
 
@@ -66,7 +66,8 @@ public @interface Rule
     Class<? extends Validator>[] validate() default {};
 
     /**
-     * The class of the condition checked when the rule is parsed.
+     * The class of the condition checked when the rule is parsed, before being added
+     * to the Settings Manager.
      */
     Class<? extends Condition>[] condition() default {};
 }

--- a/src/main/java/carpet/settings/RuleHelper.java
+++ b/src/main/java/carpet/settings/RuleHelper.java
@@ -1,0 +1,116 @@
+package carpet.settings;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import carpet.utils.Translations;
+import net.minecraft.server.command.ServerCommandSource;
+
+/**
+ * <p>A helper class for operating with {@link CarpetRule} instances and values.</p>
+ * 
+ * <p>If a method is visible and has javadocs it's probably API</p>
+ */
+public final class RuleHelper {
+	private RuleHelper() {}
+	
+	/**
+	 * <p>Gets a {@code boolean} value for a given {@link CarpetRule}.</p>
+	 * 
+	 * <p>The current implementation is as follows:</p>
+	 * <ul>
+	 *   <li>If the rule's type is a {@code boolean}, it will return the value directly.</li>
+	 *   <li>If the rule's type is a {@link Number}, it will return {@code true} if the value is greater than zero.</li>
+	 *   <li>In any other case, it will return {@code false}.</li>
+	 * </ul>
+	 * @param rule The rule to get the {@code boolean} value from
+	 * @return A {@code boolean} representation of this rule's value
+	 */
+	public static boolean getBooleanValue(CarpetRule<?> rule) {
+		if (rule.type() == Boolean.class) return (boolean) rule.value();
+        if (Number.class.isAssignableFrom(rule.type())) return ((Number) rule.value()).doubleValue() > 0;
+        return false;
+	}
+	
+	/**
+	 * <p>Converts a rule's value into its similar {@link String} representation.</p>
+	 * 
+	 * <p>If the value is an {@link Enum}, this method returns the name of the enum constant lowercased, else
+	 * it returns the result of running {@link #toString()} on the value.</p>
+	 * @param value A rule's value
+	 * @return A {@link String} representation of the given value
+	 */
+	public static String toRuleString(Object value) {
+		if (value instanceof Enum) return ((Enum<?>) value).name().toLowerCase(Locale.ROOT);
+        return value.toString();
+	}
+	
+	/**
+	 * <p>Checks whether the given {@code CarpetRule rule} is in its default value</p>
+	 * 
+	 * @param rule The rule to check
+	 * @return {@code true} if the rule's default value equals its current value
+	 */
+	public static boolean isInDefaultValue(CarpetRule<?> rule) {
+		return rule.defaultValue().equals(rule.value());
+	}
+	
+	/**
+	 * <p>Resets the given {@link CarpetRule rule} to its default value, and notifies the given source, if provided.</p>
+	 * @param rule The {@link CarpetRule} to reset to its default value
+	 * @param source A {@link ServerCommandSource} to notify about this change, or {@code null}
+	 * 
+	 * @param <T> The type of the {@link CarpetRule}
+	 */
+	public static <T> void resetToDefault(CarpetRule<T> rule, ServerCommandSource source) {
+		try {
+			rule.set(source, rule.defaultValue());
+		} catch (InvalidRuleValueException e) {
+			throw new IllegalStateException("Rule couldn't be set to default value!", e);
+		}
+	}
+	
+	// Translations
+	// TODO decide if worth keeping public
+	
+	/**
+	 * @param rule The {@link CarpetRule} to get the translated name of
+     * @return A {@link String} being the translated {@link CarpetRule#name()} of this rule,
+     *         in Carpet's configured language.
+     */
+    public static String translatedName(CarpetRule<?> rule) {
+        String key = String.format("rule.%s.name", rule.name());
+        return Translations.hasTranslation(key) ? Translations.tr(key) + String.format(" (%s)", rule.name()): rule.name();
+    }
+    
+    /**
+     * @param rule The {@link CarpetRule} to get the translated description of
+     * @return A {@link String} being the translated {@link CarpetRule#description() description} of this rule,
+     *         in Carpet's configured language.
+     */
+    public static String translatedDescription(CarpetRule<?> rule)
+    {
+        return Translations.tr(String.format("rule.%s.desc", rule.name()), rule.description());
+    }
+    
+    /**
+     * @param rule The {@link CarpetRule} to get the translated extraInfo of
+     * @return An {@link List} of {@link String} being the translated {@link CarpetRule#extraInfo() extraInfo} of this 
+     * 	       {@link CarpetRule}, in Carpet's configured language.
+     */
+    public static List<String> translatedExtras(CarpetRule<?> rule)
+    {
+        if (!Translations.hasTranslations()) return rule.extraInfo();
+        String keyBase = String.format("rule.%s.extra.", rule.name());
+        List<String> extras = new ArrayList<>();
+        int i = 0;
+        while (Translations.hasTranslation(keyBase + i))
+        {
+            extras.add(Translations.tr(keyBase+i));
+            i++;
+        }
+        return (extras.isEmpty()) ? rule.extraInfo() : extras;
+    }
+    
+}

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -573,7 +573,7 @@ public class SettingsManager
         catch (IOException e)
         {
             CarpetSettings.LOG.error("Exception while loading Carpet rules from config", e);
-            return new ConfigReadResult(new HashMap<>(), false, List.of());
+            return new ConfigFileData(new HashMap<>(), false, List.of());
         }
     }
 
@@ -690,17 +690,17 @@ public class SettingsManager
                 then(literal("removeDefault").
                         requires(s -> !locked()).
                         then(argument("rule", StringArgumentType.word()).
-                                suggests( (c, b) -> suggestMatchingContains(getRulesSorted().stream().map(r -> r.name()), b)).
+                                suggests( (c, b) -> suggestMatchingContains(getRulesSorted().stream().map(CarpetRule::name), b)).
                                 executes((c) -> removeDefault(c.getSource(), contextRule(c))))).
                 then(literal("setDefault").
                         requires(s -> !locked()).
                         then(argument("rule", StringArgumentType.word()).
-                                suggests( (c, b) -> suggestMatchingContains(getRulesSorted().stream().map(r -> r.name()), b)).
+                                suggests( (c, b) -> suggestMatchingContains(getRulesSorted().stream().map(CarpetRule::name), b)).
                                 then(argument("value", StringArgumentType.greedyString()).
                                         suggests((c, b)-> suggestMatching(contextRule(c).suggestions(), b)).
                                         executes((c) -> setDefault(c.getSource(), contextRule(c), StringArgumentType.getString(c, "value")))))).
                 then(argument("rule", StringArgumentType.word()).
-                        suggests( (c, b) -> suggestMatchingContains(getRulesSorted().stream().map(r -> r.name()), b)).
+                        suggests( (c, b) -> suggestMatchingContains(getRulesSorted().stream().map(CarpetRule::name), b)).
                         requires(s -> !locked() ).
                         executes( (c) -> displayRuleMenu(c.getSource(), contextRule(c))).
                         then(argument("value", StringArgumentType.greedyString()).

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -337,7 +337,7 @@ public class SettingsManager
     public Collection<ParsedRule<?>> getRules()
     {
         var parsedRuleClass = ParsedRule.class;
-        return rules.values().stream().filter(parsedRuleClass::isInstance).map(parsedRuleClass::cast).collect(Collectors.toUnmodifiableList());
+        return List.of(rules.values().stream().filter(parsedRuleClass::isInstance).map(parsedRuleClass::cast).toArray(ParsedRule[]::new));
     }
 
 

--- a/src/main/java/carpet/settings/Validator.java
+++ b/src/main/java/carpet/settings/Validator.java
@@ -1,30 +1,78 @@
 package carpet.settings;
 
 import carpet.CarpetServer;
+import carpet.CarpetSettings;
 import carpet.utils.Messenger;
 import net.minecraft.server.command.ServerCommandSource;
 
 import java.util.List;
-import java.util.Locale;
-import java.util.stream.Collectors;
 
+/**
+ * <p>A {@link Validator} is a class that is able to validate the values given to a {@link CarpetRule}, cancelling rule
+ * modification if the value is not valid or even changing the value to a different one if needed.</p>
+ * 
+ * <p>Validators are used in the default implementation, {@link ParsedRule}, as the way of validating most input (other than validating
+ * it can actually be introduced in the rule), but can (and may) also be used in other {@link CarpetRule} implementations, though those are not
+ * required to.</p>
+ * 
+ * @see #validate(ServerCommandSource, CarpetRule, Object, String)
+ * 
+ * @param <T> The type of the rule's value
+ */
 public abstract class Validator<T>
 {
     /**
-     * Validate the new value of a rule
-     * @return true if valid, false if new rule invalid.
+     * <p>Validates whether the value passed to the given {@link CarpetRule} is valid as a new value for it.</p>
+     * 
+     * <p>Validators can also change the value that the rule is going to be set to </p>
+     * @param source The {@link ServerCommandSource} that originated this change, and should be further notified
+     *        about it. May be {@code null} during rule synchronization.
+     * @param changingRule The {@link CarpetRule} that is being changed
+     * @param newValue The new value that is being set to the rule
+     * @param stringInput The value that is being given to the rule as a {@link String}
+     * @return The new value to set the rule to instead, can return the {@code newValue} if the given value is correct.
+     *         Returns {@code null} if the given value is not correct.
      */
-    public abstract T validate(ServerCommandSource source, ParsedRule<T> currentRule, T newValue, String string);
+    public T validate(ServerCommandSource source, CarpetRule<T> changingRule, T newValue, String stringInput) {
+    	// Temporary compatibility code
+        CarpetSettings.LOG.warn("Validator "+ getClass() +" implements the old validation method! "
+                + "Tell the extension author(s) to use the new one using CarpetRule instead, the one they're using will be removed (and crash) soon!");
+        CarpetSettings.LOG.warn("Normally it's as simple as changing the type 'ParsedRule' to 'CarpetRule' in the validate() method!");
+        if (!(changingRule instanceof ParsedRule<T> parsedRule))
+            throw new IllegalArgumentException("Passed a non-ParsedRule to a validator using the outdated method!");
+        return validate(source, parsedRule, newValue, stringInput);
+    }
+    /**
+     * @return A description of this {@link Validator}. It is used in the default {@link #notifyFailure(ServerCommandSource, CarpetRule, String)}
+     *         implementation and to add extra information in {@link SettingsManager#printAllRulesToLog(String)}
+     */
     public String description() {return null;}
-    public void notifyFailure(ServerCommandSource source, ParsedRule<T> currentRule, String providedValue)
+    /**
+     * <p>Called after failing validation of the {@link CarpetRule} in order to notify the causing {@link ServerCommandSource} about the
+     * failure.</p>
+     * 
+     * @param source The {@link ServerCommandSource} that originated this change. It will never be {@code null}
+     * @param currentRule The {@link CarpetRule} that failed verification
+     * @param providedValue The {@link String} that was provided to the changing rule
+     */
+    public void notifyFailure(ServerCommandSource source, CarpetRule<T> currentRule, String providedValue)
     {
-        Messenger.m(source, "r Wrong value for " + currentRule.name + ": " + providedValue);
+        Messenger.m(source, "r Wrong value for " + currentRule.name() + ": " + providedValue);
+        if (description() != null)
+            Messenger.m(source, "r " + description());
+    }
+    /**
+     * @deprecated Implement {@link #validate(ServerCommandSource, CarpetRule, Object, String)} instead! It will get abstract soon!
+     */
+    @Deprecated(forRemoval = true)
+    public T validate(ServerCommandSource source, ParsedRule<T> currentRule, T newValue, String string) {
+        throw new IllegalStateException("Called Validator that doesn't implement either the old nor the new validate method");
     }
 
     public static class _COMMAND<T> extends Validator<T>
     {
         @Override
-        public T validate(ServerCommandSource source, ParsedRule<T> currentRule, T newValue, String string)
+        public T validate(ServerCommandSource source, CarpetRule<T> currentRule, T newValue, String string)
         {
             if (CarpetServer.settingsManager != null && source != null)
                 CarpetServer.settingsManager.notifyPlayersCommandsChanged();
@@ -37,7 +85,7 @@ public abstract class Validator<T>
     public static class _CLIENT<T> extends Validator<T>
     {
         @Override
-        public T validate(ServerCommandSource source, ParsedRule<T> currentRule, T newValue, String string)
+        public T validate(ServerCommandSource source, CarpetRule<T> currentRule, T newValue, String string)
         {
             return newValue;
         }
@@ -48,23 +96,24 @@ public abstract class Validator<T>
     }
 
     public static class _COMMAND_LEVEL_VALIDATOR extends Validator<String> {
-        private static List<String> OPTIONS = List.of("true", "false", "ops", "0", "1", "2", "3", "4");
-        @Override public String validate(ServerCommandSource source, ParsedRule<String> currentRule, String newValue, String userString) {
-            if (!OPTIONS.contains(userString.toLowerCase(Locale.ROOT)))
+        public static final List<String> OPTIONS = List.of("true", "false", "ops", "0", "1", "2", "3", "4");
+        @Override
+        public String validate(ServerCommandSource source, CarpetRule<String> currentRule, String newValue, String userString) {
+            if (!OPTIONS.contains(newValue))
             {
                 Messenger.m(source, "r Valid options for command type rules is 'true' or 'false'");
                 Messenger.m(source, "r Optionally you can choose 'ops' to only allow operators");
                 Messenger.m(source, "r or provide a custom required permission level");
                 return null;
             }
-            return userString.toLowerCase(Locale.ROOT);
+            return newValue;
         }
         @Override public String description() { return "Can be limited to 'ops' only, or a custom permission level";}
     }
     
-    public static class _SCARPET<T> extends Validator<T> {
+    public static class _SCARPET<T> extends Validator<T> { //TODO remove?
         @Override
-        public T validate(ServerCommandSource source, ParsedRule<T> currentRule, T newValue, String string)
+        public T validate(ServerCommandSource source, CarpetRule<T> currentRule, T newValue, String string)
         {
             return newValue;
         }
@@ -76,9 +125,9 @@ public abstract class Validator<T>
     public static class WIP<T> extends Validator<T>
     {
         @Override
-        public T validate(ServerCommandSource source, ParsedRule<T> currentRule, T newValue, String string)
+        public T validate(ServerCommandSource source, CarpetRule<T> currentRule, T newValue, String string)
         {
-            Messenger.m(source, "r "+currentRule.name+" is missing a few bits - we are still working on it.");
+            Messenger.m(source, "r "+currentRule.name()+" is missing a few bits - we are still working on it.");
             return newValue;
         }
         @Override
@@ -87,27 +136,11 @@ public abstract class Validator<T>
     public static class _STRICT<T> extends Validator<T>
     {
         @Override
-        public T validate(ServerCommandSource source, ParsedRule<T> currentRule, T newValue, String string)
+        public T validate(ServerCommandSource source, CarpetRule<T> currentRule, T newValue, String string)
         {
-            if (!currentRule.options.contains(string))
+            if (!currentRule.suggestions().contains(string))
             {
-                Messenger.m(source, "r Valid options: " + currentRule.options.toString());
-                return null;
-            }
-            return newValue;
-        }
-    }
-
-    public static class _STRICT_IGNORECASE<T> extends Validator<T>
-    {
-        @Override
-        public T validate(ServerCommandSource source, ParsedRule<T> currentRule, T newValue, String string)
-        {
-            if (!currentRule.options.stream().map(s->s.toLowerCase(Locale.ROOT)).collect(Collectors.toSet())
-                    .contains(string.toLowerCase(Locale.ROOT)))
-            {
-                Messenger.m(source, "r Valid options (case insensitive): " + currentRule.options.toString());
-                return null;
+                Messenger.m(source, "r Valid options: " + currentRule.suggestions().toString());
             }
             return newValue;
         }
@@ -116,7 +149,7 @@ public abstract class Validator<T>
     public static class NONNEGATIVE_NUMBER <T extends Number> extends Validator<T>
     {
         @Override
-        public T validate(ServerCommandSource source, ParsedRule<T> currentRule, T newValue, String string)
+        public T validate(ServerCommandSource source, CarpetRule<T> currentRule, T newValue, String string)
         {
             return newValue.doubleValue() >= 0 ? newValue : null;
         }
@@ -127,7 +160,7 @@ public abstract class Validator<T>
     public static class PROBABILITY <T extends Number> extends Validator<T>
     {
         @Override
-        public T validate(ServerCommandSource source, ParsedRule<T> currentRule, T newValue, String string)
+        public T validate(ServerCommandSource source, CarpetRule<T> currentRule, T newValue, String string)
         {
             return (newValue.doubleValue() >= 0 && newValue.doubleValue() <= 1 )? newValue : null;
         }

--- a/src/main/java/carpet/utils/Translations.java
+++ b/src/main/java/carpet/utils/Translations.java
@@ -11,32 +11,33 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
 public class Translations
 {
-    private static Map<String, String> translationMap;
+    private static Map<String, String> translationMap = Map.of();
 
     public static String tr(String key)
     {
-        return translationMap == null ? key : translationMap.getOrDefault(key, key);
+        return translationMap.getOrDefault(key, key);
     }
 
     public static String tr(String key, String str)
     {
-        return translationMap == null ? str : translationMap.getOrDefault(key, str);
+        return translationMap.getOrDefault(key, str);
     }
 
     public static boolean hasTranslations()
     {
-        return translationMap != null;
+        return !translationMap.isEmpty();
     }
 
     public static boolean hasTranslation(String key)
     {
-        return translationMap != null && translationMap.containsKey(key);
+        return translationMap.containsKey(key);
     }
 
     public static Map<String, String> getTranslationFromResourcePath(String path)
@@ -59,7 +60,7 @@ public class Translations
     {
         if (CarpetSettings.language.equalsIgnoreCase("none"))
         {
-            translationMap = null;
+            translationMap = Collections.emptyMap();
             return;
         }
         Map<String, String> translations = new HashMap<>();
@@ -69,18 +70,15 @@ public class Translations
         for (CarpetExtension ext : CarpetServer.extensions)
         {
             Map<String, String> extMappings = ext.canHasTranslations(CarpetSettings.language);
-            if (extMappings != null)
+            extMappings.forEach((key, value) ->
             {
-                extMappings.forEach((key, value) ->
-                {
-                    if (!translations.containsKey(key)) translations.put(key, value);
-                });
-            }
+                if (!translations.containsKey(key)) translations.put(key, value);
+            });
         }
         translations.entrySet().removeIf(e -> e.getKey().startsWith("//"));
         if (translations.isEmpty())
         {
-            translationMap = null;
+            translationMap = Collections.emptyMap();
             return;
         }
         translationMap = translations;

--- a/src/main/java/carpet/utils/TypedField.java
+++ b/src/main/java/carpet/utils/TypedField.java
@@ -1,0 +1,98 @@
+package carpet.utils;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import org.apache.commons.lang3.ClassUtils;
+
+/**
+ * <p>A wrapper around a {@link Field} that uses a {@link VarHandle} and {@link MethodHandle}s to retrieve and set the contents of the field</p>
+ * 
+ * <p>It keeps the memory semantics of {@code volatile} if the field had that modifier.</p><!-- TODO is this needed? -->
+ *
+ * @param <T> The {@link Field}'s type
+ */
+public final class TypedField<T> {
+	private final VarHandle handle;
+	private final Class<T> returnType;
+	private final boolean isVolatile;
+	
+	/**
+	 * <p>Constructs a {@link TypedField} around the passed {@link Field}.</p>
+	 * @param field The {@link Field} to be around
+	 * @throws IllegalAccessException If the class doesn't have read/write access to the passed field
+	 */
+	@SuppressWarnings("unchecked") // The only place we extract T from is the field's type, and primitive and wrappers have the same generic type
+	public TypedField(Field field) throws IllegalAccessException {
+		this.returnType = (Class<T>) ClassUtils.primitiveToWrapper(field.getType());
+		this.handle = MethodHandles.lookup().unreflectVarHandle(field);
+		this.isVolatile = Modifier.isVolatile(field.getModifiers());
+		// TODO Use MethodHandles.varHandleExactInvoker? Would remove the isVolatile boolean (would be at constr), but would force a try catch in get/set methods
+	}
+	
+	/**
+	 * <p>Gets the contents of the field, in case it's static.</p>
+	 * 
+	 * <p>Throws otherwise</p>
+	 */
+	public T getStatic() {
+		if (isVolatile) {
+			return (T) handle.getVolatile();
+		}
+		return (T) handle.get();
+	}
+	
+	/**
+	 * <p>Gets the contents of the field, in case it's bound to an instance, and the passed object is an instance of it.</p>
+	 * 
+	 * <p>Throws otherwise.</p>
+	 * @param instance An instance of the class that contains this field
+	 */
+	public T get(Object instance) {
+		if (isVolatile) {
+			return (T) handle.getVolatile(instance);
+		}
+		return (T) handle.get(instance);
+	}
+	
+	/**
+	 * <p>Sets the contents of the field, in case it's static</p>
+	 * 
+	 * <p>Throws otherwise</p>
+	 * 
+	 * @param content The contents to put in the field
+	 */
+	public void setStatic(T content) {
+		if (isVolatile) {
+			handle.setVolatile(content);
+		} else {
+			handle.set(content);
+		}
+	}
+	
+	/**
+	 * <p>Sets the contents of the field, in case it's bound to an instance, and the passed object is an instance of it.</p>
+	 * 
+	 * <p>Throws otherwise</p>
+	 * 
+	 * @param instance An instance of the class that contains this field
+	 * @param content The contents to put in the instance's field
+	 */
+	public void set(Object instance, T content) {
+		if (isVolatile) {
+			handle.setVolatile(instance, content);
+		} else {
+			handle.set(instance, content);
+		}
+	}
+	
+	/**
+	 * <p>Returns the wrapped type of the contents of this field.</p>
+	 */
+	public Class<T> type() {
+		return returnType;
+	}
+}


### PR DESCRIPTION
Resolves #1091, Resolves #1102.

More changes related to settings:
- Adds support for more field types in `ParsedRule` (they are now easier to add)
- Uses a new `TypedField` class for managing `ParsedRule` fields
- Fixes all possible exceptions (I found) when setting rules caused by Carpet and handles them with nicer messages (such as entering letters to numeric fields, etc)
- Moves many `ParsedRule` methods to `RuleHelper` so those aren't needed in every implementation, since they can be made without accessing internal state
- Makes rule observers use a new `RuleObserver` `@FunctionalInterface` instead of a generic `TriFunction`
- Keeps fallback `@Deprecated(forRemoval)` methods and fields for those that were previously public (and were likely used, the ones that definitely weren't have been encapsulated) to prevent crashes with extensions using them

At the same time:

- Changes the translation system to not use `null` maps but empty ones
- Removes the old `CarpetServer#registerCarpetCommands(CommandDispatcher)`
- Changes `chainStone` setting to use an enum
- Makes `lightEngineMaxBatchSize` validator not set the rule field (it's not guaranteed to exist in the new API), but pass the value being set to the method that changes those

The intention is to after some versions make ParsedRule package-private, or at least make all its fields private (for more specifics see comments around the `@Deprecated` annotations). The motivation for this started after some binary incompatibilities caused by #1009, the difficulty I've had to be properly extend it, and some older incompatibilities I can't remember where did they come from.

For another PR I'd like to change a bit the Scarpet rule implementation (as stated in the TODOs) to be in a subclass of ParsedRule (or something like that), once that is properly encapsulated.