### PR TITLE
Simplify mod initializers and warn extensions from mixing into Carpet just to register themselves

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,10 +20,10 @@
   "environment": "*",
   "entrypoints": {
     "client": [
-      "carpet.CarpetServer::CLIENT_INITIALIZER"
+      "carpet.CarpetServer::onGameStarted"
     ],
     "server": [
-      "carpet.CarpetServer::SERVER_INITIALIZER"
+      "carpet.CarpetServer::onGameStarted"
     ]
   },
   "mixins": [


### PR DESCRIPTION
Does that.

- Since some version fabric loader allows static method references in the json, so let's just use that.

- Adds a warning to extensions that mixin to `CarpetServer#onGameStarted` just to register themselves because it's a very stupid practice when we're maintaining paths to allow them to use a simple `ModInitializer`. It still being allowed only makes more extensions copy the same behaviour ([literally](https://github.com/search?q=CarpetServer+onGameStarted+org.spongepowered.asm.mixin.Mixin&type=code), over 10 extensions are doing this).
  - This doesn't try to prevent them from mixing into other places of carpet if they need to (although if they do it's at their own risk)

Also makes the deprecated fallback when extensions register too late throw an exception, given they've been warned for a while, the fix is very simple and we're on snapshots now anyway.

No changes for end users.