### PR TITLE
New Logger: `updateStackCount`

### DIFF
--- a/src/main/java/carpet/logging/LoggerRegistry.java
+++ b/src/main/java/carpet/logging/LoggerRegistry.java
@@ -28,6 +28,7 @@ public class LoggerRegistry
     public static boolean __pathfinding;
     public static boolean __explosions;
     public static boolean __updateSuppressedCrashes;
+    public static boolean __updateStackCount;
 
     public static void initLoggers()
     {
@@ -48,7 +49,7 @@ public class LoggerRegistry
         registerLogger("mobcaps", HUDLogger.stardardHUDLogger("mobcaps", "dynamic",new String[]{"dynamic", "overworld", "nether","end"}));
         registerLogger("explosions", Logger.stardardLogger("explosions", "brief",new String[]{"brief", "full"}, true));
         registerLogger("updateSuppressedCrashes", Logger.stardardLogger("updateSuppressedCrashes", null,null));
-
+        registerLogger("updateStackCount", Logger.stardardLogger("updateStackCount", null,null));
     }
 
     /**

--- a/src/main/java/carpet/mixins/CollectingNeighborUpdater_loggerMixin.java
+++ b/src/main/java/carpet/mixins/CollectingNeighborUpdater_loggerMixin.java
@@ -1,0 +1,38 @@
+package carpet.mixins;
+
+import carpet.logging.LoggerRegistry;
+import carpet.utils.Messenger;
+import net.minecraft.network.chat.BaseComponent;
+import net.minecraft.world.level.redstone.CollectingNeighborUpdater;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(CollectingNeighborUpdater.class)
+public class CollectingNeighborUpdater_loggerMixin {
+
+    @Shadow
+    private int count;
+
+
+    @Inject(
+            method = "runUpdates()V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/util/ArrayDeque;clear()V",
+                    shift = At.Shift.BEFORE,
+                    ordinal = 0
+            )
+    )
+    private void onStackDone(CallbackInfo ci) {
+        if(LoggerRegistry.__updateStackCount && this.count > 25) {
+            LoggerRegistry.getLogger("updateStackCount").log(() -> {
+                return new BaseComponent[]{Messenger.c(
+                        "w Stack finished with: "+this.count+" updates"
+                )};
+            });
+        }
+    }
+}

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -194,7 +194,8 @@
     "Level_updateSuppressionCrashFixMixin",
     "MinecraftServer_updateSuppressionCrashFixMixin",
     "ServerPlayer_updateSuppressionCrashFixMixin",
-    "ChunkMap_creativePlayersLoadChunksMixin"
+    "ChunkMap_creativePlayersLoadChunksMixin",
+    "CollectingNeighborUpdater_loggerMixin"
   ],
   "client": [
     "Timer_tickSpeedMixin",


### PR DESCRIPTION
It will tell you a stacks (block updates & shape updates) Chained Neighbor Update count.
Only does this if the chain is over 25.
If this number reaches 1M then it will skip the rest of the updates, so knowing the number of updates is important.