### PR TITLE
Migrate Carpet's rules to the new settings system

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -1,11 +1,11 @@
 package carpet;
 
 import carpet.api.settings.CarpetRule;
+import carpet.api.settings.Rule;
 import carpet.api.settings.RuleCategory;
 import carpet.api.settings.Validators;
 import carpet.api.settings.Validator;
 import carpet.script.utils.AppStoreManager;
-import carpet.settings.Rule;
 import carpet.utils.Translations;
 import carpet.utils.CommandHelper;
 import carpet.utils.Messenger;
@@ -44,7 +44,7 @@ import static carpet.api.settings.RuleCategory.DISPENSER;
 import static carpet.api.settings.RuleCategory.SCARPET;
 import static carpet.api.settings.RuleCategory.CLIENT;
 
-@SuppressWarnings({"CanBeFinal", "removal"}) // removal should be removed after migrating rules to the new system
+@SuppressWarnings("CanBeFinal")
 public class CarpetSettings
 {
     public static final String carpetVersion = "1.4.83+v220727";
@@ -70,11 +70,10 @@ public class CarpetSettings
         }
     }
     @Rule(
-            desc = "Sets the language for Carpet",
-            category = FEATURE,
+            categories = FEATURE,
             options = {"en_us", "zh_cn", "zh_tw"},
             strict = true, // the current system doesn't handle fallbacks and other, not defined languages would make unreadable mess. Change later
-            validate = LanguageValidator.class
+            validators = LanguageValidator.class
     )
     public static String language = "en_us";
 
@@ -85,7 +84,7 @@ public class CarpetSettings
     @Rule(
             desc = "Turns on internal camera path tracing app",
             extra = "Controlled via 'camera' command",
-            category = {COMMAND, SCARPET},
+            categories = {COMMAND, SCARPET},
             appSource = "camera"
     )
     public static boolean commandCamera = true;
@@ -93,7 +92,7 @@ public class CarpetSettings
     @Rule(
             desc = "Allows to add extra graphical debug information",
             extra = "Controlled via 'overlay' command",
-            category = {COMMAND, SCARPET},
+            categories = {COMMAND, SCARPET},
             appSource = "overlay"
     )
     public static boolean commandOverlay = true;
@@ -101,7 +100,7 @@ public class CarpetSettings
     @Rule(
             desc = "Turns on extra information about mobs above and around them",
             extra = "Controlled via 'ai_tracker' command",
-            category = {COMMAND, SCARPET},
+            categories = {COMMAND, SCARPET},
             appSource = "ai_tracker"
     )
     public static boolean commandAITracker = true;
@@ -113,7 +112,7 @@ public class CarpetSettings
             "other shapes which are sorta difficult to do normally"
         },
         appSource = "draw",
-        category = {FEATURE, SCARPET, COMMAND}
+        categories = {FEATURE, SCARPET, COMMAND}
     )
     public static String commandDraw = "true";
 
@@ -121,7 +120,7 @@ public class CarpetSettings
         desc = "Enables /distance command to measure in game distance between points",
         extra = "Also enables brown carpet placement action if 'carpets' rule is turned on as well",
         appSource = "distance",
-        category = {FEATURE, SCARPET, COMMAND}
+        categories = {FEATURE, SCARPET, COMMAND}
     )
     public static String commandDistance = "true";
     */
@@ -140,33 +139,30 @@ public class CarpetSettings
         }
     }
     @Rule(
-            desc = "Carpet command permission level. Can only be set via .conf file",
-            category = CREATIVE,
-            validate = CarpetPermissionLevel.class,
+            categories = CREATIVE,
+            validators = CarpetPermissionLevel.class,
             options = {"ops", "2", "4"}
     )
     public static String carpetCommandPermissionLevel = "ops";
 
 
 
-    @Rule(desc = "Gbhs sgnf sadsgras fhskdpri!!!", category = EXPERIMENTAL)
+    @Rule(categories = EXPERIMENTAL)
     public static boolean superSecretSetting = false;
 
     @Rule(
-            desc = "Amount of delay ticks to use a nether portal in creative",
             options = {"1", "40", "80", "72000"},
-            category = CREATIVE,
+            categories = CREATIVE,
             strict = false,
-            validate = OneHourMaxDelayLimit.class
+            validators = OneHourMaxDelayLimit.class
     )
     public static int portalCreativeDelay = 1;
 
     @Rule(
-            desc = "Amount of delay ticks to use a nether portal in survival",
             options = {"1", "40", "80", "72000"},
-            category = SURVIVAL,
+            categories = SURVIVAL,
             strict = false,
-            validate = OneHourMaxDelayLimit.class
+            validators = OneHourMaxDelayLimit.class
     )
     public static int portalSurvivalDelay = 80;
 
@@ -179,29 +175,29 @@ public class CarpetSettings
         public String description() { return "You must choose a value from 1 to 72000";}
     }
 
-    @Rule(desc = "Dropping entire stacks works also from on the crafting UI result slot", category = {RuleCategory.BUGFIX, SURVIVAL})
+    @Rule(categories = {RuleCategory.BUGFIX, SURVIVAL})
     public static boolean ctrlQCraftingFix = false;
 
-    @Rule(desc = "Parrots don't get of your shoulders until you receive proper damage", category = {SURVIVAL, FEATURE})
+    @Rule(categories = {SURVIVAL, FEATURE})
     public static boolean persistentParrots = false;
 
     /*@Rule(
             desc = "Mobs growing up won't glitch into walls or go through fences",
-            category = BUGFIX,
-            validate = Validator.WIP.class
+            categories = BUGFIX,
+            validators = Validator.WIP.class
     )
     public static boolean growingUpWallJump = false;
 
     @Rule(
             desc = "Won't let mobs glitch into blocks when reloaded.",
             extra = "Can cause slight differences in mobs behaviour",
-            category = {BUGFIX, EXPERIMENTAL},
-            validate = Validator.WIP.class
+            categories = {BUGFIX, EXPERIMENTAL},
+            validators = Validator.WIP.class
     )
     public static boolean reloadSuffocationFix = false;
     */
 
-    @Rule( desc = "Players absorb XP instantly, without delay", category = CREATIVE )
+    @Rule(categories = CREATIVE )
     public static boolean xpNoCooldown = false;
 
     public static class StackableShulkerBoxValidator extends Validator<String> 
@@ -235,26 +231,24 @@ public class CarpetSettings
     }
 
     @Rule(
-            desc = "Empty shulker boxes can stack when thrown on the ground.",
-            extra = ".. or when manipulated inside the inventories",
-            validate = StackableShulkerBoxValidator.class,
+            validators = StackableShulkerBoxValidator.class,
             options = {"false", "true", "16"},
             strict = false,
-            category = {SURVIVAL, FEATURE}
+            categories = {SURVIVAL, FEATURE}
     )
     public static String stackableShulkerBoxes = "false";
     public static int shulkerBoxStackSize = 1;
 
-    @Rule( desc = "Explosions won't destroy blocks", category = {CREATIVE, TNT} )
+    @Rule(categories = {CREATIVE, TNT} )
     public static boolean explosionNoBlockDamage = false;
 
-    @Rule( desc = "Experience will drop from all experience barring blocks with any explosion type", category = {SURVIVAL, FEATURE})
+    @Rule(categories = {SURVIVAL, FEATURE})
     public static boolean xpFromExplosions = false;
 
-    @Rule( desc = "Removes random TNT momentum when primed", category = {CREATIVE, TNT} )
+    @Rule(categories = {CREATIVE, TNT} )
     public static boolean tntPrimerMomentumRemoved = false;
 
-    @Rule( desc = "TNT causes less lag when exploding in the same spot and in liquids", category = TNT)
+    @Rule(categories = TNT)
     public static boolean optimizedTNT = false;
 
     private static class CheckOptimizedTntEnabledValidator<T> extends Validator<T>
@@ -270,8 +264,8 @@ public class CarpetSettings
         }
     }
 
-    @Rule( desc = "Sets the tnt random explosion range to a fixed value", category = TNT, options = "-1", strict = false,
-            validate = {CheckOptimizedTntEnabledValidator.class, TNTRandomRangeValidator.class}, extra = "Set to -1 for default behavior")
+    @Rule(categories = TNT, options = "-1", strict = false,
+            validators = {CheckOptimizedTntEnabledValidator.class, TNTRandomRangeValidator.class})
     public static double tntRandomRange = -1;
 
     private static class TNTRandomRangeValidator extends Validator<Double> {
@@ -286,8 +280,8 @@ public class CarpetSettings
         }
     }
 
-    @Rule( desc = "Sets the horizontal random angle on TNT for debugging of TNT contraptions", category = TNT, options = "-1", strict = false,
-            validate = TNTAngleValidator.class, extra = "Set to -1 for default behavior")
+    @Rule(categories = TNT, options = "-1", strict = false,
+            validators = TNTAngleValidator.class)
     public static double hardcodeTNTangle = -1.0D;
 
     private static class TNTAngleValidator extends Validator<Double> {
@@ -302,88 +296,44 @@ public class CarpetSettings
         }
     }
 
-    @Rule( desc = "Merges stationary primed TNT entities", category = TNT )
+    @Rule(categories = TNT )
     public static boolean mergeTNT = false;
 
-    @Rule(
-            desc = "Lag optimizations for redstone dust",
-            extra = {
-                    "by Theosib",
-                    ".. also fixes some locational behaviours or vanilla redstone MC-11193",
-                    "so behaviour of locational vanilla contraptions is not guaranteed"
-            },
-            category = {EXPERIMENTAL, OPTIMIZATION}
-    )
+    @Rule(categories = {EXPERIMENTAL, OPTIMIZATION})
     public static boolean fastRedstoneDust = false;
 
-    @Rule(desc = "Only husks spawn in desert temples", category = FEATURE)
+    @Rule(categories = FEATURE)
     public static boolean huskSpawningInTemples = false;
 
-    @Rule( desc = "Shulkers will respawn in end cities", category = FEATURE )
+    @Rule(categories = FEATURE)
     public static boolean shulkerSpawningInEndCities = false;
 
-    @Rule(
-            desc = "Piglins will respawn in bastion remnants",
-            extra = "Includes piglins, brutes, and a few hoglins",
-            category = FEATURE
-    )
+    @Rule(categories = FEATURE)
     public static boolean piglinsSpawningInBastions = false;
 
-    @Rule( desc = "TNT doesn't update when placed against a power source", category = {CREATIVE, TNT} )
+    @Rule(categories = {CREATIVE, TNT} )
     public static boolean tntDoNotUpdate = false;
 
-    @Rule(
-            desc = "Prevents players from rubberbanding when moving too fast",
-            extra = {"... or being kicked out for 'flying'",
-                    "Puts more trust in clients positioning",
-                    "Increases player allowed mining distance to 32 blocks"
-            },
-            category = {CREATIVE, SURVIVAL}
-    )
+    @Rule(categories = {CREATIVE, SURVIVAL})
     public static boolean antiCheatDisabled = false;
 
-    @Rule(desc = "Pistons, droppers and dispensers react if block above them is powered", category = CREATIVE)
+    @Rule(categories = CREATIVE)
     public static boolean quasiConnectivity = true;
 
-    @Rule(
-            desc = "Players can flip and rotate blocks when holding cactus",
-            extra = {
-                    "Doesn't cause block updates when rotated/flipped",
-                    "Applies to pistons, observers, droppers, repeaters, stairs, glazed terracotta etc..."
-            },
-            category = {CREATIVE, SURVIVAL, FEATURE}
-    )
+    @Rule(categories = {CREATIVE, SURVIVAL, FEATURE})
     public static boolean flippinCactus = false;
 
-    @Rule(
-            desc = "hoppers pointing to wool will count items passing through them",
-            extra = {
-                    "Enables /counter command, and actions while placing red and green carpets on wool blocks",
-                    "Use /counter <color?> reset to reset the counter, and /counter <color?> to query",
-                    "In survival, place green carpet on same color wool to query, red to reset the counters",
-                    "Counters are global and shared between players, 16 channels available",
-                    "Items counted are destroyed, count up to one stack per tick per hopper"
-            },
-            category = {COMMAND, CREATIVE, FEATURE}
-    )
+    @Rule(categories = {COMMAND, CREATIVE, FEATURE})
     public static boolean hopperCounters = false;
 
-    @Rule(
-            desc = "Allows Budding Amethyst blocks to be moved",
-            extra = {
-                    "Allow for them to be moved by pistons",
-                    "as well as adds extra drop when mining with silk touch pickaxe"
-            },
-            category = FEATURE
-    )
+    @Rule(categories = FEATURE)
     public static boolean movableAmethyst = false;
 
-    @Rule( desc = "Guardians turn into Elder Guardian when struck by lightning", category = FEATURE )
+    @Rule(categories = FEATURE )
     public static boolean renewableSponges = false;
 
-    @Rule( desc = "Pistons can push block entities, like hoppers, chests etc.", category = {EXPERIMENTAL, FEATURE} )
+    @Rule(categories = {EXPERIMENTAL, FEATURE} )
     public static boolean movableBlockEntities = false;
-
 
     private static class ChainStoneSetting extends Validator<String> {
         @Override public String validate(CommandSourceStack source, CarpetRule<String> currentRule, String newValue, String string) {
@@ -395,108 +345,69 @@ public class CarpetSettings
     }
 
     @Rule(
-            desc = "Chains will stick to each other on the long ends",
-            extra = {
-                    "and will stick to other blocks that connect to them directly.",
-                    "With stick_to_all: it will stick even if not visually connected"
-            },
-            category = {EXPERIMENTAL, FEATURE},
+            categories = {EXPERIMENTAL, FEATURE},
             options = {"true", "false", "stick_to_all"},
-            validate = ChainStoneSetting.class
+            validators = ChainStoneSetting.class
     )
     public static String chainStone = "false";
 
-    @Rule( desc = "Saplings turn into dead shrubs in hot climates and no water access", category = FEATURE )
+    @Rule(categories = FEATURE)
     public static boolean desertShrubs = false;
 
-    @Rule( desc = "Silverfish drop a gravel item when breaking out of a block", category = FEATURE )
+    @Rule(categories = FEATURE )
     public static boolean silverFishDropGravel = false;
 
-    @Rule( desc = "summoning a lightning bolt has all the side effects of natural lightning", category = CREATIVE )
+    @Rule(categories = CREATIVE )
     public static boolean summonNaturalLightning = false;
 
-    @Rule(desc = "Enables /spawn command for spawn tracking", category = COMMAND)
+    @Rule(categories = COMMAND)
     public static String commandSpawn = "ops";
 
-    @Rule(desc = "Enables /tick command to control game clocks", category = COMMAND)
+    @Rule(categories = COMMAND)
     public static String commandTick = "ops";
 
-    @Rule(
-            desc = "Enables /profile command to monitor game performance",
-            extra = "subset of /tick command capabilities",
-            category = COMMAND
-    )
+    @Rule(categories = COMMAND)
     public static String commandProfile = "true";
 
     @Rule(
-            desc = "Required permission level for /perf command",
             options = {"2", "4"},
-            category = CREATIVE
+            categories = CREATIVE
     )
     public static int perfPermissionLevel = 4;
 
-    @Rule(desc = "Enables /log command to monitor events via chat and overlays", category = COMMAND)
+    @Rule(categories = COMMAND)
     public static String commandLog = "true";
 
     @Rule(
-            desc = "sets these loggers in their default configurations for all new players",
-            extra = "use csv, like 'tps,mobcaps' for multiple loggers, none for nothing",
-            category = {CREATIVE, SURVIVAL},
+            categories = {CREATIVE, SURVIVAL},
             options = {"none", "tps", "mobcaps,tps"},
             strict = false
     )
     public static String defaultLoggers = "none";
 
-    @Rule(
-            desc = "Enables /distance command to measure in game distance between points",
-            extra = "Also enables brown carpet placement action if 'carpets' rule is turned on as well",
-            category = COMMAND
-    )
+    @Rule(categories = COMMAND)
     public static String commandDistance = "true";
 
-    @Rule(
-            desc = "Enables /info command for blocks",
-            extra = {
-                    "Also enables gray carpet placement action",
-                    "if 'carpets' rule is turned on as well"
-            },
-            category = COMMAND
-    )
+    @Rule(categories = COMMAND)
     public static String commandInfo = "true";
 
-    @Rule(
-            desc = "Enables /perimeterinfo command",
-            extra = "... that scans the area around the block for potential spawnable spots",
-            category = COMMAND
-    )
+    @Rule(categories = COMMAND)
     public static String commandPerimeterInfo = "true";
 
-    @Rule(desc = "Enables /draw commands", extra = {"... allows for drawing simple shapes or","other shapes which are sorta difficult to do normally"}, category = COMMAND)
+    @Rule(categories = COMMAND)
     public static String commandDraw = "ops";
 
 
-    @Rule(
-            desc = "Enables /script command",
-            extra = "An in-game scripting API for Scarpet programming language",
-            category = {COMMAND, SCARPET}
-    )
+    @Rule(categories = {COMMAND, SCARPET})
     public static String commandScript = "true";
 
     private static class ModulePermissionLevel extends Validator<String> {
         @Override public String validate(CommandSourceStack source, CarpetRule<String> currentRule, String newValue, String string) {
             int permissionLevel = switch (newValue) {
-                    case "false":
-                        yield 0;
-                    case "true":
-                    case "ops":
-                        yield 2;
-                    case "0":
-                    case "1":
-                    case "2":
-                    case "3":
-                    case "4":
-                    	yield Integer.parseInt(newValue);
-                    default: throw new IllegalArgumentException();
+                    case "false" -> 0;
+                    case "true", "ops" -> 2;
+                    case "0", "1", "2", "3", "4" -> Integer.parseInt(newValue);
+                    default -> throw new IllegalArgumentException();
             	};
             if (source != null && !source.hasPermission(permissionLevel))
                 return null;
@@ -509,90 +420,59 @@ public class CarpetSettings
         public String description() { return "When changing the rule, you must at least have the permission level you are trying to give it";}
     }
     @Rule(
-            desc = "Enables restrictions for arbitrary code execution with scarpet",
-            extra = {
-                    "Users that don't have this permission level",
-                    "won't be able to load apps or /script run.",
-                    "It is also the permission level apps will",
-                    "have when running commands with run()"
-            },
-            category = {SCARPET},
+            categories = {SCARPET},
             options = {"ops", "0", "1", "2", "3", "4"},
-            validate = {Validators.CommandLevel.class, ModulePermissionLevel.class}
+            validators = {Validators.CommandLevel.class, ModulePermissionLevel.class}
     )
     public static String commandScriptACE = "ops";
 
-    @Rule(
-            desc = "Scarpet script from world files will autoload on server/world start ",
-            extra = "if /script is enabled",
-            category = SCARPET
-    )
+    @Rule(categories = SCARPET)
     public static boolean scriptsAutoload = true;
 
-    @Rule(
-            desc = "Enables scripts debugging messages in system log",
-            category = SCARPET
-    )
+    @Rule(categories = SCARPET)
     public static boolean scriptsDebugging = false;
 
-    @Rule(
-            desc = "Enables scripts optimization",
-            category = SCARPET
-    )
+    @Rule(categories = SCARPET)
     public static boolean scriptsOptimization = true;
 
     @Rule(
-            desc = "Location of the online repository of scarpet apps",
-            extra = {
-                    "set to 'none' to disable.",
-                    "Point to any github repo with scarpet apps",
-                    "using <user>/<repo>/contents/<path...>"
-            },
-            category = SCARPET,
+            categories = SCARPET,
             strict = false,
-            validate= AppStoreManager.ScarpetAppStoreValidator.class
+            validators = AppStoreManager.ScarpetAppStoreValidator.class
     )
     public static String scriptsAppStore = "gnembon/scarpet/contents/programs";
 
-
-    @Rule(desc = "Enables /player command to control/spawn players", category = COMMAND)
+    @Rule(categories = COMMAND)
     public static String commandPlayer = "ops";
 
-    @Rule(desc = "Spawn offline players in online mode if online-mode player with specified name does not exist", category = COMMAND)
+    @Rule(categories = COMMAND)
     public static boolean allowSpawningOfflinePlayers = true;
 
-    @Rule(desc = "Allows to track mobs AI via /track command", category = COMMAND)
+    @Rule(categories = COMMAND)
     public static String commandTrackAI = "ops";
 
-    @Rule(desc = "Placing carpets may issue carpet commands for non-op players", category = SURVIVAL)
+    @Rule(categories = SURVIVAL)
     public static boolean carpets = false;
 
-    @Rule(
-            desc = "Glass can be broken faster with pickaxes",
-            category = SURVIVAL
-    )
+    @Rule(categories = SURVIVAL)
     public static boolean missingTools = false;
 
-    @Rule(desc = "fill/clone/setblock and structure blocks cause block updates", category = CREATIVE)
+    @Rule(categories = CREATIVE)
     public static boolean fillUpdates = true;
 
-    @Rule(desc = "placing blocks cause block updates", category = CREATIVE)
+    @Rule(categories = CREATIVE)
     public static boolean interactionUpdates = true;
 
-    @Rule(desc = "Disables breaking of blocks caused by flowing liquids", category = CREATIVE)
+    @Rule(categories = CREATIVE)
     public static boolean liquidDamageDisabled = false;
 
-    @Rule(
-            desc = "smooth client animations with low tps settings",
-            extra = "works only in SP, and will slow down players",
-            category = {CREATIVE, SURVIVAL, CLIENT}
-    )
+    @Rule(categories = {CREATIVE, SURVIVAL, CLIENT})
     public static boolean smoothClientAnimations;
 
     //@Rule(
     //        desc="Fixes mining ghost blocks by trusting clients with block breaking",
     //        extra="Increases player allowed mining distance to 32 blocks",
-    //        category = SURVIVAL
+    //        categories = SURVIVAL
     //)
     //public static boolean miningGhostBlockFix = false;
 
@@ -604,20 +484,18 @@ public class CarpetSettings
         public String description() { return "You must choose a value from 1 to 1024";}
     }
     @Rule(
-            desc = "Customizable piston push limit",
             options = {"10", "12", "14", "100"},
-            category = CREATIVE,
+            categories = CREATIVE,
             strict = false,
-            validate = PushLimitLimits.class
+            validators = PushLimitLimits.class
     )
     public static int pushLimit = 12;
 
     @Rule(
-            desc = "Customizable powered rail power range",
             options = {"9", "15", "30"},
-            category = CREATIVE,
+            categories = CREATIVE,
             strict = false,
-            validate = PushLimitLimits.class
+            validators = PushLimitLimits.class
     )
     public static int railPowerLimit = 9;
 
@@ -629,65 +507,55 @@ public class CarpetSettings
         public String description() { return "You must choose a value from 1 to 20M";}
     }
     @Rule(
-            desc = "Customizable fill/clone volume limit",
             options = {"32768", "250000", "1000000"},
-            category = CREATIVE,
+            categories = CREATIVE,
             strict = false,
-            validate = FillLimitLimits.class
+            validators = FillLimitLimits.class
     )
     public static int fillLimit = 32768;
 
 
     @Rule(
-            desc = "Customizable forceload chunk limit",
             options = {"256"},
-            category = CREATIVE,
+            categories = CREATIVE,
             strict = false,
-            validate = FillLimitLimits.class
+            validators = FillLimitLimits.class
     )
     public static int forceloadLimit = 256;
 
     @Rule(
-            desc = "Customizable maximal entity collision limits, 0 for no limits",
             options = {"0", "1", "20"},
-            category = OPTIMIZATION,
+            categories = OPTIMIZATION,
             strict = false,
-            validate = Validators.NonNegativeNumber.class
+            validators = Validators.NonNegativeNumber.class
     )
     public static int maxEntityCollisions = 0;
 
     @Rule(
-            desc = "Customizable server list ping (Multiplayer menu) playerlist sample limit",
             options = {"0", "12", "20", "40"},
-            category = CREATIVE,
+            categories = CREATIVE,
             strict = false,
-            validate = Validators.NonNegativeNumber.class
+            validators = Validators.NonNegativeNumber.class
     )
     public static int pingPlayerListLimit = 12;
     /*
 
     @Rule(
             desc = "fixes water performance issues",
-            category = OPTIMIZATION,
-            validate = Validator.WIP.class
+            categories = OPTIMIZATION,
+            validators = Validator.WIP.class
     )
     public static boolean waterFlow = true;
     */
 
     @Rule(
-            desc = "Sets a different motd message on client trying to connect to the server",
-            extra = "use '_' to use the startup setting from server.properties",
             options = "_",
             strict = false,
-            category = CREATIVE
+            categories = CREATIVE
     )
     public static String customMOTD = "_";
 
-    @Rule(
-            desc = "Cactus in dispensers rotates blocks.",
-            extra = "Rotates block anti-clockwise if possible",
-            category = {FEATURE, DISPENSER}
-    )
+    @Rule(categories = {FEATURE, DISPENSER})
     public static boolean rotatorBlock = false;
 
     private static class ViewDistanceValidator extends Validator<Integer>
@@ -722,12 +590,10 @@ public class CarpetSettings
         public String description() { return "You must choose a value from 0 (use server settings) to 32";}
     }
     @Rule(
-            desc = "Changes the view distance of the server.",
-            extra = "Set to 0 to not override the value in server settings.",
             options = {"0", "12", "16", "32"},
-            category = CREATIVE,
+            categories = CREATIVE,
             strict = false,
-            validate = ViewDistanceValidator.class
+            validators = ViewDistanceValidator.class
     )
     public static int viewDistance = 0;
 
@@ -763,12 +629,10 @@ public class CarpetSettings
         public String description() { return "You must choose a value from 0 (use server settings) to 32";}
     }
     @Rule(
-            desc = "Changes the simulation distance of the server.",
-            extra = "Set to 0 to not override the value in server settings.",
             options = {"0", "12", "16", "32"},
-            category = CREATIVE,
+            categories = CREATIVE,
             strict = false,
-            validate = SimulationDistanceValidator.class
+            validators = SimulationDistanceValidator.class
     )
     public static int simulationDistance = 0;
 
@@ -807,12 +671,10 @@ public class CarpetSettings
         }
     }
     @Rule(
-            desc = "Changes size of spawn chunks",
-            extra = {"Defines new radius", "setting it to 0 - disables spawn chunks"},
-            category = CREATIVE,
+            categories = CREATIVE,
             strict = false,
             options = {"0", "11"},
-            validate = ChangeSpawnChunksValidator.class
+            validators = ChangeSpawnChunksValidator.class
     )
     public static int spawnChunksSize = 11;
 
@@ -848,12 +710,10 @@ public class CarpetSettings
     }
     
     @Rule(
-            desc = "Changes maximum light tasks batch size",
-            extra = {"Allows for a higher light suppression tolerance", "setting it to 5 - Default limit defined by the game"},
-            category = {EXPERIMENTAL, OPTIMIZATION},
+            categories = {EXPERIMENTAL, OPTIMIZATION},
             strict = false,
             options = {"5", "50", "100", "200"},
-            validate = LightBatchValidator.class
+            validators = LightBatchValidator.class
     )
     public static int lightEngineMaxBatchSize = 5;
 
@@ -862,120 +722,59 @@ public class CarpetSettings
         EXPANDED,
         TRUE;
     }
-    @Rule(
-            desc = "Coral structures will grow with bonemeal from coral plants",
-            extra = "Expanded also allows growing from coral fans for sustainable farming outside of warm oceans",
-            category = FEATURE
-    )
+    @Rule(categories = FEATURE)
     public static RenewableCoralMode renewableCoral = RenewableCoralMode.FALSE;
 
-    @Rule(
-            desc = "Nether basalt generator without soul sand below ",
-            extra = "  .. will convert into blackstone instead",
-            category = FEATURE
-    )
+    @Rule(categories = FEATURE)
     public static boolean renewableBlackstone = false;
 
-    @Rule(
-            desc = "Lava and water generate deepslate and cobbled deepslate instead below Y0",
-            category = FEATURE
-    )
+    @Rule(categories = FEATURE)
     public static boolean renewableDeepslate = false;
 
-    @Rule(desc = "fixes block placement rotation issue when player rotates quickly while placing blocks", category = RuleCategory.BUGFIX)
+    @Rule(categories = RuleCategory.BUGFIX)
     public static boolean placementRotationFix = false;
 
-    @Rule(
-            desc = "Fixes leads breaking/becoming invisible in unloaded chunks",
-            extra = "You may still get visibly broken leash links on the client side, but server side the link is still there.",
-            category = RuleCategory.BUGFIX
-    )// needs checkfix for 1.15
+    @Rule(categories = RuleCategory.BUGFIX) // needs checkfix for 1.15
     public static boolean leadFix = false;
 
-    @Rule(desc = "Spawning requires much less CPU and Memory", category = OPTIMIZATION)
+    @Rule(categories = OPTIMIZATION)
     public static boolean lagFreeSpawning = false;
     
-    @Rule(
-            desc = "Allows structure mobs to spawn in flat worlds",
-            category = {EXPERIMENTAL, CREATIVE}
-    )
+    @Rule(categories = {EXPERIMENTAL, CREATIVE})
     public static boolean flatWorldStructureSpawning = false;
 
-    @Rule(
-            desc = "Increases for testing purposes number of blue skulls shot by the wither",
-            category = CREATIVE
-    )
+    @Rule(categories = CREATIVE)
     public static boolean moreBlueSkulls = false;
 
-    @Rule(
-            desc = "Removes fog from client in the nether and the end",
-            extra = "Improves visibility, but looks weird",
-            category = CLIENT
-    )
+    @Rule(categories = CLIENT)
     public static boolean fogOff = false;
 
-    @Rule(
-            desc = "Creative No Clip",
-            extra = {
-                    "On servers it needs to be set on both ",
-                    "client and server to function properly.",
-                    "Has no effect when set on the server only",
-                    "Can allow to phase through walls",
-                    "if only set on the carpet client side",
-                    "but requires some trapdoor magic to",
-                    "allow the player to enter blocks"
-            },
-            category = {CREATIVE, CLIENT}
-    )
+    @Rule(categories = {CREATIVE, CLIENT})
     public static boolean creativeNoClip = false;
     public static boolean isCreativeFlying(Entity entity)
     {
         // #todo replace after merger to 1.17
-        return CarpetSettings.creativeNoClip && entity instanceof Player && (((Player) entity).isCreative()) && ((Player) entity).getAbilities().flying;
+        return CarpetSettings.creativeNoClip && entity instanceof Player p && p.isCreative() && p.getAbilities().flying;
     }
 
-
     @Rule(
-            desc = "Creative flying speed multiplier",
-            extra = {
-                    "Purely client side setting, meaning that",
-                    "having it set on the decicated server has no effect",
-                    "but this also means it will work on vanilla servers as well"
-            },
-            category = {CREATIVE, CLIENT},
+            categories = {CREATIVE, CLIENT},
             strict = false,
-            validate = Validators.NonNegativeNumber.class
+            validators = Validators.NonNegativeNumber.class
     )
     public static double creativeFlySpeed = 1.0;
 
     @Rule(
-            desc = "Creative air drag",
-            extra = {
-                    "Increased drag will slow down your flight",
-                    "So need to adjust speed accordingly",
-                    "With 1.0 drag, using speed of 11 seems to matching vanilla speeds.",
-                    "Purely client side setting, meaning that",
-                    "having it set on the decicated server has no effect",
-                    "but this also means it will work on vanilla servers as well"
-            },
-            category = {CREATIVE, CLIENT},
+            categories = {CREATIVE, CLIENT},
             strict = false,
-            validate = Validators.Probablity.class
+            validators = Validators.Probablity.class
     )
     public static double creativeFlyDrag = 0.09;
 
-    @Rule(
-            desc = "Removes obnoxious messages from the logs",
-            extra = {
-                    "Doesn't display 'Maximum sound pool size 247 reached'",
-                    "Which is normal with decent farms and contraptions"
-            },
-            category = {SURVIVAL, CLIENT}
-    )
+    @Rule(categories = {SURVIVAL, CLIENT})
     public static boolean cleanLogs = false;
 
     public static class StructureBlockLimitValidator extends Validator<Integer> {
-
         @Override public Integer validate(CommandSourceStack source, CarpetRule<Integer> currentRule, Integer newValue, String string) {
             return (newValue >= vanillaStructureBlockLimit) ? newValue : null;
         }
@@ -986,22 +785,14 @@ public class CarpetSettings
         }
     }
     @Rule(
-            desc = "Customizable structure block limit of each axis",
-            extra = {"WARNING: Needs to be permanent for correct loading.",
-                    "Setting 'structureBlockIgnored' to air is recommended",
-                    "when saving massive structures.",
-                    "Required on client of player editing the Structure Block.",
-                    "'structureBlockOutlineDistance' may be required for",
-                    "correct rendering of long structures."},
             options = {"48", "96", "192", "256"},
-            category = CREATIVE,
-            validate = StructureBlockLimitValidator.class,
+            categories = CREATIVE,
+            validators = StructureBlockLimitValidator.class,
             strict = false
     )
     public static int structureBlockLimit = vanillaStructureBlockLimit;
 
     public static class StructureBlockIgnoredValidator extends Validator<String> {
-
         @Override
         public String validate(CommandSourceStack source, CarpetRule<String> currentRule, String newValue, String string) {
             Optional<Block> ignoredBlock = Registry.BLOCK.getOptional(ResourceLocation.tryParse(newValue));
@@ -1014,38 +805,29 @@ public class CarpetSettings
         }
     }
     @Rule(
-            desc = "Changes the block ignored by the Structure Block",
             options = {"minecraft:structure_void", "minecraft:air"},
-            category = CREATIVE,
-            validate = StructureBlockIgnoredValidator.class,
+            categories = CREATIVE,
+            validators = StructureBlockIgnoredValidator.class,
             strict = false
     )
     public static String structureBlockIgnored = "minecraft:structure_void";
 
     @Rule(
-            desc = "Customizable Structure Block outline render distance",
-            extra = "Required on client to work properly",
             options = {"96", "192", "2048"},
-            category = {CREATIVE, CLIENT},
+            categories = {CREATIVE, CLIENT},
             strict = false,
-            validate = Validators.NonNegativeNumber.class
+            validators = Validators.NonNegativeNumber.class
     )
     public static int structureBlockOutlineDistance = 96;
 
-    @Rule(
-            desc = "Lightning kills the items that drop when lightning kills an entity",
-            extra = {"Setting to true will prevent lightning from killing drops", "Fixes [MC-206922](https://bugs.mojang.com/browse/MC-206922)."},
-            category = BUGFIX
-    )
+    @Rule(categories = BUGFIX)
     public static boolean lightningKillsDropsFix = false;
 
     @Rule(
-            desc = "Placing an activator rail on top of a barrier block will fill the neighbor updater stack when the rail turns off.",
-            extra = {"The integer entered is the amount of updates that should be left in the stack", "-1 turns it off"},
-            category = CREATIVE,
+            categories = CREATIVE,
             options = {"-1","0","10","50"},
             strict = false,
-            validate = UpdateSuppressionBlockModes.class
+            validators = UpdateSuppressionBlockModes.class
     )
     public static int updateSuppressionBlock = -1;
 
@@ -1060,20 +842,14 @@ public class CarpetSettings
         }
     }
 
-    @Rule(
-            desc = "Creative players load chunks, or they don't! Just like spectators!",
-            extra = {"Toggling behaves exactly as if the player is in spectator mode and toggling the gamerule spectatorsGenerateChunks."
-            },
-            category = {CREATIVE, FEATURE}
-    )
+    @Rule(categories = {CREATIVE, FEATURE})
     public static boolean creativePlayersLoadChunks = true;
 
     @Rule(
-            desc = "Customizable sculk sensor range",
             options = {"8", "16", "32"},
-            category = CREATIVE,
+            categories = CREATIVE,
             strict = false,
-            validate = PushLimitLimits.class
+            validators = PushLimitLimits.class
     )
     public static int sculkSensorRange = 8;
 

--- a/src/main/java/carpet/api/settings/SettingsManager.java
+++ b/src/main/java/carpet/api/settings/SettingsManager.java
@@ -176,7 +176,7 @@ public class SettingsManager {
     {
         // In the current translation system languages are not loaded this early. Ensure they are loaded
         Translations.updateLanguage();
-        boolean warned = settingsClass == CarpetSettings.class; // don't warn for ourselves
+        boolean warned = false;
 
         nextRule: for (Field field : settingsClass.getDeclaredFields())
         {

--- a/src/main/java/carpet/api/settings/SettingsManager.java
+++ b/src/main/java/carpet/api/settings/SettingsManager.java
@@ -174,6 +174,8 @@ public class SettingsManager {
      */
     public void parseSettingsClass(Class<?> settingsClass)
     {
+        // In the current translation system languages are not loaded this early. Ensure they are loaded
+        Translations.updateLanguage();
         boolean warned = settingsClass == CarpetSettings.class; // don't warn for ourselves
 
         nextRule: for (Field field : settingsClass.getDeclaredFields())
@@ -210,10 +212,6 @@ public class SettingsManager {
             CarpetRule<?> parsed = ParsedRule.of(field, this);
             rules.put(parsed.name(), parsed);
         }
-        // In the current translation system languages are not loaded this early. Ensure they are loaded
-        // after we've added fallbacks, else early systems such as the rule printer won't function for
-        // legacy rules given the validator (that triggers adding fallbacks normally) won't have ran
-        Translations.updateLanguage();
     }
 
     /**

--- a/src/main/java/carpet/utils/CarpetRulePrinter.java
+++ b/src/main/java/carpet/utils/CarpetRulePrinter.java
@@ -53,6 +53,9 @@ public class CarpetRulePrinter implements DedicatedServerModInitializer {
         } catch (IOException e) {
             throw new IllegalArgumentException("Invalid path passed, or something went very wrong", e);
         }
+        // Ensure translations fallbacks have been generated given we run before the validator that ensures that has.
+        // Remove after removing old setting system, given there'll be no fallbacks
+        Translations.updateLanguage();
         String filter = options.valueOf(filterSpec);
         if (filter != null) logger.info("Applying category filter: " + filter);
         CarpetServer.settingsManager.dumpAllRulesToStream(outputStream, filter);

--- a/src/main/resources/assets/carpet/lang/en_us.json
+++ b/src/main/resources/assets/carpet/lang/en_us.json
@@ -1,20 +1,4 @@
 {
-  // TODO Rules
-  
-  // Categories:
-
-  "carpet.category.bugfix": "bugfix",
-  "carpet.category.survival": "survival",
-  "carpet.category.creative": "creative",
-  "carpet.category.experimental": "experimental",
-  "carpet.category.optimization": "optimization",
-  "carpet.category.feature": "feature",
-  "carpet.category.command": "command",
-  "carpet.category.tnt": "TNT",
-  "carpet.category.dispenser": "dispenser",
-  "carpet.category.scarpet": "scarpet",
-  "carpet.category.client": "client",
-
   // Settings command UI elements
 
   "carpet.settings.command.browse_categories": "Browse categories",
@@ -31,6 +15,410 @@
   "carpet.settings.command.change_permanently_tooltip": "click to keep the settings in %s to save across restarts",
   "carpet.settings.command.default_set": "Rule %s will now default to %s",
   "carpet.settings.command.default_removed": "Rule %s will no longer be set on restart",
-  "carpet.settings.command.current_value": "current value"
+  "carpet.settings.command.current_value": "current value",
+  
+  // Categories
+
+  "carpet.category.bugfix": "bugfix",
+  "carpet.category.survival": "survival",
+  "carpet.category.creative": "creative",
+  "carpet.category.experimental": "experimental",
+  "carpet.category.optimization": "optimization",
+  "carpet.category.feature": "feature",
+  "carpet.category.command": "command",
+  "carpet.category.tnt": "TNT",
+  "carpet.category.dispenser": "dispenser",
+  "carpet.category.scarpet": "scarpet",
+  "carpet.category.client": "client",
+  
+  // Rules
+  
+  // allowSpawningOfflinePlayers
+  "carpet.rule.allowSpawningOfflinePlayers.desc": "Spawn offline players in online mode if online-mode player with specified name does not exist",
+
+  // antiCheatDisabled
+  "carpet.rule.antiCheatDisabled.desc": "Prevents players from rubberbanding when moving too fast",
+
+  "carpet.rule.antiCheatDisabled.extra.0": "... or being kicked out for 'flying'",
+  "carpet.rule.antiCheatDisabled.extra.1": "Puts more trust in clients positioning",
+  "carpet.rule.antiCheatDisabled.extra.2": "Increases player allowed mining distance to 32 blocks",
+
+  // carpetCommandPermissionLevel
+  "carpet.rule.carpetCommandPermissionLevel.desc": "Carpet command permission level. Can only be set via .conf file",
+
+  // carpets
+  "carpet.rule.carpets.desc": "Placing carpets may issue carpet commands for non-op players",
+
+  // chainStone
+  "carpet.rule.chainStone.desc": "Chains will stick to each other on the long ends",
+
+  "carpet.rule.chainStone.extra.0": "and will stick to other blocks that connect to them directly.",
+  "carpet.rule.chainStone.extra.1": "With stick_to_all: it will stick even if not visually connected",
+
+  // cleanLogs
+  "carpet.rule.cleanLogs.desc": "Removes obnoxious messages from the logs",
+
+  "carpet.rule.cleanLogs.extra.0": "Doesn't display 'Maximum sound pool size 247 reached'",
+  "carpet.rule.cleanLogs.extra.1": "Which is normal with decent farms and contraptions",
+
+  // commandDistance
+  "carpet.rule.commandDistance.desc": "Enables /distance command to measure in game distance between points",
+
+  "carpet.rule.commandDistance.extra.0": "Also enables brown carpet placement action if 'carpets' rule is turned on as well",
+
+  // commandDraw
+  "carpet.rule.commandDraw.desc": "Enables /draw commands",
+
+  "carpet.rule.commandDraw.extra.0": "... allows for drawing simple shapes or",
+  "carpet.rule.commandDraw.extra.1": "other shapes which are sorta difficult to do normally",
+
+  // commandInfo
+  "carpet.rule.commandInfo.desc": "Enables /info command for blocks",
+
+  "carpet.rule.commandInfo.extra.0": "Also enables gray carpet placement action",
+  "carpet.rule.commandInfo.extra.1": "if 'carpets' rule is turned on as well",
+
+  // commandLog
+  "carpet.rule.commandLog.desc": "Enables /log command to monitor events via chat and overlays",
+
+  // commandPerimeterInfo
+  "carpet.rule.commandPerimeterInfo.desc": "Enables /perimeterinfo command",
+
+  "carpet.rule.commandPerimeterInfo.extra.0": "... that scans the area around the block for potential spawnable spots",
+
+  // commandPlayer
+  "carpet.rule.commandPlayer.desc": "Enables /player command to control/spawn players",
+
+  // commandProfile
+  "carpet.rule.commandProfile.desc": "Enables /profile command to monitor game performance",
+
+  "carpet.rule.commandProfile.extra.0": "subset of /tick command capabilities",
+
+  // commandScript
+  "carpet.rule.commandScript.desc": "Enables /script command",
+
+  "carpet.rule.commandScript.extra.0": "An in-game scripting API for Scarpet programming language",
+
+  // commandScriptACE
+  "carpet.rule.commandScriptACE.desc": "Enables restrictions for arbitrary code execution with scarpet",
+
+  "carpet.rule.commandScriptACE.extra.0": "Users that don't have this permission level",
+  "carpet.rule.commandScriptACE.extra.1": "won't be able to load apps or /script run.",
+  "carpet.rule.commandScriptACE.extra.2": "It is also the permission level apps will",
+  "carpet.rule.commandScriptACE.extra.3": "have when running commands with run()",
+
+  // commandSpawn
+  "carpet.rule.commandSpawn.desc": "Enables /spawn command for spawn tracking",
+
+  // commandTick
+  "carpet.rule.commandTick.desc": "Enables /tick command to control game clocks",
+
+  // commandTrackAI
+  "carpet.rule.commandTrackAI.desc": "Allows to track mobs AI via /track command",
+
+  // creativeFlyDrag
+  "carpet.rule.creativeFlyDrag.desc": "Creative air drag",
+
+  "carpet.rule.creativeFlyDrag.extra.0": "Increased drag will slow down your flight",
+  "carpet.rule.creativeFlyDrag.extra.1": "So need to adjust speed accordingly",
+  "carpet.rule.creativeFlyDrag.extra.2": "With 1.0 drag, using speed of 11 seems to matching vanilla speeds.",
+  "carpet.rule.creativeFlyDrag.extra.3": "Purely client side setting, meaning that",
+  "carpet.rule.creativeFlyDrag.extra.4": "having it set on the decicated server has no effect",
+  "carpet.rule.creativeFlyDrag.extra.5": "but this also means it will work on vanilla servers as well",
+
+  // creativeFlySpeed
+  "carpet.rule.creativeFlySpeed.desc": "Creative flying speed multiplier",
+
+  "carpet.rule.creativeFlySpeed.extra.0": "Purely client side setting, meaning that",
+  "carpet.rule.creativeFlySpeed.extra.1": "having it set on the decicated server has no effect",
+  "carpet.rule.creativeFlySpeed.extra.2": "but this also means it will work on vanilla servers as well",
+
+  // creativeNoClip
+  "carpet.rule.creativeNoClip.desc": "Creative No Clip",
+
+  "carpet.rule.creativeNoClip.extra.0": "On servers it needs to be set on both ",
+  "carpet.rule.creativeNoClip.extra.1": "client and server to function properly.",
+  "carpet.rule.creativeNoClip.extra.2": "Has no effect when set on the server only",
+  "carpet.rule.creativeNoClip.extra.3": "Can allow to phase through walls",
+  "carpet.rule.creativeNoClip.extra.4": "if only set on the carpet client side",
+  "carpet.rule.creativeNoClip.extra.5": "but requires some trapdoor magic to",
+  "carpet.rule.creativeNoClip.extra.6": "allow the player to enter blocks",
+
+  // creativePlayersLoadChunks
+  "carpet.rule.creativePlayersLoadChunks.desc": "Creative players load chunks, or they don't! Just like spectators!",
+
+  "carpet.rule.creativePlayersLoadChunks.extra.0": "Toggling behaves exactly as if the player is in spectator mode and toggling the gamerule spectatorsGenerateChunks.",
+
+  // ctrlQCraftingFix
+  "carpet.rule.ctrlQCraftingFix.desc": "Dropping entire stacks works also from on the crafting UI result slot",
+
+  // customMOTD
+  "carpet.rule.customMOTD.desc": "Sets a different motd message on client trying to connect to the server",
+
+  "carpet.rule.customMOTD.extra.0": "use '_' to use the startup setting from server.properties",
+
+  // defaultLoggers
+  "carpet.rule.defaultLoggers.desc": "sets these loggers in their default configurations for all new players",
+
+  "carpet.rule.defaultLoggers.extra.0": "use csv, like 'tps,mobcaps' for multiple loggers, none for nothing",
+
+  // desertShrubs
+  "carpet.rule.desertShrubs.desc": "Saplings turn into dead shrubs in hot climates and no water access",
+
+  // explosionNoBlockDamage
+  "carpet.rule.explosionNoBlockDamage.desc": "Explosions won't destroy blocks",
+
+  // fastRedstoneDust
+  "carpet.rule.fastRedstoneDust.desc": "Lag optimizations for redstone dust",
+
+  "carpet.rule.fastRedstoneDust.extra.0": "by Theosib",
+  "carpet.rule.fastRedstoneDust.extra.1": ".. also fixes some locational behaviours or vanilla redstone MC-11193",
+  "carpet.rule.fastRedstoneDust.extra.2": "so behaviour of locational vanilla contraptions is not guaranteed",
+
+  // fillLimit
+  "carpet.rule.fillLimit.desc": "Customizable fill/clone volume limit",
+
+  // fillUpdates
+  "carpet.rule.fillUpdates.desc": "fill/clone/setblock and structure blocks cause block updates",
+
+  // flatWorldStructureSpawning
+  "carpet.rule.flatWorldStructureSpawning.desc": "Allows structure mobs to spawn in flat worlds",
+
+  // flippinCactus
+  "carpet.rule.flippinCactus.desc": "Players can flip and rotate blocks when holding cactus",
+
+  "carpet.rule.flippinCactus.extra.0": "Doesn't cause block updates when rotated/flipped",
+  "carpet.rule.flippinCactus.extra.1": "Applies to pistons, observers, droppers, repeaters, stairs, glazed terracotta etc...",
+
+  // fogOff
+  "carpet.rule.fogOff.desc": "Removes fog from client in the nether and the end",
+
+  "carpet.rule.fogOff.extra.0": "Improves visibility, but looks weird",
+
+  // forceloadLimit
+  "carpet.rule.forceloadLimit.desc": "Customizable forceload chunk limit",
+
+  // hardcodeTNTangle
+  "carpet.rule.hardcodeTNTangle.desc": "Sets the horizontal random angle on TNT for debugging of TNT contraptions",
+
+  "carpet.rule.hardcodeTNTangle.extra.0": "Set to -1 for default behavior",
+
+  // hopperCounters
+  "carpet.rule.hopperCounters.desc": "hoppers pointing to wool will count items passing through them",
+
+  "carpet.rule.hopperCounters.extra.0": "Enables /counter command, and actions while placing red and green carpets on wool blocks",
+  "carpet.rule.hopperCounters.extra.1": "Use /counter <color?> reset to reset the counter, and /counter <color?> to query",
+  "carpet.rule.hopperCounters.extra.2": "In survival, place green carpet on same color wool to query, red to reset the counters",
+  "carpet.rule.hopperCounters.extra.3": "Counters are global and shared between players, 16 channels available",
+  "carpet.rule.hopperCounters.extra.4": "Items counted are destroyed, count up to one stack per tick per hopper",
+
+  // huskSpawningInTemples
+  "carpet.rule.huskSpawningInTemples.desc": "Only husks spawn in desert temples",
+
+  // interactionUpdates
+  "carpet.rule.interactionUpdates.desc": "placing blocks cause block updates",
+
+  // lagFreeSpawning
+  "carpet.rule.lagFreeSpawning.desc": "Spawning requires much less CPU and Memory",
+
+  // language
+  "carpet.rule.language.desc": "Sets the language for Carpet",
+
+  // leadFix
+  "carpet.rule.leadFix.desc": "Fixes leads breaking/becoming invisible in unloaded chunks",
+
+  "carpet.rule.leadFix.extra.0": "You may still get visibly broken leash links on the client side, but server side the link is still there.",
+
+  // lightEngineMaxBatchSize
+  "carpet.rule.lightEngineMaxBatchSize.desc": "Changes maximum light tasks batch size",
+
+  "carpet.rule.lightEngineMaxBatchSize.extra.0": "Allows for a higher light suppression tolerance",
+  "carpet.rule.lightEngineMaxBatchSize.extra.1": "setting it to 5 - Default limit defined by the game",
+
+  // lightningKillsDropsFix
+  "carpet.rule.lightningKillsDropsFix.desc": "Lightning kills the items that drop when lightning kills an entity",
+
+  "carpet.rule.lightningKillsDropsFix.extra.0": "Setting to true will prevent lightning from killing drops",
+  "carpet.rule.lightningKillsDropsFix.extra.1": "Fixes [MC-206922](https://bugs.mojang.com/browse/MC-206922).",
+
+  // liquidDamageDisabled
+  "carpet.rule.liquidDamageDisabled.desc": "Disables breaking of blocks caused by flowing liquids",
+
+  // maxEntityCollisions
+  "carpet.rule.maxEntityCollisions.desc": "Customizable maximal entity collision limits, 0 for no limits",
+
+  // mergeTNT
+  "carpet.rule.mergeTNT.desc": "Merges stationary primed TNT entities",
+
+  // missingTools
+  "carpet.rule.missingTools.desc": "Glass can be broken faster with pickaxes",
+
+  // moreBlueSkulls
+  "carpet.rule.moreBlueSkulls.desc": "Increases for testing purposes number of blue skulls shot by the wither",
+
+  // movableAmethyst
+  "carpet.rule.movableAmethyst.desc": "Allows Budding Amethyst blocks to be moved",
+
+  "carpet.rule.movableAmethyst.extra.0": "Allow for them to be moved by pistons",
+  "carpet.rule.movableAmethyst.extra.1": "as well as adds extra drop when mining with silk touch pickaxe",
+
+  // movableBlockEntities
+  "carpet.rule.movableBlockEntities.desc": "Pistons can push block entities, like hoppers, chests etc.",
+
+  // optimizedTNT
+  "carpet.rule.optimizedTNT.desc": "TNT causes less lag when exploding in the same spot and in liquids",
+
+  // perfPermissionLevel
+  "carpet.rule.perfPermissionLevel.desc": "Required permission level for /perf command",
+
+  // persistentParrots
+  "carpet.rule.persistentParrots.desc": "Parrots don't get of your shoulders until you receive proper damage",
+
+  // piglinsSpawningInBastions
+  "carpet.rule.piglinsSpawningInBastions.desc": "Piglins will respawn in bastion remnants",
+
+  "carpet.rule.piglinsSpawningInBastions.extra.0": "Includes piglins, brutes, and a few hoglins",
+
+  // pingPlayerListLimit
+  "carpet.rule.pingPlayerListLimit.desc": "Customizable server list ping (Multiplayer menu) playerlist sample limit",
+
+  // placementRotationFix
+  "carpet.rule.placementRotationFix.desc": "fixes block placement rotation issue when player rotates quickly while placing blocks",
+
+  // portalCreativeDelay
+  "carpet.rule.portalCreativeDelay.desc": "Amount of delay ticks to use a nether portal in creative",
+
+  // portalSurvivalDelay
+  "carpet.rule.portalSurvivalDelay.desc": "Amount of delay ticks to use a nether portal in survival",
+
+  // pushLimit
+  "carpet.rule.pushLimit.desc": "Customizable piston push limit",
+
+  // quasiConnectivity
+  "carpet.rule.quasiConnectivity.desc": "Pistons, droppers and dispensers react if block above them is powered",
+
+  // railPowerLimit
+  "carpet.rule.railPowerLimit.desc": "Customizable powered rail power range",
+
+  // renewableBlackstone
+  "carpet.rule.renewableBlackstone.desc": "Nether basalt generator without soul sand below ",
+
+  "carpet.rule.renewableBlackstone.extra.0": "  .. will convert into blackstone instead",
+
+  // renewableCoral
+  "carpet.rule.renewableCoral.desc": "Coral structures will grow with bonemeal from coral plants",
+
+  "carpet.rule.renewableCoral.extra.0": "Expanded also allows growing from coral fans for sustainable farming outside of warm oceans",
+
+  // renewableDeepslate
+  "carpet.rule.renewableDeepslate.desc": "Lava and water generate deepslate and cobbled deepslate instead below Y0",
+
+  // renewableSponges
+  "carpet.rule.renewableSponges.desc": "Guardians turn into Elder Guardian when struck by lightning",
+
+  // rotatorBlock
+  "carpet.rule.rotatorBlock.desc": "Cactus in dispensers rotates blocks.",
+
+  "carpet.rule.rotatorBlock.extra.0": "Rotates block anti-clockwise if possible",
+
+  // scriptsAppStore
+  "carpet.rule.scriptsAppStore.desc": "Location of the online repository of scarpet apps",
+
+  "carpet.rule.scriptsAppStore.extra.0": "set to 'none' to disable.",
+  "carpet.rule.scriptsAppStore.extra.1": "Point to any github repo with scarpet apps",
+  "carpet.rule.scriptsAppStore.extra.2": "using <user>/<repo>/contents/<path...>",
+
+  // scriptsAutoload
+  "carpet.rule.scriptsAutoload.desc": "Scarpet script from world files will autoload on server/world start ",
+
+  "carpet.rule.scriptsAutoload.extra.0": "if /script is enabled",
+
+  // scriptsDebugging
+  "carpet.rule.scriptsDebugging.desc": "Enables scripts debugging messages in system log",
+
+  // scriptsOptimization
+  "carpet.rule.scriptsOptimization.desc": "Enables scripts optimization",
+
+  // sculkSensorRange
+  "carpet.rule.sculkSensorRange.desc": "Customizable sculk sensor range",
+
+  // shulkerSpawningInEndCities
+  "carpet.rule.shulkerSpawningInEndCities.desc": "Shulkers will respawn in end cities",
+
+  // silverFishDropGravel
+  "carpet.rule.silverFishDropGravel.desc": "Silverfish drop a gravel item when breaking out of a block",
+
+  // simulationDistance
+  "carpet.rule.simulationDistance.desc": "Changes the simulation distance of the server.",
+
+  "carpet.rule.simulationDistance.extra.0": "Set to 0 to not override the value in server settings.",
+
+  // smoothClientAnimations
+  "carpet.rule.smoothClientAnimations.desc": "smooth client animations with low tps settings",
+
+  "carpet.rule.smoothClientAnimations.extra.0": "works only in SP, and will slow down players",
+
+  // spawnChunksSize
+  "carpet.rule.spawnChunksSize.desc": "Changes size of spawn chunks",
+
+  "carpet.rule.spawnChunksSize.extra.0": "Defines new radius",
+  "carpet.rule.spawnChunksSize.extra.1": "setting it to 0 - disables spawn chunks",
+
+  // stackableShulkerBoxes
+  "carpet.rule.stackableShulkerBoxes.desc": "Empty shulker boxes can stack when thrown on the ground.",
+
+  "carpet.rule.stackableShulkerBoxes.extra.0": ".. or when manipulated inside the inventories",
+
+  // structureBlockIgnored
+  "carpet.rule.structureBlockIgnored.desc": "Changes the block ignored by the Structure Block",
+
+  // structureBlockLimit
+  "carpet.rule.structureBlockLimit.desc": "Customizable structure block limit of each axis",
+
+  "carpet.rule.structureBlockLimit.extra.0": "WARNING: Needs to be permanent for correct loading.",
+  "carpet.rule.structureBlockLimit.extra.1": "Setting 'structureBlockIgnored' to air is recommended",
+  "carpet.rule.structureBlockLimit.extra.2": "when saving massive structures.",
+  "carpet.rule.structureBlockLimit.extra.3": "Required on client of player editing the Structure Block.",
+  "carpet.rule.structureBlockLimit.extra.4": "'structureBlockOutlineDistance' may be required for",
+  "carpet.rule.structureBlockLimit.extra.5": "correct rendering of long structures.",
+
+  // structureBlockOutlineDistance
+  "carpet.rule.structureBlockOutlineDistance.desc": "Customizable Structure Block outline render distance",
+
+  "carpet.rule.structureBlockOutlineDistance.extra.0": "Required on client to work properly",
+
+  // summonNaturalLightning
+  "carpet.rule.summonNaturalLightning.desc": "summoning a lightning bolt has all the side effects of natural lightning",
+
+  // superSecretSetting
+  "carpet.rule.superSecretSetting.desc": "Gbhs sgnf sadsgras fhskdpri!!!",
+
+  // tntDoNotUpdate
+  "carpet.rule.tntDoNotUpdate.desc": "TNT doesn't update when placed against a power source",
+
+  // tntPrimerMomentumRemoved
+  "carpet.rule.tntPrimerMomentumRemoved.desc": "Removes random TNT momentum when primed",
+
+  // tntRandomRange
+  "carpet.rule.tntRandomRange.desc": "Sets the tnt random explosion range to a fixed value",
+
+  "carpet.rule.tntRandomRange.extra.0": "Set to -1 for default behavior",
+
+  // updateSuppressionBlock
+  "carpet.rule.updateSuppressionBlock.desc": "Placing an activator rail on top of a barrier block will fill the neighbor updater stack when the rail turns off.",
+
+  "carpet.rule.updateSuppressionBlock.extra.0": "The integer entered is the amount of updates that should be left in the stack",
+  "carpet.rule.updateSuppressionBlock.extra.1": "-1 turns it off",
+
+  // viewDistance
+  "carpet.rule.viewDistance.desc": "Changes the view distance of the server.",
+
+  "carpet.rule.viewDistance.extra.0": "Set to 0 to not override the value in server settings.",
+
+  // xpFromExplosions
+  "carpet.rule.xpFromExplosions.desc": "Experience will drop from all experience barring blocks with any explosion type",
+
+  // xpNoCooldown
+  "carpet.rule.xpNoCooldown.desc": "Players absorb XP instantly, without delay"
 
 }


### PR DESCRIPTION
Does that.

While doing this I was wondering if the language file should maybe be datagen-ed from some annotation closer to the rule.

Maybe something like
```java
@RuleData(desc = "...", extra = {"...", "..."})
@Rule(...)
```
?