### PR TITLE
Set ambient properly in modify(entity, 'effect')

### DIFF
--- a/src/main/java/carpet/script/value/EntityValue.java
+++ b/src/main/java/carpet/script/value/EntityValue.java
@@ -1516,7 +1516,7 @@ public class EntityValue extends Value
                         showIcon = lv.get(4).getBoolean();
                     boolean ambient = false;
                     if (lv.size() > 5)
-                        showIcon = lv.get(5).getBoolean();
+                        ambient = lv.get(5).getBoolean();
                     le.addEffect(new MobEffectInstance(effect, duration, amplifier, ambient, showParticles, showIcon));
                     return;
                 }


### PR DESCRIPTION
Fixes #1485 
Basically the `showIcon` variable got set twice, instead of the `ambient` variable being set.