### PR TITLE
Print a warning when an extension registers late

### DIFF
--- a/src/main/java/carpet/CarpetServer.java
+++ b/src/main/java/carpet/CarpetServer.java
@@ -66,6 +66,8 @@ public class CarpetServer // static for now - easier to handle all around the co
         if (currentCommandDispatcher != null)
         {
             extension.registerCommands(currentCommandDispatcher);
+            CarpetSettings.LOG.warn(extension.getClass().getSimpleName() + " extension registered too late!");
+            CarpetSettings.LOG.warn("This won't be supported in later Carpet versions and may crash the game!");
         }
     }
 


### PR DESCRIPTION
This PR makes Carpet print a warning if extensions register themselves late, with the idea of (maybe) later making that throw an exception and later just not have the fallback if they register late.

There's multiple methods extensions can use to register themselves in time, they should make sure they are registering correctly IMO and Carpet shouldn't be checking that.