### PR TITLE
Docs edit, noted double backslash requirement for some regex operators

### DIFF
--- a/docs/scarpet/Full.md
+++ b/docs/scarpet/Full.md
@@ -976,10 +976,11 @@ title('aBc') => 'Abc'
 ### `replace(string, regex, repl?); replace_first(string, regex, repl?)`
 
 Replaces all, or first occurence of a regular expression in the string with `repl` expression, 
-or nothing, if not specified
+or nothing, if not specified. To use escape characters(`\(`,`\+`,...), metacharacters(`\d`,`\w`,...), or position anchors(`\b`,`\z`,...) in your regular expression, use two backslashes
 
 <pre>
 replace('abbccddebfg','b+','z')  // => azccddezfg
+replace('abbccddebfg','\\w$','z')  // => abbccddebfz
 replace_first('abbccddebfg','b+','z')  // => azccddebfg
 </pre>
 


### PR DESCRIPTION
It appears that `replace` and `replace_first` require double backslashes to use some regex operators. Since I don't think this is a bug, I've added a note about it to the description of the functions in the docs. I also added an example that is similar to the originals. I don't know if docs have a style guide, but if they do, I probably failed to follow it.