### PR TITLE
Always reset the app store root in the validator (#1275).

### DIFF
--- a/src/main/java/carpet/script/utils/AppStoreManager.java
+++ b/src/main/java/carpet/script/utils/AppStoreManager.java
@@ -48,7 +48,7 @@ public class AppStoreManager
     /** A local copy of the scarpet repo's file structure, to avoid multiple queries to github.com while typing out the
      * {@code /script download} command and getting the suggestions.
      */
-    public static final StoreNode APP_STORE_ROOT = StoreNode.folder(null, "");
+    private static StoreNode APP_STORE_ROOT = StoreNode.folder(null, "");
 
     /** This is the base link to the scarpet app repo from the github api.
      */
@@ -60,8 +60,7 @@ public class AppStoreManager
     {
         @Override public String validate(ServerCommandSource source, ParsedRule<String> currentRule, String newValue, String string)
         {
-            APP_STORE_ROOT.sealed = false;
-            APP_STORE_ROOT.children = new HashMap<>();
+            APP_STORE_ROOT = StoreNode.folder(null, "");
             if (newValue.equalsIgnoreCase("none"))
             {
                 scarpetRepoLink = null;


### PR DESCRIPTION
The validator used to clear the sealed flag and the children in the validator. But it did not clear the count down latch. This led to a situation where we would throw an IOException from fillChildren because we did have the latch, but it was zero, and the sealed flag was cleared. This simply resets the node every time, which I think is the safest solution as setting the childrenProgress to null in the validator might end poorly if someone was waiting on it. Another solution was to just remove the throw inside fillChildren. This felt like the cleanest solution.