### PR TITLE
Fake players can be spawned in survival mode while flying

### DIFF
--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -299,6 +299,9 @@ public class PlayerCommand
         {
             // Force override flying to true for spectator players, or they will fell out of the world.
             flying = true;
+        } else if(mode.isSurvivalLike()){
+            // Force override flying to true for survival-like players, or they will fly too
+            flying = false;
         }
         String playerName = StringArgumentType.getString(context, "player");
         if (playerName.length()>maxPlayerLength(source.getServer()))

--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -300,7 +300,7 @@ public class PlayerCommand
             // Force override flying to true for spectator players, or they will fell out of the world.
             flying = true;
         } else if(mode.isSurvivalLike()){
-            // Force override flying to true for survival-like players, or they will fly too
+            // Force override flying to false for survival-like players, or they will fly too
             flying = false;
         }
         String playerName = StringArgumentType.getString(context, "player");


### PR DESCRIPTION
Fixes #1263 
Basically if you're in spectator (or creative for that matter), spawning a fake player in survival or adventure mode would cause that player to have flying abilities.