### PR TITLE
Fixed firing of on_move event event after no change in position.

### DIFF
--- a/src/main/java/carpet/mixins/Entity_scarpetEventsMixin.java
+++ b/src/main/java/carpet/mixins/Entity_scarpetEventsMixin.java
@@ -94,6 +94,7 @@ public abstract class Entity_scarpetEventsMixin implements EntityInterface
     @Inject(method = "setPos", at = @At("TAIL"))
     private void secondPos(CallbackInfo ci)
     {
-        events.onEvent(EntityEventsGroup.Event.ON_MOVE, motion, pos1, this.pos);
+        if(pos1!=this.pos)
+            events.onEvent(EntityEventsGroup.Event.ON_MOVE, motion, pos1, this.pos);
     }
 }


### PR DESCRIPTION
Fixes #1282 
It's basically a check for whether or not the position changed. Idk if there's a neater way to put it tho tbh.