### PR TITLE
Remove querying full `system_info()` and refactor `Monitoring` to use the annotation API

### DIFF
--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -676,8 +676,8 @@ Scarpet will not affect the entries of the statistics, even if it is just creati
 it could either mean your input is wrong, or statistic effectively has a value of `0`.
 
 
-### `system_info()`, `system_info(property)`
-Fetches the value of a system property or returns all inforation as a map when called without any arguments. It can be used to 
+### `system_info(property)`
+Fetches the value of one of the following system properties. It can be used to 
 fetch various information, mostly not changing, or only available via low level
 system calls. In all circumstances, these are only provided as read-only.
 

--- a/src/main/java/carpet/fakes/SpawnHelperInnerInterface.java
+++ b/src/main/java/carpet/fakes/SpawnHelperInnerInterface.java
@@ -5,6 +5,4 @@ import net.minecraft.util.math.GravityField;
 public interface SpawnHelperInnerInterface
 {
     GravityField getPotentialCalculator();
-
-    int cmGetChunkCount();
 }

--- a/src/main/java/carpet/mixins/SpawnHelperInnerMixin.java
+++ b/src/main/java/carpet/mixins/SpawnHelperInnerMixin.java
@@ -30,18 +30,10 @@ public class SpawnHelperInnerMixin implements SpawnHelperInnerInterface
         cir.setReturnValue(groupToCount.getInt(entityCategory) < i);
     }
 
-
-
     @Override
     public GravityField getPotentialCalculator()
     {
         return densityField;
     }
-
-    @Override
-    public int cmGetChunkCount() {
-        return spawningChunkCount;
-    }
-
 
 }

--- a/src/main/java/carpet/script/CarpetExpression.java
+++ b/src/main/java/carpet/script/CarpetExpression.java
@@ -6,7 +6,6 @@ import carpet.script.api.Auxiliary;
 import carpet.script.api.BlockIterators;
 import carpet.script.api.Entities;
 import carpet.script.api.Inventories;
-import carpet.script.api.Monitoring;
 import carpet.script.api.Scoreboards;
 import carpet.script.api.Threading;
 import carpet.script.api.WorldAccess;
@@ -45,7 +44,7 @@ public class CarpetExpression
         Auxiliary.apply(this.expr);
         Threading.apply(this.expr);
         Scoreboards.apply(this.expr);
-        Monitoring.apply(this.expr);
+        //Monitoring.apply(this.expr); Moved to annotation api
         AnnotationParser.apply(this.expr);
         CarpetServer.extensions.forEach(e -> e.scarpetApi(this));
     }

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -6,6 +6,7 @@ import carpet.script.api.Auxiliary;
 import carpet.script.api.BlockIterators;
 import carpet.script.api.Entities;
 import carpet.script.api.Inventories;
+import carpet.script.api.Monitoring;
 import carpet.script.api.Scoreboards;
 import carpet.script.api.WorldAccess;
 import carpet.script.bundled.BundledModule;
@@ -456,5 +457,6 @@ public class CarpetScriptServer
         AnnotationParser.parseFunctionClass(Scoreboards.class);
         AnnotationParser.parseFunctionClass(carpet.script.language.Threading.class);
         AnnotationParser.parseFunctionClass(WorldAccess.class);
+        AnnotationParser.parseFunctionClass(Monitoring.class);
     }
 }

--- a/src/main/java/carpet/script/api/Monitoring.java
+++ b/src/main/java/carpet/script/api/Monitoring.java
@@ -37,7 +37,7 @@ public class Monitoring {
         if (category.isPresent())
         {
             SpawnGroup group = SpawnGroup.byName(category.get().toLowerCase(Locale.ROOT));
-            if (group == null) throw new InternalExpressionException("Unreconized mob category: " + category.get());
+            if (group == null) throw new InternalExpressionException("Unrecognized mob category: " + category.get());
             return ListValue.of(
                     new NumericValue(mobcounts.getInt(group)),
                     new NumericValue((int)(group.getCapacity() * chunks / SpawnReporter.currentMagicNumber()))

--- a/src/main/java/carpet/script/api/Monitoring.java
+++ b/src/main/java/carpet/script/api/Monitoring.java
@@ -1,8 +1,8 @@
 package carpet.script.api;
 
-import carpet.fakes.SpawnHelperInnerInterface;
 import carpet.script.CarpetContext;
-import carpet.script.Expression;
+import carpet.script.Context;
+import carpet.script.annotation.ScarpetFunction;
 import carpet.script.exception.InternalExpressionException;
 import carpet.script.utils.SystemInfo;
 import carpet.script.value.ListValue;
@@ -13,62 +13,50 @@ import carpet.script.value.Value;
 import carpet.utils.SpawnReporter;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import net.minecraft.entity.SpawnGroup;
-import net.minecraft.server.world.ServerWorld;
 import net.minecraft.world.SpawnHelper;
 
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 public class Monitoring {
+    @ScarpetFunction
+    public static Value system_info(Context c, String property) {
+        Value res = SystemInfo.get(property, (CarpetContext) c);
+        if (res == null) throw new InternalExpressionException("Unknown option for 'system_info': '" + property + "'");
+        return res;
+    }
 
-    public static void apply(Expression expression)
-    {
-        expression.addContextFunction("system_info", -1, (c, t, lv) ->
+    @ScarpetFunction(maxParams = 1)
+    public static Value get_mob_counts(Context c, Optional<String> category) {
+        SpawnHelper.Info info = ((CarpetContext)c).s.getWorld().getChunkManager().getSpawnInfo();
+        if (info == null) return null;
+        Object2IntMap<SpawnGroup> mobcounts = info.getGroupToCount();
+        int chunks = info.getSpawningChunkCount();
+        if (category.isPresent())
         {
-            if (lv.size() == 0)
-            {
-                return SystemInfo.getAll((CarpetContext) c);
-            }
-            if (lv.size() == 1) {
-                String what = lv.get(0).getString();
-                Value res = SystemInfo.get(what, (CarpetContext) c);
-                if (res == null) throw new InternalExpressionException("Unknown option for 'system_info': " + what);
-                return res;
-            }
-            throw new InternalExpressionException("'system_info' requires one or no parameters");
-        });
-        // game processed snooper functions
-        expression.addContextFunction("get_mob_counts", -1, (c, t, lv) ->
-        {
-            CarpetContext cc = (CarpetContext)c;
-            ServerWorld world = cc.s.getWorld();
-            SpawnHelper.Info info = world.getChunkManager().getSpawnInfo();
-            if (info == null) return Value.NULL;
-            Object2IntMap<SpawnGroup> mobcounts = info.getGroupToCount();
-            int chunks = ((SpawnHelperInnerInterface)info).cmGetChunkCount();
-            if (lv.size() == 0)
-            {
-                Map<Value, Value> retDict = new HashMap<>();
-                for (SpawnGroup category: mobcounts.keySet())
-                {
-                    int currentCap = (int)(category.getCapacity() * chunks / SpawnReporter.currentMagicNumber()); // MAGIC_NUMBER
-                    retDict.put(
-                            new StringValue(category.asString().toLowerCase(Locale.ROOT)),
-                            ListValue.of(
-                                    new NumericValue(mobcounts.getInt(category)),
-                                    new NumericValue(currentCap))
-                    );
-                }
-                return MapValue.wrap(retDict);
-            }
-            String catString = lv.get(0).getString();
-            SpawnGroup cat = SpawnGroup.byName(catString.toLowerCase(Locale.ROOT));
-            if (cat == null) throw new InternalExpressionException("Unreconized mob category: "+catString);
+            SpawnGroup group = SpawnGroup.byName(category.get().toLowerCase(Locale.ROOT));
+            if (group == null) throw new InternalExpressionException("Unreconized mob category: " + category.get());
             return ListValue.of(
-                    new NumericValue(mobcounts.getInt(cat)),
-                    new NumericValue((int)(cat.getCapacity() * chunks / SpawnReporter.currentMagicNumber()))
+                    new NumericValue(mobcounts.getInt(group)),
+                    new NumericValue((int)(group.getCapacity() * chunks / SpawnReporter.currentMagicNumber()))
             );
-        });
+        }
+        else
+        {
+            Map<Value, Value> retDict = new HashMap<>();
+            for (SpawnGroup group: mobcounts.keySet())
+            {
+                int currentCap = (int)(group.getCapacity() * chunks / SpawnReporter.currentMagicNumber());
+                retDict.put(
+                        new StringValue(group.asString().toLowerCase(Locale.ROOT)),
+                        ListValue.of(
+                                new NumericValue(mobcounts.getInt(group)),
+                                new NumericValue(currentCap))
+                        );
+            }
+            return MapValue.wrap(retDict);
+        }
     }
 }

--- a/src/main/java/carpet/script/utils/SystemInfo.java
+++ b/src/main/java/carpet/script/utils/SystemInfo.java
@@ -202,13 +202,16 @@ public class SystemInfo {
         put("scarpet_version", c -> StringValue.of(CarpetSettings.carpetVersion));
 
     }};
-    public static Value get(String what, CarpetContext cc)
+
+    /**
+     * Computes the value for the given {@code system_info} property
+     * @param property The property to search
+     * @param context The {@link CarpetContext} for the current execution
+     * @return The {@link Value} of the requested property, or {@code null} if it doesn't exist
+     */
+    public static Value get(String property, CarpetContext context)
     {
-        return options.getOrDefault(what, c -> null).apply(cc);
-    }
-    public static Value getAll(CarpetContext cc)
-    {
-        return MapValue.wrap(options.entrySet().stream().collect(Collectors.toMap(e -> new StringValue(e.getKey()), e -> e.getValue().apply(cc))));
+        return options.getOrDefault(property, c -> null).apply(context);
     }
 
 }


### PR DESCRIPTION
Resolves #1085 by removing the no-arg version. I couldn't find any use of `system_info()` on the app store or in any of the other scarpet github repos that I know or found.

Also refactors the `Monitoring` class to use the annotation API, because I was feeling like migrating it and else there was just a single function there using the old system (since I moved system_info). Basically moves `get_mob_counts` to use it, no functional or API changes around it. And it's actually pretty much the same, just with some types already known.

And removes a no-longer needed accessor around it.