### PR TITLE
Support more actions in Messenger (and therefore `format()`)

### DIFF
--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -252,6 +252,8 @@ Decorators (listed as extra argument after the component they would affect):
  * `'^<format> <text>'` - hover over tooltip text, appearing when hovering with your mouse over the text below.
  * `'?<suggestion>` - command suggestion - a message that will be pasted to chat when text below it is clicked.
  * `'!<message>'` - a chat message that will be executed when the text below it is clicked.
+ * `'@<url>'` - an url will be opened when the text below it is clicked.
+ * `'&<text>'` - a text will be copied to clipboard when the text below it is clicked.
  
 Both suggestions and messages can contain a command, which will be executed as a player that clicks it.
 

--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -252,8 +252,8 @@ Decorators (listed as extra argument after the component they would affect):
  * `'^<format> <text>'` - hover over tooltip text, appearing when hovering with your mouse over the text below.
  * `'?<suggestion>` - command suggestion - a message that will be pasted to chat when text below it is clicked.
  * `'!<message>'` - a chat message that will be executed when the text below it is clicked.
- * `'@<url>'` - an url will be opened when the text below it is clicked.
- * `'&<text>'` - a text will be copied to clipboard when the text below it is clicked.
+ * `'@<url>'` - a URL that will be opened when the text below it is clicked.
+ * `'&<text>'` - a text that will be copied to clipboard when the text below it is clicked.
  
 Both suggestions and messages can contain a command, which will be executed as a player that clicks it.
 


### PR DESCRIPTION
Resolves #1182.

This PR adds the following two actions to `Messenger` (and therefore to the scarpet's `format()` function):
- `'@<url>'` Opens the given url when clicking the message
- `'&<text>'` Copies the given text to clipboard when clicking the message

Also changed it to use a switch statement and made some small changes to conventions in the rest of Messenger (where they didn't affect api).