### PR TITLE
Remove cotton maven given lQF is now on the Gradle plugin portal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'fabric-loom' version '0.11-SNAPSHOT'
-	id 'io.github.juuxel.loom-quiltflower' version '1.6.0'
+	id 'io.github.juuxel.loom-quiltflower' version '1.7.1'
 	id 'maven-publish'
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,10 +4,6 @@ pluginManagement {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
         }
-        maven { // for quiltflower
-            name = 'Cotton'
-            url = 'https://server.bbkr.space/artifactory/libs-release/'
-        }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
Also bumps loom QuiltFlower version, given only the latest version is there atm.

Doing this also bumps default QuiltFlower version to [1.8.0](https://github.com/QuiltMC/quiltflower/releases/tag/1.8.0).