### PR TITLE
Fix issue #1444 Pressure plates activate with creativeNoClip if anoth…

### DIFF
--- a/src/main/java/carpet/mixins/PressurePlateBlock_creativeNoClipMixin.java
+++ b/src/main/java/carpet/mixins/PressurePlateBlock_creativeNoClipMixin.java
@@ -1,0 +1,22 @@
+package carpet.mixins;
+
+import carpet.CarpetSettings;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.block.PressurePlateBlock;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(PressurePlateBlock.class)
+public class PressurePlateBlock_creativeNoClipMixin {
+    @Redirect(method="getSignalStrength", at=@At(value="INVOKE", target="Lnet/minecraft/world/entity/Entity;isIgnoringBlockTriggers()Z"))
+    private boolean ignoreNoClip(Entity instance) {
+        if (instance instanceof Player player) {
+            if (CarpetSettings.creativeNoClip && player.isCreative() && player.getAbilities().flying) {
+                return true;
+            }
+        }
+        return instance.isIgnoringBlockTriggers();
+    }
+}

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -180,6 +180,7 @@
     "StandingAndWallBlockItem_creativeNoClipMixin",
     "ShulkerBoxBlockEntity_creativeNoClipMixin",
     "TheEndGatewayBlockEntity_creativeNoClipMixin",
+    "PressurePlateBlock_creativeNoClipMixin",
     "LivingEntity_creativeFlyMixin",
     "ChunkMap_creativePlayersLoadChunksMixin",
     "SculkSensorBlock_rangeMixin",


### PR DESCRIPTION
Fix issue #1444 Pressure plates activate with creativeNoClip if another entity is in the same block

I added a mixin to intercept isIgnoringBlockTriggers() in getSignalStrength when the entity is the player in creativeNoClip mode and flying. We just report that we are ignoring triggers.

Verified that issue happens without this mixin, and goes away with it (the pressure plate no longer fires when the user flies through the plate).