### PR TITLE
Resolve raw type warnings

### DIFF
--- a/src/main/java/carpet/helpers/HopperCounter.java
+++ b/src/main/java/carpet/helpers/HopperCounter.java
@@ -406,6 +406,6 @@ public class HopperCounter
      */
     public long getTotalItems()
     {
-        return counter.isEmpty()?0:counter.values().stream().mapToLong(Long::longValue).sum();
+        return counter.isEmpty()?0:counter.values().longStream().sum();
     }
 }

--- a/src/main/java/carpet/mixins/BoundTickingBlockEntity_tickMixin.java
+++ b/src/main/java/carpet/mixins/BoundTickingBlockEntity_tickMixin.java
@@ -32,7 +32,7 @@ public class BoundTickingBlockEntity_tickMixin<T extends BlockEntity>
             value = "INVOKE",
             target = "Lnet/minecraft/world/level/block/entity/BlockEntityTicker;tick(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/entity/BlockEntity;)V"
     ))
-    private void checkProcessTEs(BlockEntityTicker blockEntityTicker, Level world, BlockPos pos, BlockState state, T blockEntity)
+    private void checkProcessBEs(BlockEntityTicker<T> blockEntityTicker, Level world, BlockPos pos, BlockState state, T blockEntity)
     {
         if (TickSpeed.process_entities) blockEntityTicker.tick(world, pos, state, blockEntity);
     }

--- a/src/main/java/carpet/mixins/PistonBaseBlock_movableBEMixin.java
+++ b/src/main/java/carpet/mixins/PistonBaseBlock_movableBEMixin.java
@@ -82,8 +82,8 @@ public abstract class PistonBaseBlock_movableBEMixin extends DirectionalBlock
     @Inject(method = "moveBlocks", at = @At(value = "INVOKE", shift = At.Shift.BEFORE,
             target = "Ljava/util/List;size()I", ordinal = 4),locals = LocalCapture.CAPTURE_FAILHARD)
     private void onMove(Level world_1, BlockPos blockPos_1, Direction direction_1, boolean boolean_1,
-                        CallbackInfoReturnable<Boolean> cir, BlockPos blockPos_2, PistonStructureResolver pistonHandler_1, Map map_1,
-                        List<BlockPos> list_1, List<BlockState> list_2, List list_3, BlockState[] blockStates_1,
+                        CallbackInfoReturnable<Boolean> cir, BlockPos blockPos_2, PistonStructureResolver pistonHandler_1, Map<?, ?> map_1,
+                        List<BlockPos> list_1, List<BlockState> list_2, List<?> list_3, BlockState[] blockStates_1,
                         Direction direction_2, int int_2)
     {
         //Get the blockEntities and remove them from the world before any magic starts to happen
@@ -110,11 +110,11 @@ public abstract class PistonBaseBlock_movableBEMixin extends DirectionalBlock
             target = "Lnet/minecraft/world/level/Level;setBlockEntity(Lnet/minecraft/world/level/block/entity/BlockEntity;)V", ordinal = 0),
             locals = LocalCapture.CAPTURE_FAILHARD)
     private void setBlockEntityWithCarried(Level world_1, BlockPos blockPos_1, Direction direction_1, boolean boolean_1,
-                                           CallbackInfoReturnable<Boolean> cir, BlockPos blockPos_2, PistonStructureResolver pistonHandler_1, Map map_1, List list_1,
-                                           List list_2, List list_3, BlockState[] blockStates_1, Direction direction_2, int int_2,
+                                           CallbackInfoReturnable<Boolean> cir, BlockPos blockPos_2, PistonStructureResolver pistonHandler_1, Map<?, ?> map_1, List<?> list_1,
+                                           List<BlockState> list_2, List<?> list_3, BlockState[] blockStates_1, Direction direction_2, int int_2,
                                            int int_3, BlockPos blockPos_4, BlockState blockState9, BlockState blockState4)
     {
-        BlockEntity blockEntityPiston = MovingPistonBlock.newMovingBlockEntity(blockPos_4, blockState4, (BlockState) list_2.get(int_3),
+        BlockEntity blockEntityPiston = MovingPistonBlock.newMovingBlockEntity(blockPos_4, blockState4, list_2.get(int_3),
                 direction_1, boolean_1, false);
         if (CarpetSettings.movableBlockEntities)
             ((PistonBlockEntityInterface) blockEntityPiston).setCarriedBlockEntity(list1_BlockEntities.get().get(int_3));

--- a/src/main/java/carpet/script/value/NBTSerializableValue.java
+++ b/src/main/java/carpet/script/value/NBTSerializableValue.java
@@ -373,7 +373,7 @@ public class NBTSerializableValue extends Value implements ContainerValueInterfa
         if (t instanceof CollectionTag)
         {
             List<Value> elems = new ArrayList<>();
-            CollectionTag<? extends Tag> ltag = (CollectionTag<? extends Tag>)t;
+            CollectionTag<?> ltag = (CollectionTag<?>)t;
             for (Tag elem: ltag)
             {
                 elems.add(decodeTagDeep(elem));

--- a/src/main/java/carpet/script/value/ValueConversions.java
+++ b/src/main/java/carpet/script/value/ValueConversions.java
@@ -274,7 +274,7 @@ public class ValueConversions
         }
         if (v instanceof Set)
         {
-            v = new ArrayList(((Set) v));
+            v = new ArrayList<>(((Set<?>) v));
         }
         if (v instanceof List<?> l)
         {

--- a/src/main/java/carpet/utils/PerimeterDiagnostics.java
+++ b/src/main/java/carpet/utils/PerimeterDiagnostics.java
@@ -85,7 +85,7 @@ public class PerimeterDiagnostics
             }
         }
         PerimeterDiagnostics diagnostic = new PerimeterDiagnostics(worldserver,ctype,el);
-        EntityType type = EntityType.ZOMBIE;
+        EntityType<?> type = EntityType.ZOMBIE;
         if (el != null) type = el.getType();
         int minY = worldserver.getMinBuildHeight();
         int maxY = worldserver.getMaxBuildHeight();
@@ -180,7 +180,7 @@ public class PerimeterDiagnostics
 
         if (NaturalSpawner.isSpawnPositionOk(spt, worldServer, pos, sle.type))
         {
-            el.moveTo((float)pos.getX() + 0.5F, (float)pos.getY(), (float)pos.getZ()+0.5F, 0.0F, 0.0F);
+            el.moveTo(pos.getX() + 0.5F, pos.getY(), pos.getZ()+0.5F, 0.0F, 0.0F);
             return el.checkSpawnObstruction(worldServer) && el.checkSpawnRules(worldServer, MobSpawnType.NATURAL) &&
                     SpawnPlacements.checkSpawnRules(el.getType(),(ServerLevel)el.getCommandSenderWorld(), MobSpawnType.NATURAL, el.blockPosition(), el.getCommandSenderWorld().random) &&
                     worldServer.noCollision(el); // check collision rules once they stop fiddling with them after 1.14.1

--- a/src/main/java/carpet/utils/SpawnReporter.java
+++ b/src/main/java/carpet/utils/SpawnReporter.java
@@ -362,7 +362,7 @@ public class SpawnReporter
                     "w ' to enable"));
             return report;
         }
-        long duration = worldIn.getServer().getTickCount() - track_spawns;
+        long duration = (long) worldIn.getServer().getTickCount() - track_spawns;
         report.add(Messenger.c("bw --------------------"));
         String simulated = mock_spawns?"[SIMULATED] ":"";
         String location = (lower_spawning_limit != null)?String.format("[in (%d, %d, %d)x(%d, %d, %d)]",
@@ -432,7 +432,7 @@ public class SpawnReporter
 
     public static boolean isInNetherFortressBounds(BlockPos blockPos, ServerLevel serverLevel, MobCategory mobCategory, StructureManager structureManager) {
         if (mobCategory == MobCategory.MONSTER && serverLevel.getBlockState(blockPos.below()).is(Blocks.NETHER_BRICKS)) {
-            Structure structure = structureManager.registryAccess().registryOrThrow(Registry.STRUCTURE_REGISTRY).get(BuiltinStructures.FORTRESS);
+            Structure structure = (Structure)structureManager.registryAccess().registryOrThrow(Registry.STRUCTURE_REGISTRY).get(BuiltinStructures.FORTRESS);
             return structure == null ? false : structureManager.getStructureAt(blockPos, structure).isValid();
         } else {
             return false;
@@ -483,9 +483,9 @@ public class SpawnReporter
                         will_spawn = 0;
                         for (int attempt = 0; attempt < 50; ++attempt)
                         {
-                            float f = x + 0.5F;
-                            float f1 = z + 0.5F;
-                            mob.moveTo(f, y, f1, worldIn.random.nextFloat() * 360.0F, 0.0F);
+                            float f = (float)x + 0.5F;
+                            float f1 = (float)z + 0.5F;
+                            mob.moveTo((double)f, (double)y, (double)f1, worldIn.random.nextFloat() * 360.0F, 0.0F);
                             fits1 = worldIn.noCollision(mob);
                             EntityType<?> etype = mob.getType();
 

--- a/src/main/java/carpet/utils/SpawnReporter.java
+++ b/src/main/java/carpet/utils/SpawnReporter.java
@@ -52,7 +52,7 @@ public class SpawnReporter
     public static Long track_spawns = 0L;
     public static final HashMap<ResourceKey<Level>, Integer> chunkCounts = new HashMap<>();
 
-    public static final HashMap<Pair<ResourceKey<Level>, MobCategory>, Object2LongMap<EntityType>> spawn_stats = new HashMap<>();
+    public static final HashMap<Pair<ResourceKey<Level>, MobCategory>, Object2LongMap<EntityType<?>>> spawn_stats = new HashMap<>();
     public static double mobcap_exponent = 0.0D;
     
     public static final HashMap<Pair<ResourceKey<Level>, MobCategory>, Long> spawn_attempts = new HashMap<>();
@@ -62,7 +62,7 @@ public class SpawnReporter
     public static final HashMap<Pair<ResourceKey<Level>, MobCategory>, Long> spawn_ticks_succ = new HashMap<>();
     public static final HashMap<Pair<ResourceKey<Level>, MobCategory>, Long> spawn_ticks_spawns = new HashMap<>();
     public static final HashMap<Pair<ResourceKey<Level>, MobCategory>, Long> spawn_cap_count = new HashMap<>();
-    public static final HashMap<Pair<ResourceKey<Level>, MobCategory>, EvictingQueue<Pair<EntityType, BlockPos>>> spawned_mobs = new HashMap<>();
+    public static final HashMap<Pair<ResourceKey<Level>, MobCategory>, EvictingQueue<Pair<EntityType<?>, BlockPos>>> spawned_mobs = new HashMap<>();
     public static final HashMap<MobCategory, Integer> spawn_tries = new HashMap<>();
     public static BlockPos lower_spawning_limit = null;
     public static BlockPos upper_spawning_limit = null;
@@ -170,7 +170,7 @@ public class SpawnReporter
         String type_code = creature_type.getName();
         
         lst.add(Messenger.s(String.format("Recent %s spawns:",type_code)));
-        for (Pair<EntityType, BlockPos> pair : spawned_mobs.get(Pair.of(world.dimension(), creature_type)).keySet()) // getDImTYpe
+        for (Pair<EntityType<?>, BlockPos> pair : spawned_mobs.get(Pair.of(world.dimension(), creature_type)).keySet()) // getDImTYpe
         {
             lst.add( Messenger.c(
                     "w  - ",
@@ -291,7 +291,7 @@ public class SpawnReporter
             if (!all && persistent)
                 continue;
 
-            EntityType type = entity.getType();
+            EntityType<?> type = entity.getType();
             BlockPos pos = entity.blockPosition();
             lst.add( Messenger.c(
                     "w  - ",
@@ -362,7 +362,7 @@ public class SpawnReporter
                     "w ' to enable"));
             return report;
         }
-        long duration = (long) worldIn.getServer().getTickCount() - track_spawns;
+        long duration = worldIn.getServer().getTickCount() - track_spawns;
         report.add(Messenger.c("bw --------------------"));
         String simulated = mock_spawns?"[SIMULATED] ":"";
         String location = (lower_spawning_limit != null)?String.format("[in (%d, %d, %d)x(%d, %d, %d)]",
@@ -387,7 +387,7 @@ public class SpawnReporter
                         (100.0D*spawn_ticks_succ.get(code))/ spawn_attempts.get(code),
                         (1.0D*spawn_ticks_spawns.get(code))/(spawn_ticks_fail.get(code)+spawn_ticks_succ.get(code))
                     )));
-                    for (EntityType type: spawn_stats.get(code).keySet())
+                    for (EntityType<?> type: spawn_stats.get(code).keySet())
                     {
                         report.add(Messenger.s(String.format("   - %s: %d spawns, %d per hour",
                                 type.getDescription().getString(),
@@ -432,7 +432,7 @@ public class SpawnReporter
 
     public static boolean isInNetherFortressBounds(BlockPos blockPos, ServerLevel serverLevel, MobCategory mobCategory, StructureManager structureManager) {
         if (mobCategory == MobCategory.MONSTER && serverLevel.getBlockState(blockPos.below()).is(Blocks.NETHER_BRICKS)) {
-            Structure structure = (Structure)structureManager.registryAccess().registryOrThrow(Registry.STRUCTURE_REGISTRY).get(BuiltinStructures.FORTRESS);
+            Structure structure = structureManager.registryAccess().registryOrThrow(Registry.STRUCTURE_REGISTRY).get(BuiltinStructures.FORTRESS);
             return structure == null ? false : structureManager.getStructureAt(blockPos, structure).isValid();
         } else {
             return false;
@@ -483,9 +483,9 @@ public class SpawnReporter
                         will_spawn = 0;
                         for (int attempt = 0; attempt < 50; ++attempt)
                         {
-                            float f = (float)x + 0.5F;
-                            float f1 = (float)z + 0.5F;
-                            mob.moveTo((double)f, (double)y, (double)f1, worldIn.random.nextFloat() * 360.0F, 0.0F);
+                            float f = x + 0.5F;
+                            float f1 = z + 0.5F;
+                            mob.moveTo(f, y, f1, worldIn.random.nextFloat() * 360.0F, 0.0F);
                             fits1 = worldIn.noCollision(mob);
                             EntityType<?> etype = mob.getType();
 


### PR DESCRIPTION
This PR resolves all raw type warnings in the codebase.

It also does a very small optimization to hopper counters and removes some redundant casts in `PerimeterDiagnostics`.