### PR TITLE
Add `movableBarriers` rule

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -1076,4 +1076,10 @@ public class CarpetSettings
     )
     public static int sculkSensorRange = 8;
 
+    @Rule(
+            desc = "Makes barrier blocks movable by pistons.",
+            category = { CREATIVE, FEATURE }
+    )
+    public static boolean movableBarriers;
+
 }

--- a/src/main/java/carpet/mixins/BarrierBlock_movableBarriersMixin.java
+++ b/src/main/java/carpet/mixins/BarrierBlock_movableBarriersMixin.java
@@ -1,0 +1,23 @@
+package carpet.mixins;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import carpet.CarpetSettings;
+
+import net.minecraft.world.level.block.BarrierBlock;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.PushReaction;
+
+@Mixin(BarrierBlock.class)
+public class BarrierBlock_movableBarriersMixin extends Block {
+
+    private BarrierBlock_movableBarriersMixin(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public PushReaction getPistonPushReaction(BlockState state) {
+        return CarpetSettings.movableBarriers ? PushReaction.NORMAL : super.getPistonPushReaction(state);
+    }
+}

--- a/src/main/java/carpet/mixins/PistonBaseBlock_movableBarriersMixin.java
+++ b/src/main/java/carpet/mixins/PistonBaseBlock_movableBarriersMixin.java
@@ -1,0 +1,33 @@
+package carpet.mixins;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import carpet.CarpetSettings;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.piston.PistonBaseBlock;
+import net.minecraft.world.level.block.state.BlockState;
+
+@Mixin(PistonBaseBlock.class)
+public class PistonBaseBlock_movableBarriersMixin {
+
+    @Inject(
+            method = "isPushable",
+            cancellable = true,
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/block/state/BlockState;getDestroySpeed(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)F"
+            )
+    )
+    private static void makeBarriersMovable(BlockState state, Level level, BlockPos pos, Direction dir, boolean allowDestroy, Direction pistonFacing, CallbackInfoReturnable<Boolean> cir) {
+        if (CarpetSettings.movableBarriers && state.is(Blocks.BARRIER)) {
+            cir.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -169,6 +169,8 @@
     "QuantizedSpaghettiRarityMixin_scarpetMixin",
 
     "BlockEntity_movableBEMixin",
+    "BarrierBlock_movableBarriersMixin",
+    "PistonBaseBlock_movableBarriersMixin",
     "PistonBaseBlock_movableBEMixin",
     "PistonMovingBlockEntity_movableBEMixin",
     "Level_movableBEMixin",


### PR DESCRIPTION
Adds a new carpet rule that allows pistons to move barrier blocks. Can be useful when designing redstone contraptions if you need a movable conductor but would like to be able to see through it so you can tell what's happening behind it.