### PR TITLE
(solve #1074)make it able to create TranslatableComponent or KeybindComponent

### DIFF
--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -653,6 +653,48 @@ public class Auxiliary {
             return new FormattedTextValue(Messenger2.c(args));
         });
 
+        expression.addFunction("translate", values -> {
+            if (values.size() == 0 ) throw new InternalExpressionException("'translate' requires at least one component");
+            ArrayList<Object> arguments=new ArrayList<>();
+            String key=values.get(0).getString();
+            if (key.indexOf(' ')<0){
+                key="j "+key;
+            }
+            else
+            {
+                key="j"+key;
+            }
+            arguments.add(key);
+            values.stream().skip(1).map(v->{
+                if (v instanceof FormattedTextValue){
+                    return ((FormattedTextValue)v).getText().copy();
+                }
+                if (v instanceof EntityValue){
+                    return ((EntityValue)v).getEntity();
+                }
+                if (v instanceof ListValue _v){//item
+                    
+                    if (_v.length()==3){
+                        String id=_v.getItems().get(0).getString();
+                        int count = (int) NumericValue.asNumber(_v.getItems().get(1)).getLong();
+                        Value nbtValue = _v.getItems().get(2);
+                        CompoundTag nbt;
+                        if (nbtValue instanceof NBTSerializableValue)
+                            nbt = ((NBTSerializableValue)nbtValue).getCompoundTag();
+                        else if (nbtValue instanceof NullValue)
+                            nbt = null;
+                        else
+                            nbt = new NBTSerializableValue(nbtValue.getString()).getCompoundTag();
+                        try {
+                            return NBTSerializableValue.parseItem(id, nbt).createItemStack(count, false);
+                        } catch (CommandSyntaxException e) {}
+                    }
+                }
+                return v.getString();
+            }).forEach(x->arguments.add(x));;
+            
+            return new FormattedTextValue(Messenger2.c(arguments.toArray()));
+        });
         expression.addContextFunction("run", 1, (c, t, lv) ->
         {
             CommandSourceStack s = ((CarpetContext)c).s;

--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -57,7 +57,6 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.BaseComponent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundClearTitlesPacket;
 import net.minecraft.network.protocol.game.ClientboundCustomSoundPacket;
@@ -621,6 +620,7 @@ public class Auxiliary {
         });
         expression.addFunction("transformat", values -> {
             if (values.size() == 0 ) throw new InternalExpressionException("'transformat' requires at least one component");
+            BaseComponent p = Messenger.getChatComponentFromDesc_but_with_translation(values.get(0).getString(),null,null);
             Object[] arg = values.stream().skip(1).map(v->{
                 if (v instanceof FormattedTextValue){
                     return ((FormattedTextValue)v).getText();
@@ -646,9 +646,11 @@ public class Auxiliary {
                         } catch (CommandSyntaxException e) {}
                     }
                 }
-                return new TextComponent(v.getString());
-            }).toArray();
-            return new FormattedTextValue(new TranslatableComponent(values.get(0).getString(), arg));
+                return Messenger.getChatComponentFromDesc_but_with_translation(v.getString(), p,null);
+            }).filter(x->x!=null).toArray();
+            BaseComponent res = (Messenger.getChatComponentFromDesc_but_with_translation(values.get(0).getString(),null, arg));
+            res.setStyle(p.getStyle());
+            return new FormattedTextValue(res);
         });
         expression.addContextFunction("run", 1, (c, t, lv) ->
         {

--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -619,16 +619,13 @@ public class Auxiliary {
             return new FormattedTextValue(Messenger.c(values.stream().map(Value::getString).toArray()));
         });
 
-        expression.addFunction("transformat", values -> {
-            if (values.size() == 0 ) throw new InternalExpressionException("'transformat' requires at least one component");
-            BaseComponent[] p = {Messenger.getChatComponentFromDesc(true,values.get(0).getString(),null,(Object[])null)};
-            BaseComponent q=p[0];
-            Object[] arg = values.stream().skip(1).map(v->{
+        expression.addFunction("newformat", values -> {
+            Object[] args = values.stream().map(v->{
                 if (v instanceof FormattedTextValue){
                     return ((FormattedTextValue)v).getText().copy();
                 }
                 if (v instanceof EntityValue){
-                    return ((EntityValue)v).getEntity().getDisplayName();
+                    return ((EntityValue)v).getEntity();
                 }
                 if (v instanceof ListValue _v){//item
                     
@@ -644,16 +641,17 @@ public class Auxiliary {
                         else
                             nbt = new NBTSerializableValue(nbtValue.getString()).getCompoundTag();
                         try {
-                            return NBTSerializableValue.parseItem(id, nbt).createItemStack(count, false).getDisplayName();
+                            return NBTSerializableValue.parseItem(id, nbt).createItemStack(count, false);
                         } catch (CommandSyntaxException e) {}
                     }
                 }
-                return Messenger.getChatComponentFromDesc(true,v.getString(), p[0],(Object[])null);
-            }).filter(x->x!=null).peek(v->{p[0]=(BaseComponent) v;}).toArray();
-            BaseComponent res = (Messenger.getChatComponentFromDesc(true,values.get(0).getString(),null, arg));
-            res.setStyle(q.getStyle());
-            return new FormattedTextValue(res);
+                return v.getString();
+            }).toArray();
+            
+            
+            return new FormattedTextValue(Messenger2.c(args));
         });
+
         expression.addContextFunction("run", 1, (c, t, lv) ->
         {
             CommandSourceStack s = ((CarpetContext)c).s;

--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -621,7 +621,7 @@ public class Auxiliary {
 
         expression.addFunction("transformat", values -> {
             if (values.size() == 0 ) throw new InternalExpressionException("'transformat' requires at least one component");
-            BaseComponent[] p = {Messenger.getChatComponentFromDesc_but_with_translation(values.get(0).getString(),null,(Object[])null)};
+            BaseComponent[] p = {Messenger.getChatComponentFromDesc(true,values.get(0).getString(),null,(Object[])null)};
             BaseComponent q=p[0];
             Object[] arg = values.stream().skip(1).map(v->{
                 if (v instanceof FormattedTextValue){
@@ -648,9 +648,9 @@ public class Auxiliary {
                         } catch (CommandSyntaxException e) {}
                     }
                 }
-                return Messenger.getChatComponentFromDesc_but_with_translation(v.getString(), p[0],(Object[])null);
+                return Messenger.getChatComponentFromDesc(true,v.getString(), p[0],(Object[])null);
             }).filter(x->x!=null).peek(v->{p[0]=(BaseComponent) v;}).toArray();
-            BaseComponent res = (Messenger.getChatComponentFromDesc_but_with_translation(values.get(0).getString(),null, arg));
+            BaseComponent res = (Messenger.getChatComponentFromDesc(true,values.get(0).getString(),null, arg));
             res.setStyle(q.getStyle());
             return new FormattedTextValue(res);
         });

--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -618,12 +618,14 @@ public class Auxiliary {
                 values = ((ListValue) values.get(0)).getItems();
             return new FormattedTextValue(Messenger.c(values.stream().map(Value::getString).toArray()));
         });
+
         expression.addFunction("transformat", values -> {
             if (values.size() == 0 ) throw new InternalExpressionException("'transformat' requires at least one component");
-            BaseComponent p = Messenger.getChatComponentFromDesc_but_with_translation(values.get(0).getString(),null,null);
+            BaseComponent[] p = {Messenger.getChatComponentFromDesc_but_with_translation(values.get(0).getString(),null,(Object[])null)};
+            BaseComponent q=p[0];
             Object[] arg = values.stream().skip(1).map(v->{
                 if (v instanceof FormattedTextValue){
-                    return ((FormattedTextValue)v).getText();
+                    return ((FormattedTextValue)v).getText().copy();
                 }
                 if (v instanceof EntityValue){
                     return ((EntityValue)v).getEntity().getDisplayName();
@@ -646,10 +648,10 @@ public class Auxiliary {
                         } catch (CommandSyntaxException e) {}
                     }
                 }
-                return Messenger.getChatComponentFromDesc_but_with_translation(v.getString(), p,null);
-            }).filter(x->x!=null).toArray();
+                return Messenger.getChatComponentFromDesc_but_with_translation(v.getString(), p[0],(Object[])null);
+            }).filter(x->x!=null).peek(v->{p[0]=(BaseComponent) v;}).toArray();
             BaseComponent res = (Messenger.getChatComponentFromDesc_but_with_translation(values.get(0).getString(),null, arg));
-            res.setStyle(p.getStyle());
+            res.setStyle(q.getStyle());
             return new FormattedTextValue(res);
         });
         expression.addContextFunction("run", 1, (c, t, lv) ->

--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -39,6 +39,7 @@ import carpet.script.value.StringValue;
 import carpet.script.value.Value;
 import carpet.script.value.ValueConversions;
 import carpet.utils.Messenger;
+import carpet.utils.Messenger2;
 import com.google.common.collect.Lists;
 import net.minecraft.SharedConstants;
 import net.minecraft.Util;

--- a/src/main/java/carpet/utils/Messenger.java
+++ b/src/main/java/carpet/utils/Messenger.java
@@ -7,6 +7,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.BaseComponent;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.KeybindComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.TextColor;
 import net.minecraft.network.chat.TextComponent;
@@ -146,7 +147,7 @@ public class Messenger
             case '@' -> previousStyle.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, message.substring(1)));
             case '&' -> previousStyle.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, message.substring(1)));
             default  -> { // Create a new component
-                ret = new TextComponent(str);
+                ret = desc.indexOf('_')<0 ? new TextComponent(str):new KeybindComponent(str);
                 ret.setStyle(parseStyle(desc));
                 yield previousStyle; // no op for the previous style
             }
@@ -173,7 +174,7 @@ public class Messenger
             str = message.substring(limit+1);
         }
         if (previousMessage == null) {
-            BaseComponent text = new TextComponent(str);
+            BaseComponent text =desc.indexOf('_')<0 ? new TextComponent(str):new KeybindComponent(str);
             text.setStyle(parseStyle(desc));
             return text;
         }
@@ -186,7 +187,7 @@ public class Messenger
             case '@' -> previousStyle.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, message.substring(1)));
             case '&' -> previousStyle.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, message.substring(1)));
             default  -> { // Create a new component
-                ret = new TextComponent(str);
+                ret = desc.indexOf('_')<0 ? new TextComponent(str):new KeybindComponent(str);
                 ret.setStyle(parseStyle(desc));
                 yield previousStyle; // no op for the previous style
             }

--- a/src/main/java/carpet/utils/Messenger.java
+++ b/src/main/java/carpet/utils/Messenger.java
@@ -115,7 +115,7 @@ public class Messenger
             default -> "w"; // missing MISC and UNDERGROUND_WATER_CREATURE
         };
     }
-    public static BaseComponent getChatComponentFromDesc_but_with_translation(String message, BaseComponent previousMessage, Object ... arg)
+    public static BaseComponent getChatComponentFromDesc(boolean for_translation,String message, BaseComponent previousMessage, Object ... arg)
     {
         if (message.equalsIgnoreCase(""))
         {
@@ -134,7 +134,7 @@ public class Messenger
             str = message.substring(limit+1);
         }
         if (previousMessage == null) {
-            BaseComponent text = new TranslatableComponent(str, arg);
+            BaseComponent text = for_translation? new TranslatableComponent(str, arg):!desc.startsWith("_") ? new TextComponent(str):new KeybindComponent(str);
             text.setStyle(parseStyle(desc));
             return text;
         }
@@ -147,7 +147,7 @@ public class Messenger
             case '@' -> previousStyle.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, message.substring(1)));
             case '&' -> previousStyle.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, message.substring(1)));
             default  -> { // Create a new component
-                ret = desc.indexOf('_')<0 ? new TextComponent(str):new KeybindComponent(str);
+                ret = !desc.startsWith("_") ? new TextComponent(str):new KeybindComponent(str);
                 ret.setStyle(parseStyle(desc));
                 yield previousStyle; // no op for the previous style
             }
@@ -157,42 +157,7 @@ public class Messenger
 
     private static BaseComponent getChatComponentFromDesc(String message, BaseComponent previousMessage)
     {
-        if (message.equalsIgnoreCase(""))
-        {
-            return new TextComponent("");
-        }
-        if (Character.isWhitespace(message.charAt(0)))
-        {
-            message = "w" + message;
-        }
-        int limit = message.indexOf(' ');
-        String desc = message;
-        String str = "";
-        if (limit >= 0)
-        {
-            desc = message.substring(0, limit);
-            str = message.substring(limit+1);
-        }
-        if (previousMessage == null) {
-            BaseComponent text =desc.indexOf('_')<0 ? new TextComponent(str):new KeybindComponent(str);
-            text.setStyle(parseStyle(desc));
-            return text;
-        }
-        Style previousStyle = previousMessage.getStyle();
-        BaseComponent ret = previousMessage;
-        previousMessage.setStyle(switch (desc.charAt(0)) {
-            case '?' -> previousStyle.withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, message.substring(1)));
-            case '!' -> previousStyle.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, message.substring(1)));
-            case '^' -> previousStyle.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, c(message.substring(1))));
-            case '@' -> previousStyle.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, message.substring(1)));
-            case '&' -> previousStyle.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, message.substring(1)));
-            default  -> { // Create a new component
-                ret = desc.indexOf('_')<0 ? new TextComponent(str):new KeybindComponent(str);
-                ret.setStyle(parseStyle(desc));
-                yield previousStyle; // no op for the previous style
-            }
-        });
-        return ret;
+        return getChatComponentFromDesc(false, message,  previousMessage);
     }
     public static BaseComponent tp(String desc, Vec3 pos) { return tp(desc, pos.x, pos.y, pos.z); }
     public static BaseComponent tp(String desc, BlockPos pos) { return tp(desc, pos.getX(), pos.getY(), pos.getZ()); }
@@ -298,8 +263,8 @@ public class Messenger
             }
             String txt = o.toString();
             BaseComponent comp = getChatComponentFromDesc(txt, previousComponent);
-            if (comp != previousComponent) message.append(comp);
-            previousComponent = comp;
+            if (comp != null){ message.append(comp);
+            previousComponent = comp;}
         }
         return message;
     }

--- a/src/main/java/carpet/utils/Messenger2.java
+++ b/src/main/java/carpet/utils/Messenger2.java
@@ -100,10 +100,7 @@ public class Messenger2 {
         c = 0;
     }
 
-    /*
-     * composes single line, multicomponent message, and returns as one chat
-     * messagge
-     */
+
     public Component getSomeComponents(){
         return getSomeComponents("|");
     }
@@ -136,7 +133,7 @@ public class Messenger2 {
                 case '!' -> previousStyle
                         .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, message.substring(1)));
                 case '^' -> previousStyle
-                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, getSomeComponents()));
+                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, message.equals("^")?getARawComponent():c(message.substring(1))));
                 case '@' -> previousStyle
                         .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, message.substring(1)));
                 case '&' -> previousStyle
@@ -242,6 +239,6 @@ public class Messenger2 {
         }
     }
 
-    // simple text
+
 
 }

--- a/src/main/java/carpet/utils/Messenger2.java
+++ b/src/main/java/carpet/utils/Messenger2.java
@@ -1,0 +1,238 @@
+package carpet.utils;
+import java.util.regex.Pattern;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.BaseComponent;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.KeybindComponent;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
+import net.minecraft.network.chat.TextColor;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.TranslatableComponent;
+
+import net.minecraft.world.entity.Entity;
+
+import net.minecraft.world.item.ItemStack;
+
+import java.util.ArrayList;
+
+import java.util.function.BiFunction;
+
+import java.util.regex.Matcher;
+import java.util.function.Function;
+public class Messenger2 {
+    ArrayList<Object> data = new ArrayList<>();
+    int c;
+    int size;
+
+
+
+    public static Style parseStyle(String style)
+    {
+        Style myStyle= Style.EMPTY.withColor(ChatFormatting.WHITE);
+        for (CarpetFormatting cf: CarpetFormatting.values()) myStyle = cf.apply(style, myStyle);
+        return myStyle;
+    }
+
+    private static final Pattern colorExtract = Pattern.compile("#([0-9a-fA-F]{6})");
+    public enum CarpetFormatting
+    {
+        ITALIC      ('i', (s, f) -> s.withItalic(true)),
+        STRIKE      ('s', (s, f) -> s.applyFormat(ChatFormatting.STRIKETHROUGH)),
+        UNDERLINE   ('u', (s, f) -> s.applyFormat(ChatFormatting.UNDERLINE)),
+        BOLD        ('b', (s, f) -> s.withBold(true)),
+        OBFUSCATE   ('o', (s, f) -> s.applyFormat(ChatFormatting.OBFUSCATED)),
+
+        WHITE       ('w', (s, f) -> s.withColor(ChatFormatting.WHITE)),
+        YELLOW      ('y', (s, f) -> s.withColor(ChatFormatting.YELLOW)),
+        LIGHT_PURPLE('m', (s, f) -> s.withColor(ChatFormatting.LIGHT_PURPLE)), // magenta
+        RED         ('r', (s, f) -> s.withColor(ChatFormatting.RED)),
+        AQUA        ('c', (s, f) -> s.withColor(ChatFormatting.AQUA)), // cyan
+        GREEN       ('l', (s, f) -> s.withColor(ChatFormatting.GREEN)), // lime
+        BLUE        ('t', (s, f) -> s.withColor(ChatFormatting.BLUE)), // light blue, teal
+        DARK_GRAY   ('f', (s, f) -> s.withColor(ChatFormatting.DARK_GRAY)),
+        GRAY        ('g', (s, f) -> s.withColor(ChatFormatting.GRAY)),
+        GOLD        ('d', (s, f) -> s.withColor(ChatFormatting.GOLD)),
+        DARK_PURPLE ('p', (s, f) -> s.withColor(ChatFormatting.DARK_PURPLE)), // purple
+        DARK_RED    ('n', (s, f) -> s.withColor(ChatFormatting.DARK_RED)),  // brown
+        DARK_AQUA   ('q', (s, f) -> s.withColor(ChatFormatting.DARK_AQUA)),
+        DARK_GREEN  ('e', (s, f) -> s.withColor(ChatFormatting.DARK_GREEN)),
+        DARK_BLUE   ('v', (s, f) -> s.withColor(ChatFormatting.DARK_BLUE)), // navy
+        BLACK       ('k', (s, f) -> s.withColor(ChatFormatting.BLACK)),
+
+        COLOR       ('#', (s, f) -> {
+            TextColor color = TextColor.parseColor("#"+f);
+            return color == null ? s : s.withColor(color);
+        }, s -> {
+            Matcher m = colorExtract.matcher(s);
+            return m.find() ? m.group(1) : null;
+        }),
+        ;
+
+        public char code;
+        public BiFunction<Style, String, Style> applier;
+        public Function<String, String> container;
+        CarpetFormatting(char code, BiFunction<Style, String, Style> applier)
+        {
+            this(code, applier, s -> s.indexOf(code)>=0?Character.toString(code):null);
+        }
+        CarpetFormatting(char code, BiFunction<Style, String, Style> applier, Function<String, String> container)
+        {
+            this.code = code;
+            this.applier = applier;
+            this.container = container;
+        }
+        public Style apply(String format, Style previous)
+        {
+            String fmt;
+            if ((fmt = container.apply(format))!= null) return applier.apply(previous, fmt);
+            return previous;
+        }
+    };
+
+    Messenger2(Object... data) {
+        for (Object x : data) {
+            this.data.add(x);
+        }
+        this.size = this.data.size();
+        c = 0;
+    }
+
+    /*
+     * composes single line, multicomponent message, and returns as one chat
+     * messagge
+     */
+
+    public Component getSomeComponents() {
+        TextComponent message = new TextComponent("");
+        while (true) {
+            if (isEnd()) {
+                return message;
+            }
+            Component com = getAComponent();
+            message.append(com);
+        }
+    }
+
+    private Component getAComponent() {
+        BaseComponent base = (BaseComponent) getARawComponent();
+        while (isModifier(now())) {
+            base = (BaseComponent) getModifier(((String) now()).charAt(0)).apply(base, (String) now());
+        }
+        return base;
+    }
+
+    private BiFunction<BaseComponent, String, Component> getModifier(char ch) {
+        c += 1;
+        return (base, message) -> {
+            Style previousStyle = base.getStyle();
+            base.setStyle(switch (ch) {
+                case '?' -> previousStyle
+                        .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, message.substring(1)));
+                case '!' -> previousStyle
+                        .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, message.substring(1)));
+                case '^' -> previousStyle
+                        .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, getSomeComponents()));
+                case '@' -> previousStyle
+                        .withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, message.substring(1)));
+                case '&' -> previousStyle
+                        .withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, message.substring(1)));
+                default -> null;
+            });
+            return base;
+        };
+
+    }
+
+    private static boolean isModifier(Object peek) {
+        if (peek instanceof String pek) {
+            if (pek.startsWith("^") || pek.startsWith("?") || pek.startsWith("!") || pek.startsWith("@")
+                    || pek.startsWith("&")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Component getARawComponent() {
+        Component res;
+        if (now() instanceof Component b) {
+            res=  b;
+            c += 1;return res;
+        }
+        if (now() instanceof Entity ent) {
+            res=  (ent.getDisplayName());
+            c += 1;return res;
+        }
+        if (now() instanceof ItemStack ent) {
+            res= (ent.getDisplayName());
+            c += 1;return res;
+        }
+        if (now() instanceof String message) {
+            if (message.equalsIgnoreCase("")) {
+                return new TextComponent("");
+            }
+            if (message.charAt(0)==' ') {
+                message = "w" + message;
+            }
+            int limit = message.indexOf(' ');
+            String desc = message;
+            String str = "";
+            if (limit >= 0) {
+                desc = message.substring(0, limit);
+                str = message.substring(limit + 1);
+            }
+            c += 1;
+            ArrayList<Object> args = new ArrayList<>();
+            if(desc.indexOf('j')>=0){
+                while(true){
+                    if(isEnd())break;
+                    args.add(getAComponent());
+                }
+                
+            }
+            BaseComponent text = desc.indexOf('j')>=0? new TranslatableComponent(str,args.toArray()):!desc.startsWith("_") ? new TextComponent(str):new KeybindComponent(str);
+            text.setStyle(parseStyle(desc));
+            
+            return text;
+        }
+
+        return null;
+        // TO DO
+    }
+
+    private boolean isEnd() {
+        if (c >= size)
+            return true;
+        if ("|".equals(now())) {
+            c += 1;
+            return true;
+        }
+        ;
+        return false;
+    }
+
+
+
+    private Object now() {
+        if (c >= size)
+            return null;
+        return data.get(c);
+
+    }
+
+    public static Component c(Object... fields) {
+        Messenger2 m = new Messenger2(fields);
+
+        if (m.size < 1) {
+            return new TextComponent("");
+        } else {
+            return m.getSomeComponents();
+        }
+    }
+
+    // simple text
+
+}

--- a/src/main/java/carpet/utils/Messenger2.java
+++ b/src/main/java/carpet/utils/Messenger2.java
@@ -104,11 +104,13 @@ public class Messenger2 {
      * composes single line, multicomponent message, and returns as one chat
      * messagge
      */
-
-    public Component getSomeComponents() {
+    public Component getSomeComponents(){
+        return getSomeComponents("|");
+    }
+    public Component getSomeComponents(String str) {
         TextComponent message = new TextComponent("");
         while (true) {
-            if (isEnd()) {
+            if (isEnd(str)) {
                 return message;
             }
             Component com = getAComponent();
@@ -172,7 +174,12 @@ public class Messenger2 {
         }
         if (now() instanceof String message) {
             if (message.equalsIgnoreCase("")) {
+                c+=1;
                 return new TextComponent("");
+            }
+            if (message.equals("[")){
+                c+=1;
+                return getSomeComponents("]");
             }
             if (message.charAt(0)==' ') {
                 message = "w" + message;
@@ -203,17 +210,19 @@ public class Messenger2 {
         // TO DO
     }
 
-    private boolean isEnd() {
+    private boolean isEnd(String s) {
         if (c >= size)
             return true;
-        if ("|".equals(now())) {
+        if (s.equals(now())) {
             c += 1;
             return true;
         }
         ;
         return false;
     }
-
+    private boolean isEnd() {
+        return isEnd("|");
+    }
 
 
     private Object now() {

--- a/src/main/java/carpet/utils/Messenger2.java
+++ b/src/main/java/carpet/utils/Messenger2.java
@@ -118,7 +118,8 @@ public class Messenger2 {
     private Component getAComponent() {
         BaseComponent base = (BaseComponent) getARawComponent();
         while (isModifier(now())) {
-            base = (BaseComponent) getModifier(((String) now()).charAt(0)).apply(base, (String) now());
+            Object now = now();
+            base = (BaseComponent) getModifier(((String) now()).charAt(0)).apply(base, (String) now);
         }
         return base;
     }


### PR DESCRIPTION
* `UPDATE`
seems that gnembon really want a function called translate
so i add one. 
https://github.com/gnembon/fabric-carpet/pull/1315/commits/bef2339686648107362af864051dc2680d7911f1

------------------------

I&#39;ve completely rewritten it.
I wrote a method called Messenger2.c() . Hopefully it will replace the existing Messenger.c() . Because the existing one has some flaws. (such as the parameter...
it is the same as newformat, but adding a 'j' at the front of the first argument.

I've completely rewritten it. 

I wrote a method called Messenger2.c() . Hopefully it will replace the existing Messenger.c() . Because the existing one has some flaws. (such as the parameter can only be string value, and cannot be text value & hover text cannot be complex.)I also managed to make the new function fully compatible with the way to use the old one.

and add a scarpet function which is nothing but a warper of it for testing.i named it "newformat" temporary as i do not want to remove the old one too early to compare.

example:
`/script run print(newformat('bj death.fell.assist.item','e good guy',p,p~'holds','|','^','_ key.command',newformat('e g','b g')))`

'j' (maybe '%' is better) from the first arg marks that it is a translation component. args between it and next '|' ( or #EOF) will be its inputs.
'^' marks that next args will be hover text. Current '^b eee' format is allowed too.(maintain compatibility) '^b eee' == '^','b eee'
'_' marks that it is a keyboard component. (key.command is '/' for me)
![图片](https://user-images.githubusercontent.com/45825511/153243702-8c4c2bb1-68cc-421e-a595-886da9f42a51.png)

This is a structure that allows recursion. It can be nested.

inner newformat function is not necessary. but u can put it here too.

and entities/item\`s len3 vectors are allowed too.