### PR TITLE
Shulker box stack size is now configurable

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -205,11 +205,22 @@ public class CarpetSettings
     @Rule( desc = "Players absorb XP instantly, without delay", category = CREATIVE )
     public static boolean xpNoCooldown = false;
 
+    public static class ShulkerBoxStackSizeValidator extends Validator<Integer>
+    {
+        @Override
+        public Integer validate(ServerCommandSource source, ParsedRule<Integer> currentRule, Integer newValue, String string) {
+            return (newValue>=1&&newValue<=64) ? newValue : null;
+        }
+        @Override
+        public String description() {return "Must choose value between 1 and 64";}
+     }
+
     @Rule(
             desc = "Controls the amount of empty shulker boxes that can be stacked together when dropped on the ground",
             extra = ".. or when manipulated inside the inventories",
             options = {"1", "8", "16", "64"},
             strict = false,
+            validate = ShulkerBoxStackSizeValidator.class,
             category = {SURVIVAL, FEATURE}
     )
     public static int shulkerBoxStackSize = 1;

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -236,7 +236,8 @@ public class CarpetSettings
     }
 
     @Rule(
-            desc = "Empty shulker boxes can stack to 64 or a custom value.",
+            desc = "Empty shulker boxes can stack to 64 or a custom value when thrown on the ground.",
+            extra = ".. or when manipulated inside the inventories",
             validate = StackableShulkerBoxValidator.class,
             options = {"false", "true", "16"},
             strict = false,

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -205,24 +205,44 @@ public class CarpetSettings
     @Rule( desc = "Players absorb XP instantly, without delay", category = CREATIVE )
     public static boolean xpNoCooldown = false;
 
-    public static class ShulkerBoxStackSizeValidator extends Validator<Integer>
+    public static class StackableShulkerBoxValidator extends Validator<String> //Doing the logic here avoids doing the logic several times over in the relevant mixin classes.
     {
         @Override
-        public Integer validate(ServerCommandSource source, ParsedRule<Integer> currentRule, Integer newValue, String string) {
-            return (newValue>=1&&newValue<=64) ? newValue : null;
+        public String validate(ServerCommandSource source, ParsedRule<String> currentRule, String newValue, String string)
+        {
+            if (newValue.matches("^[0-9]+$")) {
+                int value = Integer.parseInt(newValue);
+                if (value <= 64 && value >= 2) {
+                    shulkerBoxStackSize = value;
+                    return newValue;
+                }
+            }
+            if (newValue.equals("false")) {
+                shulkerBoxStackSize = 1;
+                return newValue;
+            }
+            if (newValue.equals("true")) {
+                shulkerBoxStackSize = 64;
+                return newValue;
+            }
+            return null;
         }
+
         @Override
-        public String description() {return "Must choose value between 1 and 64";}
-     }
+        public String description()
+        {
+            return "Value must either be true, false, or a number between 2-64";
+        }
+    }
 
     @Rule(
-            desc = "Controls the amount of empty shulker boxes that can be stacked together when dropped on the ground",
-            extra = ".. or when manipulated inside the inventories",
-            options = {"1", "8", "16", "64"},
+            desc = "Empty shulker boxes can stack to 64 or a custom value.",
+            validate = StackableShulkerBoxValidator.class,
+            options = {"false", "true", "16"},
             strict = false,
-            validate = ShulkerBoxStackSizeValidator.class,
             category = {SURVIVAL, FEATURE}
     )
+    public static String stackableShulkerBoxes = "false";
     public static int shulkerBoxStackSize = 1;
 
     @Rule( desc = "Explosions won't destroy blocks", category = {CREATIVE, TNT} )

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -206,12 +206,13 @@ public class CarpetSettings
     public static boolean xpNoCooldown = false;
 
     @Rule(
-            desc = "Empty shulker boxes can stack to 64 when dropped on the ground",
+            desc = "Controls the amount of empty shulker boxes that can be stacked together when dropped on the ground",
             extra = ".. or when manipulated inside the inventories",
+            options = {"1", "8", "16", "64"},
+            strict = false,
             category = {SURVIVAL, FEATURE}
     )
-    public static boolean stackableShulkerBoxes = false;
-    public static final int SHULKER_STACK_SIZE = 64;
+    public static int shulkerBoxStackSize = 1;
 
     @Rule( desc = "Explosions won't destroy blocks", category = {CREATIVE, TNT} )
     public static boolean explosionNoBlockDamage = false;

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -205,7 +205,7 @@ public class CarpetSettings
     @Rule( desc = "Players absorb XP instantly, without delay", category = CREATIVE )
     public static boolean xpNoCooldown = false;
 
-    public static class StackableShulkerBoxValidator extends Validator<String> //Doing the logic here avoids doing the logic several times over in the relevant mixin classes.
+    public static class StackableShulkerBoxValidator extends Validator<String> 
     {
         @Override
         public String validate(ServerCommandSource source, ParsedRule<String> currentRule, String newValue, String string)

--- a/src/main/java/carpet/mixins/AbstractCauldronBlock_stackableSBoxesMixin.java
+++ b/src/main/java/carpet/mixins/AbstractCauldronBlock_stackableSBoxesMixin.java
@@ -23,7 +23,7 @@ public class AbstractCauldronBlock_stackableSBoxesMixin
     private ActionResult wrapInteractor(CauldronBehavior cauldronBehavior, BlockState blockState, World world, BlockPos blockPos, PlayerEntity playerEntity, Hand hand, ItemStack itemStack)
     {
         int count = -1;
-        if (CarpetSettings.stackableShulkerBoxes && itemStack.getItem() instanceof BlockItem && ((BlockItem)itemStack.getItem()).getBlock() instanceof ShulkerBoxBlock)
+        if (CarpetSettings.shulkerBoxStackSize > 1 && itemStack.getItem() instanceof BlockItem && ((BlockItem)itemStack.getItem()).getBlock() instanceof ShulkerBoxBlock)
             count = itemStack.getCount();
         ActionResult result = cauldronBehavior.interact(blockState, world, blockPos, playerEntity, hand, itemStack);
         if (count > 0 && result.isAccepted())

--- a/src/main/java/carpet/mixins/ItemEntityMixin.java
+++ b/src/main/java/carpet/mixins/ItemEntityMixin.java
@@ -55,7 +55,7 @@ public abstract class ItemEntityMixin extends Entity implements ItemEntityInterf
     @Inject(method="<init>(Lnet/minecraft/world/World;DDDLnet/minecraft/item/ItemStack;)V", at = @At("RETURN"))
     private void removeEmptyShulkerBoxTags(World worldIn, double x, double y, double z, ItemStack stack, CallbackInfo ci)
     {
-        if (CarpetSettings.stackableShulkerBoxes
+        if (CarpetSettings.shulkerBoxStackSize > 1
                 && stack.getItem() instanceof BlockItem
                 && ((BlockItem)stack.getItem()).getBlock() instanceof ShulkerBoxBlock)
         {
@@ -73,8 +73,8 @@ public abstract class ItemEntityMixin extends Entity implements ItemEntityInterf
             )
     )
     private int getItemStackMaxAmount(ItemStack stack) {
-        if (CarpetSettings.stackableShulkerBoxes && stack.getItem() instanceof BlockItem && ((BlockItem)stack.getItem()).getBlock() instanceof ShulkerBoxBlock)
-            return SHULKERBOX_MAX_STACK_AMOUNT;
+        if (CarpetSettings.shulkerBoxStackSize > 1 && stack.getItem() instanceof BlockItem && ((BlockItem)stack.getItem()).getBlock() instanceof ShulkerBoxBlock)
+            return CarpetSettings.shulkerBoxStackSize;
 
         return stack.getMaxCount();
     }
@@ -88,7 +88,7 @@ public abstract class ItemEntityMixin extends Entity implements ItemEntityInterf
     {
         ItemEntity self = (ItemEntity)(Object)this;
         ItemStack selfStack = self.getStack();
-        if (!CarpetSettings.stackableShulkerBoxes || !(selfStack.getItem() instanceof BlockItem) || !(((BlockItem)selfStack.getItem()).getBlock() instanceof ShulkerBoxBlock)) {
+        if (CarpetSettings.shulkerBoxStackSize == 1 || !(selfStack.getItem() instanceof BlockItem) || !(((BlockItem)selfStack.getItem()).getBlock() instanceof ShulkerBoxBlock)) {
             return;
         }
 
@@ -97,9 +97,9 @@ public abstract class ItemEntityMixin extends Entity implements ItemEntityInterf
                 && !InventoryHelper.shulkerBoxHasItems(selfStack)
                 && !InventoryHelper.shulkerBoxHasItems(otherStack)
                 && selfStack.hasNbt() == otherStack.hasNbt()
-                && selfStack.getCount() + otherStack.getCount() <= SHULKERBOX_MAX_STACK_AMOUNT)
+                && selfStack.getCount() + otherStack.getCount() <= CarpetSettings.shulkerBoxStackSize)
         {
-            int amount = Math.min(otherStack.getCount(), SHULKERBOX_MAX_STACK_AMOUNT - selfStack.getCount());
+            int amount = Math.min(otherStack.getCount(), CarpetSettings.shulkerBoxStackSize - selfStack.getCount());
 
             selfStack.increment(amount);
             self.setStack(selfStack);

--- a/src/main/java/carpet/mixins/ScreenHandler_stackableSBoxesMixin.java
+++ b/src/main/java/carpet/mixins/ScreenHandler_stackableSBoxesMixin.java
@@ -20,13 +20,13 @@ public class ScreenHandler_stackableSBoxesMixin
     ))
     private int getMaxCountForSboxesInScreenHander(Slot slot, ItemStack stack)
     {
-        if (CarpetSettings.stackableShulkerBoxes &&
+        if (CarpetSettings.shulkerBoxStackSize > 1 &&
                 stack.getItem() instanceof BlockItem &&
                 ((BlockItem)stack.getItem()).getBlock() instanceof ShulkerBoxBlock &&
                 !InventoryHelper.shulkerBoxHasItems(stack)
         )
         {
-            return CarpetSettings.SHULKER_STACK_SIZE;
+            return CarpetSettings.shulkerBoxStackSize;
         }
         return slot.getMaxItemCount(stack);
     }

--- a/src/main/java/carpet/mixins/Slot_stackableSBoxesMixin.java
+++ b/src/main/java/carpet/mixins/Slot_stackableSBoxesMixin.java
@@ -18,13 +18,13 @@ public class Slot_stackableSBoxesMixin {
     ))
     private int getMaxCountForSboxesInSlot(Slot slot, ItemStack stack)
     {
-        if (CarpetSettings.stackableShulkerBoxes &&
+        if (CarpetSettings.shulkerBoxStackSize > 1 &&
                 stack.getItem() instanceof BlockItem &&
                 ((BlockItem)stack.getItem()).getBlock() instanceof ShulkerBoxBlock &&
                 !InventoryHelper.shulkerBoxHasItems(stack)
         )
         {
-            return CarpetSettings.SHULKER_STACK_SIZE;
+            return CarpetSettings.shulkerBoxStackSize;
         }
         return slot.getMaxItemCount(stack);
     }

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -485,7 +485,6 @@ public class SettingsManager
         }
     }
 
-
     private Collection<ParsedRule<?>> getRulesMatching(String search) {
         String lcSearch = search.toLowerCase(Locale.ROOT);
         return rules.values().stream().filter(rule ->

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -432,6 +432,7 @@ public class SettingsManager
             String line = "";
             boolean confLocked = false;
             Map<String,String> result = new HashMap<String, String>();
+            boolean doShulkerMigration = false;
             while ((line = reader.readLine()) != null)
             {
                 line = line.replaceAll("[\\r\\n]", "");
@@ -444,6 +445,16 @@ public class SettingsManager
                 {
                     if (!rules.containsKey(fields[0]))
                     {
+                        if (fields[0].equals("stackableShulkerBoxes")) //Shulker rule conversion logic
+                        {
+                            if (fields[1].equals("true")) {
+                                doShulkerMigration = true;
+
+                            } else {
+                                CarpetSettings.LOG.info("[CM]: Old shulker box rule present but set to false, redundant");
+                            }
+                            continue;
+                        }
                         CarpetSettings.LOG.error("[CM]: "+fancyName+" Setting " + fields[0] + " is not a valid - ignoring...");
                         continue;
                     }
@@ -454,9 +465,18 @@ public class SettingsManager
                         CarpetSettings.LOG.error("[CM]: The value of " + fields[1] + " for " + fields[0] + "("+fancyName+") is not valid - ignoring...");
                         continue;
                     }
+                    if (fields[0].equals("shulkerBoxStackSize")) { //In case both rules are present for whatever reason, this prevents the stack size rule from getting overridden
+                        doShulkerMigration = false;
+                    }
+
                     result.put(fields[0],fields[1]);
 
                 }
+            }
+            if (doShulkerMigration)
+            {
+                CarpetSettings.LOG.info("[CM]: Stackable shulker box rule detected, setting shulker stack size rule to 64");
+                result.put("shulkerBoxStackSize", "64");
             }
             return new ConfigReadResult(result, confLocked);
         }

--- a/src/main/java/carpet/settings/SettingsManager.java
+++ b/src/main/java/carpet/settings/SettingsManager.java
@@ -432,7 +432,6 @@ public class SettingsManager
             String line = "";
             boolean confLocked = false;
             Map<String,String> result = new HashMap<String, String>();
-            boolean doShulkerMigration = false;
             while ((line = reader.readLine()) != null)
             {
                 line = line.replaceAll("[\\r\\n]", "");
@@ -445,16 +444,6 @@ public class SettingsManager
                 {
                     if (!rules.containsKey(fields[0]))
                     {
-                        if (fields[0].equals("stackableShulkerBoxes")) //Shulker rule conversion logic
-                        {
-                            if (fields[1].equals("true")) {
-                                doShulkerMigration = true;
-
-                            } else {
-                                CarpetSettings.LOG.info("[CM]: Old shulker box rule present but set to false, redundant");
-                            }
-                            continue;
-                        }
                         CarpetSettings.LOG.error("[CM]: "+fancyName+" Setting " + fields[0] + " is not a valid - ignoring...");
                         continue;
                     }
@@ -465,18 +454,9 @@ public class SettingsManager
                         CarpetSettings.LOG.error("[CM]: The value of " + fields[1] + " for " + fields[0] + "("+fancyName+") is not valid - ignoring...");
                         continue;
                     }
-                    if (fields[0].equals("shulkerBoxStackSize")) { //In case both rules are present for whatever reason, this prevents the stack size rule from getting overridden
-                        doShulkerMigration = false;
-                    }
-
                     result.put(fields[0],fields[1]);
 
                 }
-            }
-            if (doShulkerMigration)
-            {
-                CarpetSettings.LOG.info("[CM]: Stackable shulker box rule detected, setting shulker stack size rule to 64");
-                result.put("shulkerBoxStackSize", "64");
             }
             return new ConfigReadResult(result, confLocked);
         }
@@ -504,6 +484,7 @@ public class SettingsManager
             return new ConfigReadResult(new HashMap<>(), false);
         }
     }
+
 
     private Collection<ParsedRule<?>> getRulesMatching(String search) {
         String lcSearch = search.toLowerCase(Locale.ROOT);


### PR DESCRIPTION
This is to help balance this feature a bit. Also makes a bit more sense to have shulker boxes to stack to 16 instead of 64 since Minecraft has already established (see: bucket) that empty stuff can only stack to 16. Anyway this just allows it to be configurable.

The old stackableShulkerBoxes rule has been removed and replaced with simply using the value "1" as the stack size for shulker boxes. It's up to you if this is how you want to implement it, I think it makes the most sense to have it as the one option but people might prefer having two separate options, one for stack size and one for whether they stack at all. 

With my implementation, the configuration will simply default to 1, which is basically "off" like before and no calculations will be attempted until the value exceeds 1. 