### PR TITLE
Ease concrete restrictions on Annotated Scarpet API and make instantiating lazier

### DIFF
--- a/src/main/java/carpet/script/annotation/ScarpetFunction.java
+++ b/src/main/java/carpet/script/annotation/ScarpetFunction.java
@@ -15,8 +15,8 @@ import carpet.script.value.Value;
 /**
  * <p>Defines a method that can be used as a function in the Scarpet language.</p>
  * 
- * <p>Methods annotated with this annotation are not required to accept and return the typical {@code Context context, Integer t, List<Value> lv}, but
- * instead can specify whatever parameters they actually need that will be automatically converted from their respective {@link Value}s and passed to
+ * <p>Methods annotated with this annotation are not required to accept and return the implementation {@code Context context, Context.Type t, List<Value> lv}, 
+ * but instead can specify whatever parameters they actually need that will be automatically converted from their respective {@link Value}s and passed to
  * the method as the expected type. Functions will automatically fail if given parameters are not compatible with the specified ones, or if the number
  * of provided arguments is either too large or too small.</p>
  * 
@@ -26,8 +26,7 @@ import carpet.script.value.Value;
  * In order to convert the output of your method to a {@link LazyValue} you will also need to register its conversion in {@link OutputConverter}</p>
  * 
  * <p>In order for Carpet to find methods annotated with this annotation, you must add your function class(es) to Carpet by running
- * {@link AnnotationParser#parseFunctionClass(Class)} ONCE. The provided {@link Class} must be concrete and provide the default constructor or an
- * equivalent to it.</p>
+ * {@link AnnotationParser#parseFunctionClass(Class)} ONCE.</p>
  * 
  * <p>Methods annotated with this annotation must not declare throwing any checked exceptions.</p>
  * 


### PR DESCRIPTION
Prevents instantiating classes with all annotated methods static, making it also more flexible in that you can put annotated functions near to other API that may be initialized in special ways.

The docs really need rewriting, but that's for another day, this should be trivial.

This is motivated after discovering that Java doesn't throw binary compatibility errors if an annotation type is missing, just ignores those annotations.

Therefore other mods should be able annotate their already API methods directly without fear of binary issues when carpet isn't present, as long as the call to parseFunctionsClass is wrapped inside a condition. This PR improves this by not adding strange behaviour to parsing a class. Further PRs will try to improve this by adding utils like allowing to change the method name from the annotation. Even considered making a "scarpet API lite" jar with just the annotation, Context.Type and a stub for parseFunctionsClass to ease it even further by not requiring the whole carpet package at compile time, but that's way more long term and not sure if really worth it.