### PR TITLE
Added lazydfu mod in dev runtime for faster startup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,12 @@ plugins {
 	id 'maven-publish'
 }
 
+repositories {
+	maven {
+		url 'https://www.jitpack.io'
+	}
+}
+
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 
@@ -24,6 +30,9 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	//modImplementation "net.fabricmc:fabric:${project.fabric_version}"
 	modCompileOnly fabricApi.module("fabric-rendering-v1", project.fabric_version)
+
+	// runtime mods
+	modRuntimeOnly "com.github.astei:lazydfu:0.1.2"  // faster startup
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.


### PR DESCRIPTION
Data fixer initialization loves to eat all cpu during Minecraft startup (100% CPU usage for >1min on my i7-8750H) and that's really annoying

Here comes the fix for that: [LazyDFU](https://github.com/astei/lazydfu) mod at runtime

## Compatibility

LazyDFU only has 1 single mixin and it works from 1.14 to current 1.18.2 snapshots, and it's likely to work in future versions without changes

## Stability

For the mod, LazyDFU changed nothing about game behaviors

For the maven, jitpack is used as the maven repository of LazyDFU which is stable

## Dependency

If somehow LazyDFU doesn't work anymore in the future, you can simply removed it from runtime (basically revert this commit) and nothing will get hurted