### PR TITLE
Fix caveEntrance sampling being incorrect (please check)

### DIFF
--- a/src/main/java/carpet/mixins/NoiseColumnSamplerMixin_scarpetMixin.java
+++ b/src/main/java/carpet/mixins/NoiseColumnSamplerMixin_scarpetMixin.java
@@ -59,7 +59,7 @@ public abstract class NoiseColumnSamplerMixin_scarpetMixin implements NoiseColum
     @Shadow @Final
     private DoublePerlinNoiseSampler spaghetti3dSecondNoise;
 
-    @Shadow @Finalav
+    @Shadow @Final
     private DoublePerlinNoiseSampler spaghetti3dRarityNoise;
 
     @Shadow @Final

--- a/src/main/java/carpet/mixins/NoiseColumnSamplerMixin_scarpetMixin.java
+++ b/src/main/java/carpet/mixins/NoiseColumnSamplerMixin_scarpetMixin.java
@@ -59,7 +59,7 @@ public abstract class NoiseColumnSamplerMixin_scarpetMixin implements NoiseColum
     @Shadow @Final
     private DoublePerlinNoiseSampler spaghetti3dSecondNoise;
 
-    @Shadow @Final
+    @Shadow @Finalav
     private DoublePerlinNoiseSampler spaghetti3dRarityNoise;
 
     @Shadow @Final
@@ -219,7 +219,11 @@ public abstract class NoiseColumnSamplerMixin_scarpetMixin implements NoiseColum
                 return NoiseHelper.lerpFromProgress(this.spaghettiRoughnessModulatorNoise, x, y, z, 0.0, 0.1);
             }
             case "caveEntrance" -> {
-                return this.sampleCaveEntranceNoise(x, y, z);
+                return this.sampleCaveEntranceNoise(
+                        BiomeCoords.toBlock(x),
+                        BiomeCoords.toBlock(y),
+                        BiomeCoords.toBlock(z)
+                );
             }
             case "caveLayer" -> {
                 // scaling them by 4 because it's sampled in normal coords


### PR DESCRIPTION
hi - caveEntrance noise was previously being checked incorrectly (it was scaled up by 4x when it should actually just use world pos.) This should fix it, but I haven't tested it (to verify, stand in a cave entrance and do /script run sample_noise(x,y,z,'caveEntrance'). If it returns less than 0, the value is accurate.