### PR TITLE
Added jitpack support

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+- sdk install java 17.0.1-open
+- sdk use java 17.0.1-open


### PR DESCRIPTION
Jitpack uses java8 by default and obviously that doesn't work for MC 1.17+ development. We need java17 to make jitpack work and what we need is just a jitpack config file (https://docs.jitpack.io/building/#java-version)

With this PR, mod devs don't need to wait until carpet publishing to masa's maven to test their extensions with the latest carpet

It's also useful when testing the PR branches since the `jitpack.yml` will be in those PR branches too