### PR TITLE
Simplify cache in action workflows

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -17,12 +17,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 17
-    - name: Cache Gradle packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle
+        cache: 'gradle'
     - name: Grant execute permission to gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -17,12 +17,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 17
-    - name: Cache Gradle packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle
+        cache: 'gradle'
     - name: Grant execute permission to gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -70,12 +70,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+          cache: 'gradle'
       - name: Grant execute permission to gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
@@ -145,12 +140,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+          cache: 'gradle'
       - name: Replace fabric.mod.json
         run: |
           cd src/main/resources


### PR DESCRIPTION
Since a while back, `setup-java` has an option to prepare and restore the cache of gradle packages directly there. It's not only simpler but they also claim for it to be faster given it runs at the same time java is being setup.

In this PR I drop the cache step in favour of adding `setup-java`'s in all three workflows.