### PR TITLE
Change the default gamemode for fake players

### DIFF
--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -278,7 +278,7 @@ public class PlayerCommand
                 () -> DimensionArgument.getDimension(context, "dimension").dimension(),
                 () -> source.getLevel().dimension() // dimension.getType()
         );
-        GameType mode = GameType.CREATIVE;
+        GameType mode = GameType.SURVIVAL; // some 3rd-part chat bot may use the server source to execute the spawn command directly, so set default gamemode to survival is safer!
         boolean flying = false;
         try
         {


### PR DESCRIPTION
Many minecraft server administrators choose to give their server's players a 3rd-part way（like a website, or a bot for social media apps）to spawn the fake player, and these 3rd-part way always execute the spawn command from the server source, and that makes the spawned fake player is creative mode, that's not safe for a server! So I try to make the deafult gamemode to survival.