### PR TITLE
Fixed player ticking issue caused by rule updateSuppressionCrashFix

### DIFF
--- a/src/main/java/carpet/mixins/ServerPlayerEntity_updateSuppressionCrashFixMixin.java
+++ b/src/main/java/carpet/mixins/ServerPlayerEntity_updateSuppressionCrashFixMixin.java
@@ -4,17 +4,23 @@ import carpet.CarpetSettings;
 import carpet.helpers.ThrowableSuppression;
 import carpet.logging.LoggerRegistry;
 import carpet.utils.Messenger;
+import com.mojang.authlib.GameProfile;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.BaseText;
 import net.minecraft.util.crash.CrashException;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ServerPlayerEntity.class)
-public class ServerPlayerEntity_updateSuppressionCrashFixMixin {
+public class ServerPlayerEntity_updateSuppressionCrashFixMixin extends PlayerEntity {
+
+    public ServerPlayerEntity_updateSuppressionCrashFixMixin(World world, BlockPos pos, float yaw, GameProfile profile) {
+        super(world, pos, yaw, profile);
+    }
 
     @Redirect(
             method = "playerTick()V",
@@ -26,11 +32,11 @@ public class ServerPlayerEntity_updateSuppressionCrashFixMixin {
     )
     private void fixUpdateSuppressionCrashPlayerTick(PlayerEntity playerEntity){
         if (!CarpetSettings.updateSuppressionCrashFix) {
-            playerEntity.tick();
+            super.tick();
             return;
         }
         try {
-            playerEntity.tick();
+            super.tick();
         } catch (CrashException e) {
             if (!(e.getCause() instanceof ThrowableSuppression throwableSuppression)) throw e;
             logUpdateSuppressionPlayer(throwableSuppression.pos);
@@ -51,5 +57,22 @@ public class ServerPlayerEntity_updateSuppressionCrashFixMixin {
                 )};
             });
         }
+    }
+
+    // make mixin happy
+
+    @Override
+    public boolean isSpectator() {
+        return false;
+    }
+
+    @Override
+    public boolean isCreative() {
+        return false;
+    }
+
+    @Override
+    public boolean cannotBeSilenced() {
+        return super.cannotBeSilenced();
     }
 }


### PR DESCRIPTION
## Issue

- Player entities will never executes their `PlayerEntity#tick` method, resulting in player cannot pick up items etc.
- Ticking carpet fake player crashes the server

## Analyzation

In `@Redirect` in `ServerPlayerEntity_updateSuppressionCrashFixMixin`

https://github.com/gnembon/fabric-carpet/blob/07140983471214ddf7b8bd4eb679046ef2063305/src/main/java/carpet/mixins/ServerPlayerEntity_updateSuppressionCrashFixMixin.java#L19-L40

It invokes `playerEntity.tick()`, but this will actually invokes `ServerPlayerEntity#tick` but not `PlayerEntity#tick`

## Fix

Basically it just replaces all directly `playerEntity.tick()` with `super.tick()` in `ServerPlayerEntity_updateSuppressionCrashFixMixin`
