### PR TITLE
Fixed issue about shadowed fields in UpdateStructureBlockC2SPacketMixin

### DIFF
--- a/src/main/java/carpet/mixins/UpdateStructureBlockC2SPacketMixin.java
+++ b/src/main/java/carpet/mixins/UpdateStructureBlockC2SPacketMixin.java
@@ -8,7 +8,9 @@ import net.minecraft.network.packet.c2s.play.UpdateStructureBlockC2SPacket;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3i;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -16,9 +18,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(UpdateStructureBlockC2SPacket.class)
 public class UpdateStructureBlockC2SPacketMixin {
-    @Shadow
+    @Mutable @Final @Shadow
     private BlockPos offset;
-    @Shadow
+    @Mutable @Final @Shadow
     private Vec3i size;
 
     @Inject(


### PR DESCRIPTION
Added missing `@Mutable` `@Final` annotations in `carpet.mixins.UpdateStructureBlockC2SPacketMixin`

Fixed #1101
