### PR TITLE
Show local type in exception hover tooltips

### DIFF
--- a/src/main/java/carpet/script/CarpetScriptHost.java
+++ b/src/main/java/carpet/script/CarpetScriptHost.java
@@ -1059,13 +1059,15 @@ public class CarpetScriptHost extends ScriptHost
                 continue;
             stringsToFormat.add(format + line.substring(lastPos, foundLocal.getKey()));
             stringsToFormat.add(format + foundLocal.getValue());
+            Value val = context.variables.get(foundLocal.getValue()).evalValue(context);
+            String type = val.getTypeString();
             String value;
             try {
-                value = context.variables.get(foundLocal.getValue()).evalValue(context).getPrettyString();
+                value = val.getPrettyString();
             } catch (StackOverflowError e) {
                 value = "Exception while rendering variable, there seems to be a recursive reference in there";
             }
-            stringsToFormat.add("^ Value of '" + foundLocal.getValue() + "' at position: \n"
+            stringsToFormat.add("^ Value of '" + foundLocal.getValue() + "' at position (" + type + "): \n"
                         + value);
             lastPos = foundLocal.getKey() + foundLocal.getValue().length();
         }


### PR DESCRIPTION
Adds the type of the value to the hover over tooltips from the error snooper.

![imagen](https://user-images.githubusercontent.com/17107132/161609916-786c9b2f-bf7a-477a-a808-029ea898b08c.png)
