### PR TITLE
fixed logger option bug

### DIFF
--- a/src/main/java/carpet/commands/LogCommand.java
+++ b/src/main/java/carpet/commands/LogCommand.java
@@ -13,11 +13,7 @@ import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.entity.player.PlayerEntity;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.mojang.brigadier.arguments.StringArgumentType.getString;
 import static net.minecraft.command.CommandSource.suggestMatching;
@@ -201,15 +197,19 @@ public class LogCommand
             Messenger.m(source, "r Unknown logger: ","rb "+logname);
             return 0;
         }
+        if (!Arrays.asList(LoggerRegistry.getLogger(logname).getOptions()).contains(option)) {
+            Messenger.m(source, "r Unknown option: ","rb "+option);
+            return 0;
+        }
         LoggerRegistry.subscribePlayer(player_name, logname, option);
-        if (option!=null)
-        {
-            Messenger.m(source, "gi Subscribed to " + logname + "(" + option + ")");
-        }
-        else
-        {
-            Messenger.m(source, "gi Subscribed to " + logname);
-        }
-            return 1;
+            if (option != null)
+            {
+                Messenger.m(source, "gi Subscribed to " + logname + "(" + option + ")");
+            }
+            else
+            {
+                Messenger.m(source, "gi Subscribed to " + logname);
+            }
+        return 1;
     }
 }

--- a/src/main/java/carpet/commands/LogCommand.java
+++ b/src/main/java/carpet/commands/LogCommand.java
@@ -13,7 +13,12 @@ import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.entity.player.PlayerEntity;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Arrays;
 
 import static com.mojang.brigadier.arguments.StringArgumentType.getString;
 import static net.minecraft.command.CommandSource.suggestMatching;
@@ -197,19 +202,20 @@ public class LogCommand
             Messenger.m(source, "r Unknown logger: ","rb "+logname);
             return 0;
         }
-        if (!Arrays.asList(LoggerRegistry.getLogger(logname).getOptions()).contains(option)) {
-            Messenger.m(source, "r Unknown option: ","rb "+option);
+        if (!LoggerRegistry.getLogger(logname).isOptionValid(option))
+        {
+            Messenger.m(source, "r Invalid option: ", "rb "+option);
             return 0;
         }
         LoggerRegistry.subscribePlayer(player_name, logname, option);
-            if (option != null)
-            {
-                Messenger.m(source, "gi Subscribed to " + logname + "(" + option + ")");
-            }
-            else
-            {
-                Messenger.m(source, "gi Subscribed to " + logname);
-            }
+        if (option != null)
+        {
+            Messenger.m(source, "gi Subscribed to " + logname + "(" + option + ")");
+        }
+        else
+        {
+            Messenger.m(source, "gi Subscribed to " + logname);
+        }
         return 1;
     }
 }

--- a/src/main/java/carpet/logging/HUDLogger.java
+++ b/src/main/java/carpet/logging/HUDLogger.java
@@ -9,10 +9,15 @@ public class HUDLogger extends Logger
 {
     static Logger stardardHUDLogger(String logName, String def, String [] options)
     {
+        return stardardHUDLogger(logName, def, options, false);
+    }
+
+    static Logger stardardHUDLogger(String logName, String def, String [] options, boolean strictOptions)
+    {
         // should convert to factory method if more than 2 classes are here
         try
         {
-            return new HUDLogger(LoggerRegistry.class.getField("__"+logName), logName, def, options);
+            return new HUDLogger(LoggerRegistry.class.getField("__"+logName), logName, def, options, strictOptions);
         }
         catch (NoSuchFieldException e)
         {
@@ -20,9 +25,9 @@ public class HUDLogger extends Logger
         }
     }
 
-    public HUDLogger(Field field, String logName, String def, String[] options)
+    public HUDLogger(Field field, String logName, String def, String[] options, boolean strictOptions)
     {
-        super(field, logName, def, options);
+        super(field, logName, def, options, strictOptions);
     }
 
     @Override

--- a/src/main/java/carpet/logging/HUDLogger.java
+++ b/src/main/java/carpet/logging/HUDLogger.java
@@ -30,6 +30,11 @@ public class HUDLogger extends Logger
         super(field, logName, def, options, strictOptions);
     }
 
+    @Deprecated
+    public HUDLogger(Field field, String logName, String def, String[] options) {
+        super(field, logName, def, options, false);
+    }
+
     @Override
     public void removePlayer(String playerName)
     {

--- a/src/main/java/carpet/logging/Logger.java
+++ b/src/main/java/carpet/logging/Logger.java
@@ -51,6 +51,11 @@ public class Logger
         }
     }
 
+    @Deprecated
+    public Logger(Field acceleratorField, String logName, String def, String [] options) {
+        this(acceleratorField, logName, def, options, false);
+    }
+
     public Logger(Field acceleratorField, String logName, String def, String [] options, boolean strictOptions)
     {
         subscribedOnlinePlayers = new HashMap<>();

--- a/src/main/java/carpet/logging/Logger.java
+++ b/src/main/java/carpet/logging/Logger.java
@@ -32,11 +32,18 @@ public class Logger
 
     private Field acceleratorField;
 
+    private boolean strictOptions;
+
     static Logger stardardLogger(String logName, String def, String [] options)
+    {
+        return stardardLogger(logName, def, options, false);
+    }
+
+    static Logger stardardLogger(String logName, String def, String [] options, boolean strictOptions)
     {
         try
         {
-            return new Logger(LoggerRegistry.class.getField("__"+logName), logName, def, options);
+            return new Logger(LoggerRegistry.class.getField("__"+logName), logName, def, options, strictOptions);
         }
         catch (NoSuchFieldException e)
         {
@@ -44,7 +51,7 @@ public class Logger
         }
     }
 
-    public Logger(Field acceleratorField, String logName, String def, String [] options)
+    public Logger(Field acceleratorField, String logName, String def, String [] options, boolean strictOptions)
     {
         subscribedOnlinePlayers = new HashMap<>();
         subscribedOfflinePlayers = new HashMap<>();
@@ -52,6 +59,7 @@ public class Logger
         this.logName = logName;
         this.default_option = def;
         this.options = options;
+        this.strictOptions = strictOptions;
         if (acceleratorField == null)
             CarpetSettings.LOG.error("[CM] Logger "+getLogName()+" is missing a specified accelerator");
     }
@@ -231,5 +239,13 @@ public class Logger
     {
         if (options != null && Arrays.asList(options).contains(arg)) return arg;
         return null;
+    }
+
+    public boolean isOptionValid(String option) {
+        if (strictOptions)
+        {
+            return Arrays.asList(this.options).contains(option);
+        }
+        return true;
     }
 }

--- a/src/main/java/carpet/logging/LoggerRegistry.java
+++ b/src/main/java/carpet/logging/LoggerRegistry.java
@@ -38,7 +38,7 @@ public class LoggerRegistry
 
     public static void registerLoggers()
     {
-        registerLogger("tnt", Logger.stardardLogger( "tnt", "brief", new String[]{"brief", "full"}));
+        registerLogger("tnt", Logger.stardardLogger( "tnt", "brief", new String[]{"brief", "full"}, true));
         registerLogger("projectiles", Logger.stardardLogger("projectiles", "brief",  new String[]{"brief", "full"}));
         registerLogger("fallingBlocks",Logger.stardardLogger("fallingBlocks", "brief", new String[]{"brief", "full"}));
         registerLogger("pathfinding", Logger.stardardLogger("pathfinding", "20", new String[]{"2", "5", "10"}));
@@ -46,7 +46,7 @@ public class LoggerRegistry
         registerLogger("packets", HUDLogger.stardardHUDLogger("packets", null, null));
         registerLogger("counter",HUDLogger.stardardHUDLogger("counter","white", Arrays.stream(DyeColor.values()).map(Object::toString).toArray(String[]::new)));
         registerLogger("mobcaps", HUDLogger.stardardHUDLogger("mobcaps", "dynamic",new String[]{"dynamic", "overworld", "nether","end"}));
-        registerLogger("explosions", HUDLogger.stardardLogger("explosions", "brief",new String[]{"brief", "full"}));
+        registerLogger("explosions", Logger.stardardLogger("explosions", "brief",new String[]{"brief", "full"}, true));
 
     }
 


### PR DESCRIPTION
Fixed a small bug I noticed when working with the explosion logger. Putting in an invalid option is not caught by carpet mod. Basically you could run the command /log explosions invalid (where invalid can be any random string) and it would allow that. When it logs an explosions, the logger would just output the tick but no actual info about the explosion. All I did was add a check to the LogCommand.java class which checks if the given option is a valid option or not. 