### PR TITLE
Fix Curseforge release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ org.gradle.jvmargs=-Xmx1G
 	# The Curseforge versions "names" or ids for the main branch (comma separated: 1.16.4,1.16.5)
 	# This is needed because CF uses too vague names for prereleases and release candidates
 	# Can also be the version ID directly coming from https://minecraft.curseforge.com/api/game/versions?token=[API_TOKEN]
-	release-curse-versions = 1.18.2
+	release-curse-versions = 1.18:1.18.2
 	# Whether or not to build another branch on release
 	release-extra-branch = true
 	# The name of the second branch to release


### PR DESCRIPTION
According to the author of the action we use, that should prevent the curseforge api from messing up the build (and if it doesn't, then it's `Minecraft 1.18:1.18.2`).