### PR TITLE
Fix typo

### DIFF
--- a/docs/scarpet/Full.md
+++ b/docs/scarpet/Full.md
@@ -3812,7 +3812,7 @@ Moves the entity by a vector from its current location.
 
 Sets the motion vector (where and how much entity is moving).
 
-### `modify(e, 'motion_z', x), modify(e, 'motion_y', y), modify(e, 'motion_z', z)`
+### `modify(e, 'motion_x', x), modify(e, 'motion_y', y), modify(e, 'motion_z', z)`
 
 Sets the corresponding component of the motion vector.
 


### PR DESCRIPTION
`modify(e, 'motion_z', x)` -> `modify(e, 'motion_x', x)`