### PR TITLE
Reinstating old behaviour of += with lists

### DIFF
--- a/src/main/java/carpet/script/value/ListValue.java
+++ b/src/main/java/carpet/script/value/ListValue.java
@@ -147,7 +147,10 @@ public class ListValue extends AbstractListValue implements ContainerValueInterf
     @Override
     public void append(Value v)
     {
-        items.add(v);
+        if(v instanceof AbstractListValue)
+            items.addAll(((AbstractListValue) v).unpack())
+        else
+            items.add(v);
     }
 
     @Override

--- a/src/main/java/carpet/script/value/ListValue.java
+++ b/src/main/java/carpet/script/value/ListValue.java
@@ -148,7 +148,7 @@ public class ListValue extends AbstractListValue implements ContainerValueInterf
     public void append(Value v)
     {
         if(v instanceof AbstractListValue)
-            items.addAll(((AbstractListValue) v).unpack())
+            items.addAll(((AbstractListValue) v).unpack());
         else
             items.add(v);
     }

--- a/src/main/java/carpet/script/value/MapValue.java
+++ b/src/main/java/carpet/script/value/MapValue.java
@@ -162,7 +162,13 @@ public class MapValue extends AbstractListValue implements ContainerValueInterfa
     @Override
     public void append(Value v)
     {
-        map.put(v, Value.NULL);
+        if (v instanceof MapValue)
+            map.putAll(((MapValue) v).getMap());
+        else if (v instanceof AbstractListValue)
+            for (Value value : ((AbstractListValue) v))
+                map.put(value, Value.NULL);
+        else
+            map.put(v, Value.NULL);
     }
 
     @Override


### PR DESCRIPTION
Properly fixes #1152, as opposed to the hack-fix in #1154 which just works around it.
In ye olden days, when the += operator simply called `Value.add()`, this is the behaviour that would occur, i.e.: doing `l=[]; l+=['3','4']`, would result in `l==['3','4']`, whereas now it results in `l==[['3','4']]` . This broke `shapes.scl` accidentally. I have also fixed this behaviour for maps, cos it's also broken there.