### PR TITLE
Fix handling files with uppercase letters in case-sensitive systems

### DIFF
--- a/src/main/java/carpet/script/argument/FileArgument.java
+++ b/src/main/java/carpet/script/argument/FileArgument.java
@@ -140,7 +140,7 @@ public class FileArgument
 
     public static Pair<String,String> recognizeResource(String origfile, boolean isFolder, Type type)
     {
-        String[] pathElements = origfile.toLowerCase(Locale.ROOT).split("[/\\\\]+");
+        String[] pathElements = origfile.split("[/\\\\]+");
         List<String> path = new ArrayList<>();
         String zipPath = null;
         for (int i =0; i < pathElements.length; i++ )


### PR DESCRIPTION
Should fix #1502.

Windows file system is case-insensitive, so doing a `toLowerCase` on the file names doesn't matter. However, others, such as Linux, do not ignore upper/lower case, so this was preventing scarpet from reading or modifying files that weren't fully lower-case. Luckily I believe files created by scarpet should have gotten lower case given they're handled by this path so they didn't break, but if you put the files by yourself (or through some other code path, if there is) they do.