### PR TITLE
Add quiltflower

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'fabric-loom' version '0.11-SNAPSHOT'
+	id 'io.github.juuxel.loom-quiltflower' version '1.6.0'
 	id 'maven-publish'
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,10 @@ pluginManagement {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
         }
+        maven {
+            name = 'Cotton'
+            url = 'https://server.bbkr.space/artifactory/libs-release/'
+        }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
### Description

Simply adds [loom quiltflower](https://github.com/Juuxel/LoomQuiltflower) as a plugin which adds `genSourcesWithQuiltflower`.
This task uses [quiltflower](https://github.com/QuiltMC/quiltflower) to decompile sources which is an improved fork of original fernflower developed by [QuiltMC](https://github.com/QuiltMC) team

### To generate sources

Run `genSourcesWithQuiltflower` task instead of `genSources`