### PR TITLE
Fix exceptions in `place_item` by implementing a missing method in PlacementContext and special case paintings

### DIFF
--- a/src/main/java/carpet/script/api/WorldAccess.java
+++ b/src/main/java/carpet/script/api/WorldAccess.java
@@ -1006,9 +1006,13 @@ public class WorldAccess {
             Vector3Argument locator = Vector3Argument.findIn(lv, 1);
             ItemInput stackArg = NBTSerializableValue.parseItem(itemString);
             BlockPos where = new BlockPos(locator.vec);
-            String facing = "up";
-            if (lv.size() > locator.offset)
+            String facing;
+            if (lv.size() > locator.offset) {
                 facing = lv.get(locator.offset).getString();
+            } else {
+                // Paintings throw an exception if their direction is vertical, therefore we change the default here
+                facing = stackArg.getItem() != Items.PAINTING ? "up" : "north";
+            }
             boolean sneakPlace = false;
             if (lv.size() > locator.offset+1)
                 sneakPlace = lv.get(locator.offset+1).getBoolean();

--- a/src/main/java/carpet/script/value/BlockValue.java
+++ b/src/main/java/carpet/script/value/BlockValue.java
@@ -10,13 +10,13 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import net.minecraft.commands.arguments.blocks.BlockStateParser;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Direction.Axis;
 import net.minecraft.core.GlobalPos;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
@@ -312,6 +312,11 @@ public class BlockValue extends Value
         @Override
         public Direction getHorizontalDirection() {
             return this.facing.getAxis() == Direction.Axis.Y ? Direction.NORTH : this.facing;
+        }
+
+        @Override
+        public Direction getNearestLookingVerticalDirection() {
+            return facing.getAxis() == Axis.Y ? facing : Direction.UP;
         }
 
         @Override


### PR DESCRIPTION
Fixed an issue reported in Discord where an exception would be thrown in those cases.

The unimplemented method was going back to try to use the player (that isn't passed), throwing a NPE with items like pointed dripstone, and the painting fix is because it relies in the context being horizontal already without asking the context via the horizontal method, therefore we now change the default to a horizontal direction if it's a painting. The direction isn't changed if the user did specify a direction.

With this, a loop through all items completes without those exceptions.

PS: The method was added in 1.17 if I used fabric bot correctly for that.