### PR TITLE
Highlight scarpet files with github's highlighter for python

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sc linguist-language=Python
+*.scl linguist-language=Python


### PR DESCRIPTION
Adds a `.gitattributes` file to do that.

Closes #1406.