### PR TITLE
Allow modded structures in overlay's `structure` renderer

### DIFF
--- a/src/main/resources/assets/carpet/scripts/overlay.sc
+++ b/src/main/resources/assets/carpet/scripts/overlay.sc
@@ -44,7 +44,7 @@ __config() ->
         'clear' -> 'clear',
     },
     'arguments' -> {
-        'structure' -> {'type' -> 'term', 'suggest' -> plop():'structures' },
+        'structure' -> {'type' -> 'identifier', 'suggest' -> plop():'structures' },
         'radius' -> {'type' -> 'int', 'min' -> 0, 'max' -> 1024, 'suggest' -> [128, 24, 32]},
         'shape' -> {'type' -> 'term', 'options' -> keys(global_shapes) },
         'color' -> {'type' -> 'teamcolor'}


### PR DESCRIPTION
Should fix #1447, closes #1283.

Does that by changing the argument type to an identifier, so it allows `:` to be used.