### PR TITLE
[Scarpet] Task value refactor for better extendability

### DIFF
--- a/src/main/java/carpet/script/value/ThreadValue.java
+++ b/src/main/java/carpet/script/value/ThreadValue.java
@@ -19,15 +19,15 @@ public class ThreadValue extends Value
     private final long id;
     private static long sequence = 0L;
 
-    protected ThreadValue(CompletableFuture<Value> taskFuture, long id)
+    protected ThreadValue(CompletableFuture<Value> taskFuture)
     {
         this.taskFuture = taskFuture;
-        this.id = id;
+        this.id = sequence++;
     }
 
     public ThreadValue(Value pool, FunctionValue function, Expression expr, Tokenizer.Token token, Context ctx, List<Value> args)
     {
-        this(getCompletableFutureFromFunction(pool, function, expr, token, ctx, args), sequence++);
+        this(getCompletableFutureFromFunction(pool, function, expr, token, ctx, args));
         Thread.yield();
     }
 

--- a/src/main/java/carpet/script/value/ThreadValue.java
+++ b/src/main/java/carpet/script/value/ThreadValue.java
@@ -19,18 +19,29 @@ public class ThreadValue extends Value
     private final long id;
     private static long sequence = 0L;
 
+    protected ThreadValue(CompletableFuture<Value> taskFuture, long id)
+    {
+        this.taskFuture = taskFuture;
+        this.id = id;
+    }
+
     public ThreadValue(Value pool, FunctionValue function, Expression expr, Tokenizer.Token token, Context ctx, List<Value> args)
     {
-        id = sequence++;
+        this(getCompletableFutureFromFunction(pool, function, expr, token, ctx, args), sequence++);
+        Thread.yield();
+    }
+
+    public static CompletableFuture<Value> getCompletableFutureFromFunction(Value pool, FunctionValue function, Expression expr, Tokenizer.Token token, Context ctx, List<Value> args)
+    {
         ExecutorService executor = ctx.host.getExecutor(pool);
         if (executor == null)
         {
             // app is shutting down - no more threads can be spawned.
-            taskFuture = CompletableFuture.completedFuture(Value.NULL);
+            return CompletableFuture.completedFuture(Value.NULL);
         }
         else
         {
-            taskFuture = CompletableFuture.supplyAsync(
+            return CompletableFuture.supplyAsync(
                     () ->
                     {
                         try
@@ -52,7 +63,6 @@ public class ThreadValue extends Value
                     ctx.host.getExecutor(pool)
             );
         }
-        Thread.yield();
     }
 
     @Override

--- a/src/main/java/carpet/script/value/ThreadValue.java
+++ b/src/main/java/carpet/script/value/ThreadValue.java
@@ -19,7 +19,7 @@ public class ThreadValue extends Value
     private final long id;
     private static long sequence = 0L;
 
-    protected ThreadValue(CompletableFuture<Value> taskFuture)
+    public ThreadValue(CompletableFuture<Value> taskFuture)
     {
         this.taskFuture = taskFuture;
         this.id = sequence++;


### PR DESCRIPTION
This refactors the constructor of `ThreadValue`, in order to allow extending it in extensions more easily. As an example, in Discarpet I am hoping to use scarpet tasks as the return value of functions that run API calls, and as such, they take a while to finish and return a value. (https://github.com/replaceitem/carpet-discarpet/issues/18#issuecomment-986299250) However, the current constructor only allows for the creation of tasks from `FunctionValue`s.