### PR TITLE
new: fakePlayersLoadChunks carpet rule

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -1068,6 +1068,15 @@ public class CarpetSettings
     public static boolean creativePlayersLoadChunks = true;
 
     @Rule(
+            desc = "Fake players load chunks, or they don't! Just like spectators!",
+            extra = {"Like creativePlayersLoadChunks",
+                    "this rule toggling behaves exactly as if the player is in spectator mode and toggling the gamerule spectatorsGenerateChunks."
+            },
+            category = {CREATIVE, FEATURE}
+    )
+    public static boolean fakePlayersLoadChunks = true;
+
+    @Rule(
             desc = "Customizable sculk sensor range",
             options = {"8", "16", "32"},
             category = CREATIVE,

--- a/src/main/java/carpet/mixins/ChunkMap_creativePlayersLoadChunksMixin.java
+++ b/src/main/java/carpet/mixins/ChunkMap_creativePlayersLoadChunksMixin.java
@@ -1,6 +1,7 @@
 package carpet.mixins;
 
 import carpet.CarpetSettings;
+import carpet.patches.EntityPlayerMPFake;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerPlayer;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,7 +15,8 @@ public class ChunkMap_creativePlayersLoadChunksMixin {
     @Inject(method = "skipPlayer(Lnet/minecraft/server/level/ServerPlayer;)Z", at = @At("HEAD"), cancellable = true)
     private void startProfilerSection(ServerPlayer serverPlayer, CallbackInfoReturnable<Boolean> cir)
     {
-        if (!CarpetSettings.creativePlayersLoadChunks && serverPlayer.isCreative()) {
+        if ((!CarpetSettings.creativePlayersLoadChunks && serverPlayer.isCreative())
+            || (!CarpetSettings.fakePlayersLoadChunks && serverPlayer instanceof EntityPlayerMPFake)) {
             cir.setReturnValue(true);
         }
     }


### PR DESCRIPTION
enabled by default: behavior of fake players like vanilla players
disabled: fake players do not load chunks like spectators with gamerule spectatorsGenerateChunks false

This rule allows the server to save performance while they are using fake players.
Server owners can use /forceload to load only a few selected chunks.
It would be useful for farms. (Neither creative nor spectator mode cannot be used for this purpose)