### PR TITLE
Fix unhandled exceptions when evaluating operators

### DIFF
--- a/src/main/java/carpet/script/Fluff.java
+++ b/src/main/java/carpet/script/Fluff.java
@@ -238,14 +238,16 @@ public abstract class Fluff
         @Override
         public LazyValue lazyEval(Context cc, Context.Type type, Expression e, Tokenizer.Token t, final LazyValue v1, final LazyValue v2)
         {
-            try
-            {
-                return (c, type_ignored) -> AbstractOperator.this.eval(v1.evalValue(c, Context.Type.NONE), v2.evalValue(c, Context.Type.NONE));
-            }
-            catch (RuntimeException exc)
-            {
-                throw Expression.handleCodeException(cc, exc, e, t);
-            }
+            return (c, typeIgnored) -> {
+                try
+                {
+                    return AbstractOperator.this.eval(v1.evalValue(c, Context.Type.NONE), v2.evalValue(c, Context.Type.NONE));
+                }
+                catch (RuntimeException exc)
+                {
+                    throw Expression.handleCodeException(cc, exc, e, t);
+                }
+            };
         }
     }
 
@@ -267,24 +269,26 @@ public abstract class Fluff
         @Override
         public LazyValue lazyEval(Context cc, Context.Type type, Expression e, Tokenizer.Token t, final LazyValue v1, final LazyValue v2)
         {
-            try
+            if (v2 != null)
             {
-                if (v2 != null)
+                throw new ExpressionException(cc, e, t, "Did not expect a second parameter for unary operator");
+            }
+            return (c, ignoredType) -> {
+                try
                 {
-                    throw new ExpressionException(cc, e, t, "Did not expect a second parameter for unary operator");
+                    return AbstractUnaryOperator.this.evalUnary(v1.evalValue(c, Context.Type.NONE));
                 }
-                return (c, ignored_type) -> AbstractUnaryOperator.this.evalUnary(v1.evalValue(c, Context.Type.NONE));
-            }
-            catch (RuntimeException exc)
-            {
-                throw Expression.handleCodeException(cc, exc, e, t);
-            }
+                catch (RuntimeException exc)
+                {
+                    throw Expression.handleCodeException(cc, exc, e, t);
+                }
+            };
         }
 
         @Override
         public Value eval(Value v1, Value v2)
         {
-            throw new RuntimeException("Shouldn't end up here");
+            throw new IllegalStateException("Shouldn't end up here");
         }
 
         public abstract Value evalUnary(Value v1);


### PR DESCRIPTION
When the optimizer is on, running those operators during the optimization phase in a way they throw `InternalExpressionException` will cause the exception to be leaked outside of the scarpet stack, returning "unexpected error while running command" or crashing the game.

The issue is caused because their try-catch blocks were placed when creating the lambda, not when executing them.

Given the exceptions don't get leaked during regular execution (outside the optimizer), this makes me feel like there's unnecessary try-catch blocks in regular execution somewhere, but I don't know enough of the inner workings of Scarpet to analyse it or be confident about removing any.

Reproducers that trigger this issue:
- `-[]`
- `'a' % 2`