### PR TITLE
Map from id in `system_info('server_mods')`

### DIFF
--- a/src/main/java/carpet/script/utils/SystemInfo.java
+++ b/src/main/java/carpet/script/utils/SystemInfo.java
@@ -131,7 +131,7 @@ public class SystemInfo {
         put("server_mods", c -> {
             Map<Value, Value> ret = new HashMap<>();
             for (ModContainer mod : FabricLoader.getInstance().getAllMods())
-                ret.put(new StringValue(mod.getMetadata().getName()), new StringValue(mod.getMetadata().getVersion().getFriendlyString()));
+                ret.put(new StringValue(mod.getMetadata().getId()), new StringValue(mod.getMetadata().getVersion().getFriendlyString()));
             return MapValue.wrap(ret);
         });
         put("server_last_tick_times", c -> {


### PR DESCRIPTION
Mods may change their name, but should keep their id. Even carpet changed it once.

There's a small compatibility risk, with apps that use that function, though I haven't been able to find any on github, though maybe it's just it doesn't know how to search scarpet code (or I don't).