### PR TITLE
Publish changelogs to Discord when releasing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -118,17 +118,40 @@ jobs:
     needs: [Build-And-Publish]
     steps:
      - name: Publish to discord
-       uses: appleboy/discord-action@0.0.3
-       with:
-         webhook_id: ${{ secrets.WEBHOOK_ID }}
-         webhook_token: ${{ secrets.WEBHOOK_TOKEN }}
-         message: |
-           **${{ github.event.release.name }}** has been released!
-           
-           ${{ github.event.release.body }}
-           
-           Get it on Github Releases: <${{ github.event.release.html_url }}>
-           Or on CurseForge
+       run: |
+         BOT_TOKEN="${{ secrets.DISCORD_BOT_TOKEN }}"
+         NEWS_CHANNEL_ID="967520511452143677"
+         
+         CONTENT=$(cat <<EOF
+         **${{ github.event.release.name }}** has been released!
+         
+         ${{ github.event.release.body }}
+
+         Get it on Github Releases: <${{ github.event.release.html_url }}>
+         Or on CurseForge
+         EOF
+         )
+         
+         MESSAGE_CONTENT_JSON=$(jq -n --arg content "$CONTENT" '{content: $content}')
+         
+         MESSAGES_ENDPOINT="https://discord.com/api/v9/channels/$NEWS_CHANNEL_ID/messages"
+         
+         CREATE_MESSAGE_RESPONSE=$(curl -s -L -X POST "$MESSAGES_ENDPOINT" \
+             --header "Authorization: Bot $BOT_TOKEN" \
+             --header 'Accept: application/json' \
+             --header 'Content-Type: application/json' \
+             --data-raw "$MESSAGE_CONTENT_JSON"
+         )
+         
+         RESPONSE_MESSAGE_ID=$(echo $CREATE_MESSAGE_RESPONSE | jq -r '.id')
+         
+         CROSSPOST_ENDPOINT="$MESSAGES_ENDPOINT/$RESPONSE_MESSAGE_ID/crosspost"
+         
+         CROSSPOST_RESPONSE=$(curl -s -L -X POST "$CROSSPOST_ENDPOINT" \
+             --header "Authorization: Bot $BOT_TOKEN" \
+             --header 'Content-Type: application/json' \
+             --data-raw "$CREATE_MESSAGE_RESPONSE"
+         )
   Merge-Scarpet-Docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -120,7 +120,7 @@ jobs:
      - name: Publish to discord
        run: |
          BOT_TOKEN="${{ secrets.DISCORD_BOT_TOKEN }}"
-         NEWS_CHANNEL_ID="967520511452143677"
+         NEWS_CHANNEL_ID="897934715200339999"
          
          CONTENT=$(cat <<EOF
          **${{ github.event.release.name }}** has been released!

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -113,6 +113,22 @@ jobs:
         with:
           name: Maven publishing artifacts for ${{ matrix.branch }}
           path: publish/carpet/fabric-carpet/
+  Publish-To-Discord:
+    runs-on: ubuntu-latest
+    needs: [Build-And-Publish]
+    steps:
+     - name: Publish to discord
+       uses: appleboy/discord-action@0.0.3
+       with:
+         webhook_id: ${{ secrets.WEBHOOK_ID }}
+         webhook_token: ${{ secrets.WEBHOOK_TOKEN }}
+         message: |
+           **${{ github.event.release.name }}** has been released!
+           
+           ${{ github.event.release.body }}
+           
+           Get it on Github Releases: <${{ github.event.release.html_url }}>
+           Or on CurseForge
   Merge-Scarpet-Docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -118,40 +118,17 @@ jobs:
     needs: [Build-And-Publish]
     steps:
      - name: Publish to discord
-       run: |
-         BOT_TOKEN="${{ secrets.DISCORD_BOT_TOKEN }}"
-         NEWS_CHANNEL_ID="897934715200339999"
-         
-         CONTENT=$(cat <<EOF
-         **${{ github.event.release.name }}** has been released!
-         
-         ${{ github.event.release.body }}
-
-         Get it on Github Releases: <${{ github.event.release.html_url }}>
-         Or on CurseForge
-         EOF
-         )
-         
-         MESSAGE_CONTENT_JSON=$(jq -n --arg content "$CONTENT" '{content: $content}')
-         
-         MESSAGES_ENDPOINT="https://discord.com/api/v9/channels/$NEWS_CHANNEL_ID/messages"
-         
-         CREATE_MESSAGE_RESPONSE=$(curl -s -L -X POST "$MESSAGES_ENDPOINT" \
-             --header "Authorization: Bot $BOT_TOKEN" \
-             --header 'Accept: application/json' \
-             --header 'Content-Type: application/json' \
-             --data-raw "$MESSAGE_CONTENT_JSON"
-         )
-         
-         RESPONSE_MESSAGE_ID=$(echo $CREATE_MESSAGE_RESPONSE | jq -r '.id')
-         
-         CROSSPOST_ENDPOINT="$MESSAGES_ENDPOINT/$RESPONSE_MESSAGE_ID/crosspost"
-         
-         CROSSPOST_RESPONSE=$(curl -s -L -X POST "$CROSSPOST_ENDPOINT" \
-             --header "Authorization: Bot $BOT_TOKEN" \
-             --header 'Content-Type: application/json' \
-             --data-raw "$CREATE_MESSAGE_RESPONSE"
-         )
+       uses: Crec0/announce-n-crosspost@v1
+       with:
+         bot-token: ${{ secrets.DISCORD_BOT_TOKEN }}
+         channel: '897934715200339999'
+         content: |
+           **${{ github.event.release.name }}** has been released!
+           
+           ${{ github.event.release.body }}
+           
+           Get it on Github Releases: <${{ github.event.release.html_url }}>
+           Or on CurseForge
   Merge-Scarpet-Docs:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds a new job to the release action that publishes a proper message to a discord webhook after everything has been built and published (and therefore jars are available at least in github releases). The curseforge URLs aren't added because there's an issue/not implemented feature on github actions where matrix builds only output the results of one branch, and we have up to two.

Image of the result (from the release input from https://github.com/altrisi/fabric-carpet/releases/tag/test3):
![imagen](https://user-images.githubusercontent.com/17107132/164896373-f7496fde-1e8e-4159-afc3-ec93d8d0df32.png)

Requires the setup of a secret, `DISCORD_BOT_TOKEN`, that I can DM you when you are able to add it to the repo, as I can't manage secrets.

Would also need disabling of releases being posted via github's webhook.