### PR TITLE
Add local server entity id fix

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -991,4 +991,32 @@ public class CarpetSettings
             return "Cannot be negative, can be true, false, or # > 0";
         }
     }
+
+    private static class LocalServerEntityIdFixValidator extends Validator<Boolean>
+    {
+        @Override public Boolean validate(ServerCommandSource source, ParsedRule<Boolean> currentRule, Boolean newValue, String string)
+        {
+            if (currentRule.get().equals(newValue) || source == null)
+            {
+                return newValue;
+            }
+            MinecraftServer server = source.getServer();
+            if (!server.isDedicated())
+            {
+                return newValue;
+            }
+            else
+            {
+                Messenger.m(source, "r the local server entity id fix can only be enabled on a local server.");
+                return currentRule.get();
+            }
+        }
+    }
+    @Rule(
+            desc = "Fix client rendering incrementing local server entity id counter.",
+            extra = {"Fixes [MC-238384](https://bugs.mojang.com/browse/MC-238384)."},
+            category = {BUGFIX},
+            validate = LocalServerEntityIdFixValidator.class
+    )
+    public static boolean localServerEntityIdFix = false;
 }

--- a/src/main/java/carpet/mixins/EntityMixin.java
+++ b/src/main/java/carpet/mixins/EntityMixin.java
@@ -1,5 +1,6 @@
 package carpet.mixins;
 
+import carpet.CarpetSettings;
 import carpet.fakes.EntityInterface;
 import carpet.patches.EntityPlayerMPFake;
 import net.minecraft.entity.Entity;
@@ -10,11 +11,16 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Mixin(Entity.class)
 public abstract class EntityMixin implements EntityInterface
 {
+    private static final AtomicInteger SERVER_CURRENT_ID = new AtomicInteger();
+
     @Shadow
     public float yaw;
     
@@ -24,6 +30,19 @@ public abstract class EntityMixin implements EntityInterface
     @Shadow public @Nullable abstract Entity getPrimaryPassenger();
 
     @Shadow public World world;
+
+    @Shadow public abstract void setId(int id);
+
+    @Inject(at=@At("RETURN"), method="<init>")
+    private void constructor(CallbackInfo info) {
+        if(CarpetSettings.localServerEntityIdFix) {
+            if (!world.isClient()) {
+                setId(SERVER_CURRENT_ID.incrementAndGet());
+            }
+        } else {
+            SERVER_CURRENT_ID.incrementAndGet();
+        }
+    }
 
     public float getMainYaw(float partialTicks)
     {


### PR DESCRIPTION
This fix allows [2No2Name's wireless redstone](https://www.youtube.com/watch?v=hr-twzxs6FM) to work 100% reliably in single player. It (somewhat hackily) separates the entity id counter for server entities from the counter for renderer entities.

I'm fairly confident there is a better way to accomplish this, feedback greatly appreciated