### PR TITLE
Use vanilla cramming code when possible

### DIFF
--- a/src/main/java/carpet/mixins/LivingEntity_maxCollisionsMixin.java
+++ b/src/main/java/carpet/mixins/LivingEntity_maxCollisionsMixin.java
@@ -30,6 +30,10 @@ public abstract class LivingEntity_maxCollisionsMixin extends Entity
 
     @Inject(method = "pushEntities", cancellable = true, at = @At("HEAD"))
     private void tickPushingReplacement(CallbackInfo ci) {
+        if (CarpetSettings.maxEntityCollisions == 0)
+        {
+            return;
+        }
         List<Entity> entities;
         int maxEntityCramming =-1;
         if (CarpetSettings.maxEntityCollisions > 0)


### PR DESCRIPTION
Improve compatibility with mods that manipulate how cramming works. When the carpet rule is disabled, the vanilla code can be used, allowing features from other mods to work.