### PR TITLE
fix #1454

### DIFF
--- a/src/main/java/carpet/mixins/RedstoneWireBlock_fastMixin.java
+++ b/src/main/java/carpet/mixins/RedstoneWireBlock_fastMixin.java
@@ -79,7 +79,10 @@ public abstract class RedstoneWireBlock_fastMixin implements RedstoneWireBlockIn
         if (blockState_1.getValue(POWER) != i) {
             blockState_1 = blockState_1.setValue(POWER, i);
             if (world_1.getBlockState(blockPos_1) == blockState) {
-                world_1.setBlock(blockPos_1, blockState_1, 2);
+                // [Space Walker] suppress shape updates and emit those manually to
+                // bypass the new neighbor update stack.
+                if (world_1.setBlock(blockPos_1, blockState_1, Block.UPDATE_KNOWN_SHAPE | Block.UPDATE_CLIENTS))
+                    wireTurbo.updateNeighborShapes(world_1, blockPos_1, blockState_1);
             }
 
             if (!CarpetSettings.fastRedstoneDust) {

--- a/src/main/resources/carpet.accesswidener
+++ b/src/main/resources/carpet.accesswidener
@@ -5,3 +5,5 @@ accessible class net/minecraft/server/level/ThreadedLevelLightEngine$TaskType
 accessible class net/minecraft/world/item/crafting/Ingredient$Value
 accessible class net/minecraft/world/level/lighting/BlockLightSectionStorage$BlockDataLayerStorageMap
 accessible class net/minecraft/server/MinecraftServer$ReloadableResources
+
+accessible field net/minecraft/world/level/block/state/BlockBehaviour UPDATE_SHAPE_ORDER [Lnet/minecraft/core/Direction;


### PR DESCRIPTION
This PR fixes some Vanilla parity issues with the `fastRedstoneDust` setting by bypassing the new neighbor update stack and doing shape and block updates manually. This almost perfectly restores old behavior (meaning behavior of this setting prior to 1.19) but it does bypass the `max-chained-neighbor-updates` server property.