### PR TITLE
Fix Stack Overflow in development environment with mojmap

### DIFF
--- a/src/main/java/carpet/fakes/ThreadedAnvilChunkStorageInterface.java
+++ b/src/main/java/carpet/fakes/ThreadedAnvilChunkStorageInterface.java
@@ -14,5 +14,5 @@ public interface ThreadedAnvilChunkStorageInterface
 
     void releaseRelightTicket(ChunkPos pos);
 
-    Iterable<ChunkHolder> getChunks();
+    Iterable<ChunkHolder> getChunksCM();
 }

--- a/src/main/java/carpet/mixins/ServerChunkManager_tickMixin.java
+++ b/src/main/java/carpet/mixins/ServerChunkManager_tickMixin.java
@@ -62,7 +62,7 @@ public abstract class ServerChunkManager_tickMixin
             // simplified chunk tick iteration assuming world is frozen otherwise as suggested by Hadron67
             // to be kept in sync with the original injection source
             if (!debug){
-                List<ChunkHolder> holders = Lists.newArrayList(((ThreadedAnvilChunkStorageInterface)threadedAnvilChunkStorage).getChunks());
+                List<ChunkHolder> holders = Lists.newArrayList(((ThreadedAnvilChunkStorageInterface)threadedAnvilChunkStorage).getChunksCM());
                 Collections.shuffle(holders);
                 for (ChunkHolder holder: holders){
                     Optional<WorldChunk> optional = holder.getTickingFuture().getNow(ChunkHolder.UNLOADED_WORLD_CHUNK).left();

--- a/src/main/java/carpet/mixins/ThreadedAnvilChunkStorage_scarpetChunkCreationMixin.java
+++ b/src/main/java/carpet/mixins/ThreadedAnvilChunkStorage_scarpetChunkCreationMixin.java
@@ -484,7 +484,7 @@ public abstract class ThreadedAnvilChunkStorage_scarpetChunkCreationMixin implem
     }
 
     @Override
-    public Iterable<ChunkHolder> getChunks() {
+    public Iterable<ChunkHolder> getChunksCM() {
         return entryIterator();
     }
 }


### PR DESCRIPTION
Simple rename.

This occurs because getChunks is a method of TACS (ChunkMap) in mojmap, and mixin by default overwrites whatever it finds, and it actually calls the same method, so it ends up being a recursive call until there's a StackOverflow.