### PR TITLE
Adding min_y, max_y and world_border_info to system_info

### DIFF
--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -667,6 +667,8 @@ Available options in the scarpet app space:
   * `world_gamerules` - returns all gamerules in a map form (`rule`->`value`). Like carpet rules, values are returned as strings, so you can use appropriate value conversions using `bool()` or `number()` to convert them to other values. Gamerules are read-only to discourage app programmers to mess up with the settings intentionally applied by server admins. Isn't that just super annoying when a datapack messes up with your gamerule settings? It is still possible to change them though using `run('gamerule ...`.
   * `world_spawn_point` - world spawn point
   * `world_time` - Returns dimension-specific tick counter.
+  * `world_max_y` - Returns maximum y-value in caller dimension. For other dimensions run `in_dimension('dimension', system_info('world_max_y')))`.
+  * `world_min_y` - Same as above, returning minimum y-value.
 
  Relevant gameplay related properties
   * `game_difficulty` - current difficulty of the game: `'peaceful'`, `'easy'`, `'normal'`, or `'hard'`

--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -665,7 +665,7 @@ Available options in the scarpet app space:
   * `world_folder` - name of the direct folder in the saves that holds world files
   * `world_carpet_rules` - returns all Carpet rules in a map form (`rule`->`value`). Note that the values are always returned as strings, so you can't do boolean comparisons directly. Includes rules from extensions with their namespace (`namespace:rule`->`value`). You can later listen to rule changes with the `on_carpet_rule_changes(rule, newValue)` event.
   * `world_gamerules` - returns all gamerules in a map form (`rule`->`value`). Like carpet rules, values are returned as strings, so you can use appropriate value conversions using `bool()` or `number()` to convert them to other values. Gamerules are read-only to discourage app programmers to mess up with the settings intentionally applied by server admins. Isn't that just super annoying when a datapack messes up with your gamerule settings? It is still possible to change them though using `run('gamerule ...`.
-  * `world_spawn_point` - world spawn point
+  * `world_spawn_point` - world spawn point in the overworld dimension
   * `world_time` - Returns dimension-specific tick counter.
   * `world_max_y` - Returns all dimension's maximum y-values in a map form (`dimension` -> `max_y`). Values are numeric
   * `world_min_y` - Same as above, returning minimum y-values instead.

--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -669,6 +669,7 @@ Available options in the scarpet app space:
   * `world_time` - Returns dimension-specific tick counter.
   * `world_max_y` - Returns all dimension's maximum y-values in a map form (`dimension` -> `max_y`). Values are numeric
   * `world_min_y` - Same as above, returning minimum y-values instead.
+  * `world_border_info` - Returns all dimension's world border info in a map form (`dimension` -> `[[centre_pos], radius]`). Note that the y-value of `centre_pos` is always 0.
 
  Relevant gameplay related properties
   * `game_difficulty` - current difficulty of the game: `'peaceful'`, `'easy'`, `'normal'`, or `'hard'`

--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -667,8 +667,8 @@ Available options in the scarpet app space:
   * `world_gamerules` - returns all gamerules in a map form (`rule`->`value`). Like carpet rules, values are returned as strings, so you can use appropriate value conversions using `bool()` or `number()` to convert them to other values. Gamerules are read-only to discourage app programmers to mess up with the settings intentionally applied by server admins. Isn't that just super annoying when a datapack messes up with your gamerule settings? It is still possible to change them though using `run('gamerule ...`.
   * `world_spawn_point` - world spawn point
   * `world_time` - Returns dimension-specific tick counter.
-  * `world_max_y` - Returns maximum y-value in caller dimension. For other dimensions run `in_dimension('dimension', system_info('world_max_y')))`.
-  * `world_min_y` - Same as above, returning minimum y-value.
+  * `world_max_y` - Returns all dimension's maximum y-values in a map form (`dimension` -> `max_y`). Values are numeric
+  * `world_min_y` - Same as above, returning minimum y-values instead.
 
  Relevant gameplay related properties
   * `game_difficulty` - current difficulty of the game: `'peaceful'`, `'easy'`, `'normal'`, or `'hard'`

--- a/src/main/java/carpet/script/utils/SystemInfo.java
+++ b/src/main/java/carpet/script/utils/SystemInfo.java
@@ -18,7 +18,9 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.SharedConstants;
 import net.minecraft.util.WorldSavePath;
+import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.GameRules;
+import net.minecraft.world.World;
 import net.minecraft.world.WorldProperties;
 
 import java.lang.management.ManagementFactory;
@@ -60,6 +62,9 @@ public class SystemInfo {
             WorldProperties prop = c.s.getServer().getOverworld().getLevelProperties();
             return ListValue.of(NumericValue.of(prop.getSpawnX()), NumericValue.of(prop.getSpawnY()), NumericValue.of(prop.getSpawnZ()));
         });
+        put("world_min_height", c-> new NumericValue(c.s.getWorld().getBottomY()));
+        put("world_max_height", c-> new NumericValue(c.s.getWorld().getLogicalHeight()));
+
         put("world_time", c -> new NumericValue(c.s.getWorld().getTime()));
 
         put("game_difficulty", c -> StringValue.of(c.s.getServer().getSaveProperties().getDifficulty().getName()));

--- a/src/main/java/carpet/script/utils/SystemInfo.java
+++ b/src/main/java/carpet/script/utils/SystemInfo.java
@@ -17,6 +17,7 @@ import com.sun.management.OperatingSystemMXBean;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.SharedConstants;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.WorldSavePath;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.GameRules;
@@ -62,8 +63,22 @@ public class SystemInfo {
             WorldProperties prop = c.s.getServer().getOverworld().getLevelProperties();
             return ListValue.of(NumericValue.of(prop.getSpawnX()), NumericValue.of(prop.getSpawnY()), NumericValue.of(prop.getSpawnZ()));
         });
-        put("world_min_height", c-> new NumericValue(c.s.getWorld().getBottomY()));
-        put("world_max_height", c-> new NumericValue(c.s.getWorld().getLogicalHeight()));
+
+        put("world_min_height", c-> {
+            Map<Value, Value> dimMap = new HashMap<>();
+            for (ServerWorld world : c.s.getServer().getWorlds()) {
+                dimMap.put(ValueConversions.of(world.getRegistryKey().getValue()), new NumericValue(world.getBottomY()));
+            }
+            return MapValue.wrap(dimMap);
+        });
+
+        put("world_max_height", c-> {
+            Map<Value, Value> dimMap = new HashMap<>();
+            for (ServerWorld world : c.s.getServer().getWorlds()) {
+                dimMap.put(ValueConversions.of(world.getRegistryKey().getValue()), new NumericValue(world.getLogicalHeight()));
+            }
+            return MapValue.wrap(dimMap);
+        });
 
         put("world_time", c -> new NumericValue(c.s.getWorld().getTime()));
 

--- a/src/main/java/carpet/script/utils/SystemInfo.java
+++ b/src/main/java/carpet/script/utils/SystemInfo.java
@@ -23,6 +23,7 @@ import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldProperties;
+import net.minecraft.world.border.WorldBorder;
 
 import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
@@ -76,6 +77,21 @@ public class SystemInfo {
             Map<Value, Value> dimMap = new HashMap<>();
             for (ServerWorld world : c.s.getServer().getWorlds()) {
                 dimMap.put(ValueConversions.of(world.getRegistryKey().getValue()), new NumericValue(world.getLogicalHeight()));
+            }
+            return MapValue.wrap(dimMap);
+        });
+
+        put("world_border_info", c-> {
+            Map<Value, Value> dimMap = new HashMap<>();
+            for (ServerWorld world : c.s.getServer().getWorlds()) {
+                WorldBorder worldBorder = world.getWorldBorder();
+                dimMap.put(
+                    ValueConversions.of(world.getRegistryKey().getValue()),
+                    ListValue.of(
+                        ListValue.fromTriple(worldBorder.getCenterX(), 0, worldBorder.getCenterZ()),
+                        new NumericValue(worldBorder.getMaxRadius())
+                    )
+                );
             }
             return MapValue.wrap(dimMap);
         });


### PR DESCRIPTION
Adds `world_min_y` and `world_max_y` to `system_info`. Rn only works in caller dimension, though I bet there's a way to get around that.