### PR TITLE
Improve Annotated Scarpet runtime performance

### DIFF
--- a/src/main/java/carpet/script/annotation/SimpleTypeConverter.java
+++ b/src/main/java/carpet/script/annotation/SimpleTypeConverter.java
@@ -86,9 +86,10 @@ public final class SimpleTypeConverter<T extends Value, R> implements ValueConve
     }
 
     @Override
-    public R convert(Value value)
+    @SuppressWarnings("unchecked") // more than checked. not using class.cast because then "method is too big" for inlining, because javac is useless
+    public R convert(Value value)                                                          // and adds millions of casts. This one is even removed
     {
-        return valueClass.isInstance(value) ? converter.apply(valueClass.cast(value)) : null;
+        return valueClass.isInstance(value) ? converter.apply((T)value) : null;
     }
 
     /**

--- a/src/main/java/carpet/script/annotation/ValueCaster.java
+++ b/src/main/java/carpet/script/annotation/ValueCaster.java
@@ -77,11 +77,12 @@ public final class ValueCaster<R> implements ValueConverter<R> // R always exten
     }
 
     @Override
+    @SuppressWarnings("unchecked") // more than checked, see SimpleTypeConverter#converter for reasoning
     public R convert(Value value)
     {
         if (!outputType.isInstance(value))
             return null;
-        return outputType.cast(value);
+        return (R)value;
     }
 
     /**


### PR DESCRIPTION
Changes in this PR:

- Changed `valueConverters` List to array for faster access
- Remove duped param size check when scarpet argument count isn't variable, as it's already checked by LazyFunction
- Remove invocations of `Class.cast` and use direct casts instead

The last point adds the need for two `SuppressWarning` annotations. However, the change is needed because even with `Class.cast` being intrinsic, neither javac or the jvm knows they can get rid of it, and javac even adds more casts to the method. Doing it this way, the compiler even assumes the (T) cast is safe and removes it.

This was needed because checking the inlining log, I was amazed after seeing that `SimpleTypeConverter#convert` was hot but "too big to be inlined", and I dug for the reason.

I haven't checked much more, but the next things I'll check to make the system compete even more against native will be check how costly is the parameter array instantiation and if I can get rid of it, and then I'm out of ideas tbh. Maybe manually inlining `getMethodArgs` too, there's no reason for it to be separate.

For reference, this is the only code that runs at function invocation (in 99% of the methods, those without a `...` java varargs):

https://github.com/gnembon/fabric-carpet/blob/f61b8b52290f1828fd88de395d1f65f5c1494675/src/main/java/carpet/script/annotation/AnnotationParser.java#L228-L242

https://github.com/gnembon/fabric-carpet/blob/f61b8b52290f1828fd88de395d1f65f5c1494675/src/main/java/carpet/script/annotation/AnnotationParser.java#L254-L263