### PR TITLE
Docs edit, noted double backslash requirement for some regex operators

### DIFF
--- a/docs/scarpet/language/SystemFunctions.md
+++ b/docs/scarpet/language/SystemFunctions.md
@@ -206,9 +206,11 @@ title('aBc') => 'Abc'
 
 Replaces all, or first occurence of a regular expression in the string with `repl` expression, 
 or nothing, if not specified
+or nothing, if not specified. To use escape characters(`\(`,`\+`,...), metacharacters(`\d`,`\w`,...), or position anchors(`\b`,`\z`,...) in your regular expression, use two backslashes
 
 <pre>
 replace('abbccddebfg','b+','z')  // => azccddezfg
+replace('abbccddebfg','\\w$','z')  // => abbccddebfz
 replace_first('abbccddebfg','b+','z')  // => azccddebfg
 </pre>
 

--- a/docs/scarpet/language/SystemFunctions.md
+++ b/docs/scarpet/language/SystemFunctions.md
@@ -205,8 +205,7 @@ title('aBc') => 'Abc'
 ### `replace(string, regex, repl?); replace_first(string, regex, repl?)`
 
 Replaces all, or first occurence of a regular expression in the string with `repl` expression, 
-or nothing, if not specified
-or nothing, if not specified. To use escape characters(`\(`,`\+`,...), metacharacters(`\d`,`\w`,...), or position anchors(`\b`,`\z`,...) in your regular expression, use two backslashes
+or nothing, if not specified. To use escape characters (`\(`,`\+`,...), metacharacters (`\d`,`\w`,...), or position anchors (`\b`,`\z`,...) in your regular expression, use two backslashes.
 
 <pre>
 replace('abbccddebfg','b+','z')  // => azccddezfg


### PR DESCRIPTION
It appears that `replace` and `replace_first` require double backslashes to use some regex operators, probably because it seems that Java also requires this. I've added a note about it to the description of the functions in the docs and also added an example that is similar to the originals. If this requirement is considered a bug and is fixed soon, this pr can be ignored.