### PR TITLE
new: creativePlayersLoadChunks carpet rule

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -1092,4 +1092,13 @@ public class CarpetSettings
             return "Cannot be negative, can be true, false, or # > 0";
         }
     }
+
+    @Rule(
+            desc = "Creative players load chunks, or they don't! Just like spectators!",
+            extra = {"Toggling behaves exactly as if the player is in spectator mode and toggling the gamerule spectatorsGenerateChunks."
+            },
+            category = {CREATIVE, FEATURE}
+    )
+    public static boolean creativePlayersLoadChunks = true;
+
 }

--- a/src/main/java/carpet/mixins/ChunkMap_creativePlayersLoadChunksMixin.java
+++ b/src/main/java/carpet/mixins/ChunkMap_creativePlayersLoadChunksMixin.java
@@ -1,0 +1,21 @@
+package carpet.mixins;
+
+import carpet.CarpetSettings;
+import net.minecraft.server.level.ChunkMap;
+import net.minecraft.server.level.ServerPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ChunkMap.class)
+public class ChunkMap_creativePlayersLoadChunksMixin {
+
+    @Inject(method = "skipPlayer(Lnet/minecraft/server/level/ServerPlayer;)Z", at = @At("HEAD"), cancellable = true)
+    private void startProfilerSection(ServerPlayer serverPlayer, CallbackInfoReturnable<Boolean> cir)
+    {
+        if (!CarpetSettings.creativePlayersLoadChunks && serverPlayer.isCreative()) {
+            cir.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -190,7 +190,8 @@
     "LivingEntity_creativeFlyMixin",
     "Level_updateSuppressionCrashFixMixin",
     "MinecraftServer_updateSuppressionCrashFixMixin",
-    "ServerPlayer_updateSuppressionCrashFixMixin"
+    "ServerPlayer_updateSuppressionCrashFixMixin",
+    "ChunkMap_creativePlayersLoadChunksMixin"
   ],
   "client": [
     "Timer_tickSpeedMixin",


### PR DESCRIPTION
enabled by default: behavior like vanilla
disabled: creative players do not load chunks like spectators with gamerule spectatorsGenerateChunks false