### PR TITLE
Minor Docs update

### DIFF
--- a/docs/scarpet/Full.md
+++ b/docs/scarpet/Full.md
@@ -437,7 +437,7 @@ Or an example to find if a player has specific enchantment on a held axe (either
 
 <pre>
 global_get_enchantment(p, ench) -> (
-$   for(['main','offhand'],
+$   for(['mainhand','offhand'],
 $      holds = query(p, 'holds', _);
 $      if( holds,
 $         [what, count, nbt] = holds;

--- a/docs/scarpet/Full.md
+++ b/docs/scarpet/Full.md
@@ -437,7 +437,7 @@ Or an example to find if a player has specific enchantment on a held axe (either
 
 <pre>
 global_get_enchantment(p, ench) -> (
-$   for(['mainhand','offhand'],
+$   for(['main','offhand'],
 $      holds = query(p, 'holds', _);
 $      if( holds,
 $         [what, count, nbt] = holds;

--- a/docs/scarpet/api/Entities.md
+++ b/docs/scarpet/api/Entities.md
@@ -202,13 +202,19 @@ List of entities riding the entity.
 
 Entity that `e` rides.
 
-### `query(e, 'scoreboard_tags')` and 
 ### `query(e, 'tags')`(deprecated)
+
+Deprecated by `query(e, 'scoreboard_tags')`
+
+### `query(e, 'scoreboard_tags')`
 
 List of entity's scoreboard tags.
 
-### `query(e, 'has_scoreboard_tag',tag)` and
 ### `query(e, 'has_tag',tag)`(deprecated)
+
+Deprecated by `query(e, 'has_scoreboard_tag',tag)`
+
+### `query(e, 'has_scoreboard_tag',tag)`
 
 Boolean, true if the entity is marked with a `tag` scoreboad tag.
 

--- a/docs/scarpet/api/Entities.md
+++ b/docs/scarpet/api/Entities.md
@@ -202,7 +202,7 @@ List of entities riding the entity.
 
 Entity that `e` rides.
 
-### `query(e, 'tags')`(deprecated)
+### `(deprecated) query(e, 'tags')`
 
 Deprecated by `query(e, 'scoreboard_tags')`
 
@@ -210,7 +210,7 @@ Deprecated by `query(e, 'scoreboard_tags')`
 
 List of entity's scoreboard tags.
 
-### `query(e, 'has_tag',tag)`(deprecated)
+### `(deprecated) query(e, 'has_tag',tag)`
 
 Deprecated by `query(e, 'has_scoreboard_tag',tag)`
 

--- a/docs/scarpet/language/Operators.md
+++ b/docs/scarpet/language/Operators.md
@@ -110,7 +110,7 @@ Or an example to find if a player has specific enchantment on a held axe (either
 
 <pre>
 global_get_enchantment(p, ench) -> (
-$   for(['main','offhand'],
+$   for(['mainhand','offhand'],
 $      holds = query(p, 'holds', _);
 $      if( holds,
 $         [what, count, nbt] = holds;


### PR DESCRIPTION
`query(p, 'holds', 'main')` is invalid.
`query(p, 'holds', 'mainhand')` is the correct format currently.