### PR TITLE
Giving scarpet powers of perimeterinfo

### DIFF
--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -105,6 +105,7 @@ public class CarpetScriptServer
         registerBuiltInScript(BundledModule.carpetNative("draw_beta", false));
         registerBuiltInScript(BundledModule.carpetNative("shapes", true));
         registerBuiltInScript(BundledModule.carpetNative("distance_beta", false));
+        registerBuiltInScript(BundledModule.carpetNative("perimeter_info_beta", false));
     }
 
     public CarpetScriptServer(MinecraftServer server)

--- a/src/main/java/carpet/script/api/Entities.java
+++ b/src/main/java/carpet/script/api/Entities.java
@@ -161,7 +161,7 @@ public class Entities {
             CarpetContext cc = (CarpetContext)c;
             if (lv.size() < 2)
                 throw new InternalExpressionException("'can_spawn' function takes mob name, and position to check for spawning conditions");
-            String entityString = lv.get(0).getString();//todo remove test func : /script run can_spawn('cow',0,1,0)
+            String entityString = lv.get(0).getString();
             Identifier entityId;
             try {
                 entityId = Identifier.fromCommandInput(new StringReader(entityString));

--- a/src/main/java/carpet/script/api/Entities.java
+++ b/src/main/java/carpet/script/api/Entities.java
@@ -13,7 +13,6 @@ import carpet.script.value.NBTSerializableValue;
 import carpet.script.value.BooleanValue;
 import carpet.script.value.NumericValue;
 import carpet.script.value.Value;
-import carpet.utils.Messenger;
 import carpet.utils.PerimeterDiagnostics;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;

--- a/src/main/java/carpet/utils/PerimeterDiagnostics.java
+++ b/src/main/java/carpet/utils/PerimeterDiagnostics.java
@@ -1,22 +1,21 @@
 package carpet.utils;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.Material;
-import net.minecraft.block.BlockState;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnGroup;
-import net.minecraft.entity.SpawnRestriction;
 import net.minecraft.entity.SpawnReason;
-import net.minecraft.entity.mob.WaterCreatureEntity;
+import net.minecraft.entity.SpawnRestriction;
 import net.minecraft.entity.mob.AmbientEntity;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.mob.Monster;
+import net.minecraft.entity.mob.WaterCreatureEntity;
 import net.minecraft.entity.passive.PassiveEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.SpawnHelper;
-import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.SpawnSettings;
 
 import java.util.ArrayList;
@@ -184,6 +183,29 @@ public class PerimeterDiagnostics
             return el.canSpawn(worldServer) && el.canSpawn(worldServer, SpawnReason.NATURAL) &&
                     SpawnRestriction.canSpawn(el.getType(),(ServerWorld)el.getEntityWorld(), SpawnReason.NATURAL, el.getBlockPos(), el.getEntityWorld().random) &&
                     worldServer.isSpaceEmpty(el); // check collision rules once they stop fiddling with them after 1.14.1
+        }
+        return false;
+    }
+
+    public static boolean checkEntitySpawn(ServerWorld worldServer, BlockPos pos, MobEntity mob) {
+        SpawnSettings.SpawnEntry spawnEntry = null;
+        for (SpawnSettings.SpawnEntry sle: worldServer.getChunkManager().getChunkGenerator().getEntitySpawnList(worldServer.getBiome(pos), worldServer.getStructureAccessor(), mob.getType().getSpawnGroup(), pos).getEntries()) {
+            if (mob.getType() == sle.type) {
+                spawnEntry = sle;
+                break;
+            }
+        }
+        if (spawnEntry == null || !worldServer.getChunkManager().getChunkGenerator().getEntitySpawnList(worldServer.getBiome(pos), worldServer.getStructureAccessor(), mob.getType().getSpawnGroup(), pos).getEntries().contains(spawnEntry)) {
+            return false;
+        }
+
+        SpawnRestriction.Location spt = SpawnRestriction.getLocation(spawnEntry.type);
+
+        if (SpawnHelper.canSpawn(spt, worldServer, pos, spawnEntry.type)) {
+            mob.refreshPositionAndAngles((float)pos.getX() + 0.5F, (float)pos.getY(), (float)pos.getZ()+0.5F, 0.0F, 0.0F);
+            return mob.canSpawn(worldServer) && mob.canSpawn(worldServer, SpawnReason.NATURAL) &&
+                    SpawnRestriction.canSpawn(mob.getType(),(ServerWorld)mob.getEntityWorld(), SpawnReason.NATURAL, pos, mob.getEntityWorld().random) &&
+                    worldServer.isSpaceEmpty(mob); // check collision rules once they stop fiddling with them after 1.14.1
         }
         return false;
     }

--- a/src/main/resources/assets/carpet/scripts/perimeter_info_beta.sc
+++ b/src/main/resources/assets/carpet/scripts/perimeter_info_beta.sc
@@ -1,0 +1,58 @@
+import('shapes', 'draw_sphere');
+
+__config() -> {
+    'commands' -> {
+        '' -> ['_check_spawn', null, ''],
+        '<centre_pos>' -> ['_check_spawn', ''],
+        '<centre_pos> <mob_entitytype>' -> '_check_spawn'
+    }
+};
+
+_check_spawn(centre_pos, mob_string) -> (
+    centre_pos = if(centre_pos == null, pos(player()), centre_pos + [0.5, 0, 0.5]);
+
+    land_count = 0;
+    water_count = 0;
+    count = 0;
+    samples = [];
+
+    mob = if(mob_string!='', spawn(mob_string, centre_pos), null);
+
+    c_for(x = -128, x <= 128, x += 1, //todo use shapes library at some point when it's fixed
+        c_for(y = -128, y <= 128, y += 1,
+            c_for(z = -128, z <= 128, z += 1,
+                if(x*x + y*y + z*z > 128*128*128, continue());
+                pos = centre_pos + [x, y, z];
+                foot_block = block(pos);
+                standing_block = block(pos + [0, -1, 0]);
+                if(!solid(foot_block) && standing_block != 'bedrock' && standing_block != 'barrier' &&
+                    (solid(standing_block) || standing_block == 'water'), //failing early to be faster
+
+                    if(air(foot_block) && solid(standing_block),
+                        land_count += 1
+                    );
+                    if(foot_block=='water' && standing_block == 'water' && !solid(block(pos + [0, 1, 0])),
+                        water_count += 1
+                    );
+                    if(can_spawn(mob, pos),
+                        count +=1;
+                        if(length(samples) < 10, samples += pos)
+                    )
+                )
+            )
+        )
+    );
+
+    if(mob_string!='', modify(mob, 'remove'));
+    print(player(), format(
+        'w Spawning spaces around ', 'cb ' + str(pos), 'w :\n',
+        'w   potential in-liquid: ', 'wb ' + water_count,
+        'w \n  potential on-ground: ', 'wb ' + land_count,
+    ));
+    if(mob, print(player(), format(
+        'w '+mob_string + ': ', 'wb '+ count
+    )));
+    if(samples, for(samples, s = _; print(player(), format(
+        'w   ', 'c '+ str(s) //todo tp command stuff here
+    ))));
+);


### PR DESCRIPTION
Fixes #153

Basically, this adds the `can_spawn()` function, which takes an entity or string, and a position. The reason it takes an entity or a string is cos passing an entity s a lot faster, cos then the function doesn't have to initiate its own entity and then kill it. I'll add this to the docs ofc.

As a side note, when coding this I came across the issue of drawing spheres, hence all the issues I have created in the past few days, cos I wanted to use those shapes. I'll leave this pr a draft, therefore, until another pr fixing shapes.scl is merged (and I'll link that here).

Still left to do:
- [ ] Add docs
- [ ] Use `shapes.scl` sphere instead of current slow version, once I fix that