### PR TITLE
Prevent assigning variables to `UNDEF`

### DIFF
--- a/src/main/java/carpet/script/value/UndefValue.java
+++ b/src/main/java/carpet/script/value/UndefValue.java
@@ -137,4 +137,18 @@ public class UndefValue extends NullValue {
         throw getError();
     }
 
+    @Override
+    public Value reboundedTo(String var) {
+        if (getVariable() != null) {
+            // Here we're making a few assumptions:
+            // The bound variable of the constants in Value can be (unwillingly) set by some functions that set it on the instance directly
+            // (mostly loops, I'd assume for performance). Here we're assuming UNDEF will never get to that because:
+            // - Loops don't currently set variables to UNDEF, but to stuff like NULL or ZERO (therefore it won't get assigned by accident on init)
+            // - We are preventing someone from rebounding UNDEF into a loop variable with this (or trying to, at least), that should prevent you
+            //   from inserting UNDEF into those loop functions and therefore protect the boundVariable
+            throw getError();
+        }
+        return super.reboundedTo(var);
+    }
+
 }


### PR DESCRIPTION
Closes #1439.

Testing wanted! Especially if you have `strict` scripts with loops type `map`, `filter`, `reduce`, etc.

Even though I mentioned my rationale on why it should work, I'm still not 100% sure `UNDEF` can't get into one of those places. All I know is randomly I've seen stuff like `Value.TRUE` or `Value.NULL` with a `boundVariable`.

This has had some successful testing, but sending as a draft because it still looks fragile to me. I believe a single script managing to set a `boundVariable` to `Value.UNDEF` could cause all apps in `strict` mode to stop working.