### PR TITLE
Improve (about issues#1248)

### DIFF
--- a/src/main/java/carpet/script/utils/SystemInfo.java
+++ b/src/main/java/carpet/script/utils/SystemInfo.java
@@ -5,8 +5,11 @@ import carpet.CarpetSettings;
 import carpet.script.CarpetContext;
 import carpet.script.CarpetScriptHost;
 import carpet.script.value.BooleanValue;
+import carpet.script.value.BlockValue;
 import carpet.script.value.ListValue;
 import carpet.script.value.MapValue;
+import carpet.script.value.NBTSerializableValue;
+import carpet.script.value.NullValue;
 import carpet.script.value.NumericValue;
 import carpet.script.value.StringValue;
 import carpet.script.value.Value;
@@ -17,6 +20,8 @@ import com.sun.management.OperatingSystemMXBean;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.SharedConstants;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtOps;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.WorldSavePath;
 import net.minecraft.util.registry.RegistryKey;
@@ -24,6 +29,11 @@ import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldProperties;
 import net.minecraft.world.border.WorldBorder;
+import net.minecraft.world.gen.GeneratorOptions;
+import net.minecraft.world.gen.chunk.ChunkGenerator;
+import net.minecraft.world.gen.chunk.DebugChunkGenerator;
+import net.minecraft.world.gen.chunk.FlatChunkGenerator;
+import net.minecraft.world.gen.chunk.NoiseChunkGenerator;
 
 import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
@@ -34,8 +44,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class SystemInfo {
     private static final Map<String, Function<CarpetContext,Value>> options = new HashMap<String, Function<CarpetContext,Value>>(){{
@@ -200,6 +212,37 @@ public class SystemInfo {
             return MapValue.wrap(rules);
         });
         put("scarpet_version", c -> StringValue.of(CarpetSettings.carpetVersion));
+        put("layers_of_super_flat_world", c-> {
+            GeneratorOptions generatorOptions=c.s.getServer().getSaveProperties().getGeneratorOptions();
+            Stream<Value> s = generatorOptions.getDimensions().getEntries().stream().map(
+                    x->{
+                        Value dimname = StringValue.of(x.getKey().getValue().toString());
+                        ChunkGenerator cg = x.getValue().getChunkGenerator();
+                        Value dimdata;
+                        if (cg instanceof DebugChunkGenerator){
+                            dimdata =StringValue.of("debug");
+                        }else if (cg instanceof NoiseChunkGenerator){
+                            dimdata =StringValue.of("noise");
+                        }else if (cg instanceof FlatChunkGenerator){
+                            Stream<Value> layers = ((FlatChunkGenerator)cg).getConfig().getLayers().stream().map(lay->ListValue.of(new NumericValue((long)lay.getThickness()),new BlockValue(lay.getBlockState(),null,null)));
+                            dimdata =ListValue.wrap(layers);
+                        }else{
+                            dimdata =StringValue.of("???");
+                        }
+                        return ListValue.of(dimname,dimdata);
+                    }
+                );
+            return new MapValue(s.collect(Collectors.toList()));
+        });
+        put("world_gen_settings", c-> {
+            GeneratorOptions generatorOptions=c.s.getServer().getSaveProperties().getGeneratorOptions();
+            Optional<NbtElement> x = GeneratorOptions.CODEC.encodeStart(NbtOps.INSTANCE, generatorOptions).result();
+            if(x.isPresent()){
+                return new NBTSerializableValue(x.get());
+            }else{
+                return NullValue.NULL;
+            }
+        });
 
     }};
     public static Value get(String what, CarpetContext cc)


### PR DESCRIPTION
https://github.com/gnembon/fabric-carpet/issues/1248

this pr is to add some wor gen related systeminfo.


layers_of_super_flat_world should return a map value. which includes the layers of all dimensions if that dimension is a super flat world.     eg: [[1,bedrock],[3,stone],[52,sandstone]]
for dimensions that are not superflat, it may return a string value says why it is not layered XD.

...want to add more methods here......

world_gen_settings should be view as a 'ultimate solution', only consider using it if the information provided by other methods are not enough. may change in the future ver. of minecraft.