### PR TITLE
Added __on_player_message event

### DIFF
--- a/docs/scarpet/api/Events.md
+++ b/docs/scarpet/api/Events.md
@@ -275,6 +275,9 @@ Triggered when the player has successfully logged in and was placed in the game.
 ### `__on_player_disconnects(player, reason)`
 Triggered when a player sends a disconnect package or is forcefully disconnected from the server.
 
+### `__on_player_sends_message(player, message)`
+Triggered when a player sends a chat message or runs a command.
+
 ### `__on_statistic(player, category, event, value)`
 Triggered when a player statistic changes. Doesn't notify on periodic an rhythmic events, i.e. 
 `time_since_death`, `time_since_rest`, and `played_one_minute` since these are triggered every tick. Event 

--- a/docs/scarpet/api/Events.md
+++ b/docs/scarpet/api/Events.md
@@ -275,7 +275,7 @@ Triggered when the player has successfully logged in and was placed in the game.
 ### `__on_player_disconnects(player, reason)`
 Triggered when a player sends a disconnect package or is forcefully disconnected from the server.
 
-### `__on_player_sends_message(player, message)`
+### `__on_player_message(player, message)`
 Triggered when a player sends a chat message or runs a command.
 
 ### `__on_statistic(player, category, event, value)`

--- a/docs/scarpet/resources/editors/idea/4.txt
+++ b/docs/scarpet/resources/editors/idea/4.txt
@@ -44,5 +44,6 @@ __on_player_dies(player) ->
 __on_player_respawns(player) -> 
 __on_player_disconnects(player, reason) -> 
 __on_player_connects(player) -> 
+__on_player_message(player, message) ->
 __on_explosion(pos, power, source, causer, mode, fire) ->
 __on_explosion_outcome(pos, power, source, causer, mode, fire, blocks, entities) ->

--- a/docs/scarpet/resources/editors/npp/scarpet.xml
+++ b/docs/scarpet/resources/editors/npp/scarpet.xml
@@ -147,6 +147,7 @@
                 __on_player_respawns
                 __on_player_disconnects
                 __on_player_connects
+                __on_player_message
                 __on_explosion
                 __on_explosion_outcome
             </Keywords>

--- a/src/main/java/carpet/mixins/ServerGamePacketListenerImpl_scarpetEventsMixin.java
+++ b/src/main/java/carpet/mixins/ServerGamePacketListenerImpl_scarpetEventsMixin.java
@@ -1,5 +1,6 @@
 package carpet.mixins;
 
+import net.minecraft.server.network.TextFilter;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -24,6 +25,7 @@ import static carpet.script.CarpetEventServer.Event.PLAYER_STOPS_SPRINTING;
 import static carpet.script.CarpetEventServer.Event.PLAYER_SWAPS_HANDS;
 import static carpet.script.CarpetEventServer.Event.PLAYER_SWINGS_HAND;
 import static carpet.script.CarpetEventServer.Event.PLAYER_SWITCHES_SLOT;
+import static carpet.script.CarpetEventServer.Event.PLAYER_SENDS_MESSAGE;
 import static carpet.script.CarpetEventServer.Event.PLAYER_USES_ITEM;
 import static carpet.script.CarpetEventServer.Event.PLAYER_WAKES_UP;
 
@@ -42,6 +44,7 @@ import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.BlockHitResult;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 
 @Mixin(ServerGamePacketListenerImpl.class)
@@ -276,6 +279,17 @@ public class ServerGamePacketListenerImpl_scarpetEventsMixin
         if (PLAYER_SWINGS_HAND.isNeeded() && !player.swinging)
         {
             PLAYER_SWINGS_HAND.onHandAction(player, packet.getHand());
+        }
+    }
+
+    @Inject(method = "handleChat(Lnet/minecraft/server/network/TextFilter$FilteredText;)V",
+            at = @At(value = "INVOKE", target = "Ljava/lang/String;startsWith(Ljava/lang/String;)Z"),
+            locals = LocalCapture.CAPTURE_FAILHARD
+    )
+    private void onChatMessage(TextFilter.FilteredText filteredText, CallbackInfo ci, String string) {
+        if (PLAYER_SENDS_MESSAGE.isNeeded())
+        {
+            PLAYER_SENDS_MESSAGE.onPlayerMessage(player,string);
         }
     }
 }

--- a/src/main/java/carpet/mixins/ServerGamePacketListenerImpl_scarpetEventsMixin.java
+++ b/src/main/java/carpet/mixins/ServerGamePacketListenerImpl_scarpetEventsMixin.java
@@ -25,7 +25,7 @@ import static carpet.script.CarpetEventServer.Event.PLAYER_STOPS_SPRINTING;
 import static carpet.script.CarpetEventServer.Event.PLAYER_SWAPS_HANDS;
 import static carpet.script.CarpetEventServer.Event.PLAYER_SWINGS_HAND;
 import static carpet.script.CarpetEventServer.Event.PLAYER_SWITCHES_SLOT;
-import static carpet.script.CarpetEventServer.Event.PLAYER_SENDS_MESSAGE;
+import static carpet.script.CarpetEventServer.Event.PLAYER_MESSAGE;
 import static carpet.script.CarpetEventServer.Event.PLAYER_USES_ITEM;
 import static carpet.script.CarpetEventServer.Event.PLAYER_WAKES_UP;
 
@@ -287,9 +287,9 @@ public class ServerGamePacketListenerImpl_scarpetEventsMixin
             locals = LocalCapture.CAPTURE_FAILHARD
     )
     private void onChatMessage(TextFilter.FilteredText filteredText, CallbackInfo ci, String string) {
-        if (PLAYER_SENDS_MESSAGE.isNeeded())
+        if (PLAYER_MESSAGE.isNeeded())
         {
-            PLAYER_SENDS_MESSAGE.onPlayerMessage(player,string);
+            PLAYER_MESSAGE.onPlayerMessage(player,string);
         }
     }
 }

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -856,6 +856,14 @@ public class CarpetEventServer
                 handler.call( () -> Arrays.asList(new EntityValue(player), new StringValue(message)), player::createCommandSourceStack);
             }
         };
+
+        public static final Event PLAYER_SENDS_MESSAGE = new Event("player_sends_message", 2, false) {
+            @Override
+            public void onPlayerMessage(ServerPlayer player, String message) {
+                handler.call( () -> Arrays.asList(new EntityValue(player), new StringValue(message)), player::createCommandSourceStack);
+            }
+        };
+
         public static final Event STATISTICS = new Event("statistic", 4, false)
         {
             private <T> ResourceLocation getStatId(Stat<T> stat)

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -857,7 +857,7 @@ public class CarpetEventServer
             }
         };
 
-        public static final Event PLAYER_SENDS_MESSAGE = new Event("player_sends_message", 2, false) {
+        public static final Event PLAYER_MESSAGE = new Event("player_message", 2, false) {
             @Override
             public void onPlayerMessage(ServerPlayer player, String message) {
                 handler.call( () -> Arrays.asList(new EntityValue(player), new StringValue(message)), player::createCommandSourceStack);

--- a/src/main/resources/assets/carpet/scripts/event_test.sc
+++ b/src/main/resources/assets/carpet/scripts/event_test.sc
@@ -251,6 +251,13 @@ __on_player_disconnects(player, reason) ->
     print('Player '+player+' disconnects because: '+reason)
 );
 
+__on_player_message(player, message) ->
+(
+    print('');
+    print('__on_player_message(player, message)');
+    print('Player '+player+' sent message: '+message)
+);
+
 __on_player_chooses_recipe(player, recipe, full_stack) ->
 (
     print('');


### PR DESCRIPTION
Adds an `__on_player_message(player,message)` event, which triggers when a player sends a chat message or runs a command.

This is part of #937, and the interception part will be achievable when event cancellation is a thing.