### PR TITLE
Make scarpet internal and control flow exceptions stackless

### DIFF
--- a/src/main/java/carpet/script/exception/CarpetExpressionException.java
+++ b/src/main/java/carpet/script/exception/CarpetExpressionException.java
@@ -5,7 +5,7 @@ import carpet.utils.Messenger;
 import java.util.List;
 import net.minecraft.commands.CommandSourceStack;
 
-public class CarpetExpressionException extends RuntimeException implements ResolvedException
+public class CarpetExpressionException extends StacklessRuntimeException implements ResolvedException
 {
     public final List<FunctionValue> stack;
 

--- a/src/main/java/carpet/script/exception/ExitStatement.java
+++ b/src/main/java/carpet/script/exception/ExitStatement.java
@@ -3,7 +3,7 @@ package carpet.script.exception;
 import carpet.script.value.Value;
 
 /* Exception thrown to terminate execution mid expression (aka return statement) */
-public class ExitStatement extends RuntimeException
+public class ExitStatement extends StacklessRuntimeException
 {
     public final Value retval;
     public ExitStatement(Value value)

--- a/src/main/java/carpet/script/exception/ExpressionException.java
+++ b/src/main/java/carpet/script/exception/ExpressionException.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 /* The expression evaluators exception class. */
-public class ExpressionException extends RuntimeException implements ResolvedException
+public class ExpressionException extends StacklessRuntimeException implements ResolvedException
 {
     public final Context context;
     public final Tokenizer.Token token;

--- a/src/main/java/carpet/script/exception/InternalExpressionException.java
+++ b/src/main/java/carpet/script/exception/InternalExpressionException.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /* The internal expression evaluators exception class. */
-public class InternalExpressionException extends RuntimeException
+public class InternalExpressionException extends StacklessRuntimeException
 {
     public List<FunctionValue> stack = new ArrayList<>();
     public InternalExpressionException(String message)

--- a/src/main/java/carpet/script/exception/StacklessRuntimeException.java
+++ b/src/main/java/carpet/script/exception/StacklessRuntimeException.java
@@ -1,0 +1,19 @@
+package carpet.script.exception;
+
+/**
+ * A type of {@link RuntimeException} that doesn't spend time producing and filling a stacktrace
+ */
+abstract class StacklessRuntimeException extends RuntimeException {
+    public StacklessRuntimeException() {
+        super();
+    }
+
+    public StacklessRuntimeException(String message) {
+        super(message);
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+}


### PR DESCRIPTION
Resolves #1391.

Does that by introducing an abstract class that doesn't do anything when `fillInStacktrace()` is called, `StacklessRuntimeException`. See the issue for more details.