### PR TITLE
Remove the last few `File` usages and fix some resource leaks

### DIFF
--- a/src/main/java/carpet/script/Module.java
+++ b/src/main/java/carpet/script/Module.java
@@ -89,7 +89,7 @@ public record Module(String name, String code, boolean library) {
     {
         Path dataFile = resolveResource(module);
         if (dataFile == null) return null;
-        if (!Files.exists(dataFile) || !(dataFile.toFile().isFile())) return null;
+        if (!Files.exists(dataFile) || !(Files.isRegularFile(dataFile))) return null;
         synchronized (FileArgument.writeIOSync) { return FileArgument.readTag(dataFile); }
     }
 
@@ -97,7 +97,13 @@ public record Module(String name, String code, boolean library) {
     {
         Path dataFile = resolveResource(module);
         if (dataFile == null) return;
-        if (!Files.exists(dataFile.getParent()) && !dataFile.toFile().getParentFile().mkdirs()) return;
+        if (!Files.exists(dataFile.getParent())) {
+            try {
+                Files.createDirectories(dataFile.getParent());
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
         synchronized (FileArgument.writeIOSync) { FileArgument.writeTagDisk(globalState, dataFile, false); }
     }
 

--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -80,7 +80,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.CommandStorage;
 import net.minecraft.world.level.storage.LevelResource;
 import net.minecraft.world.phys.Vec3;
-import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.file.PathUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -1076,7 +1076,7 @@ public class Auxiliary {
                 {
                     successful[0] = false;
                     try {
-                        FileUtils.forceDelete(packFloder.toFile());
+                        PathUtils.delete(packFloder);
                     } catch (IOException ignored) {
                         throw new InternalExpressionException("Failed to install a datapack and failed to clean up after it");
                     }

--- a/src/main/java/carpet/script/utils/WorldTools.java
+++ b/src/main/java/carpet/script/utils/WorldTools.java
@@ -32,7 +32,6 @@ import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import net.minecraft.world.level.levelgen.WorldGenSettings;
 import net.minecraft.world.level.storage.DerivedLevelData;
 import net.minecraft.world.level.storage.ServerLevelData;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
@@ -54,10 +53,9 @@ public class WorldTools
             if (region == null) return false;
             return region.hasChunk(chpos);
         }
-        Path regionPath = new File(((MinecraftServerInterface )world.getServer()).getCMSession().getDimensionPath(world.dimension()).toFile(), "region").toPath();
-        Path regionFilePath = regionPath.resolve(currentRegionName);
-        File regionFile = regionFilePath.toFile();
-        if (!regionFile.exists())
+        Path regionsFolder = ((MinecraftServerInterface)world.getServer()).getCMSession().getDimensionPath(world.dimension()).resolve("region");
+        Path regionPath = regionsFolder.resolve(currentRegionName);
+        if (!regionPath.toFile().exists())
         {
             if (regionCache != null) regionCache.put(currentRegionName, null);
             return false;
@@ -65,7 +63,7 @@ public class WorldTools
         if (!deepcheck) return true; // not using cache in this case.
         try
         {
-            RegionFile region = new RegionFile(regionFile.toPath(), regionPath, true);
+            RegionFile region = new RegionFile(regionPath, regionsFolder, true);
             if (regionCache != null) regionCache.put(currentRegionName, region);
             return region.hasChunk(chpos);
         }


### PR DESCRIPTION
This PR removes all remaining `File` usages (via `Path.toFile()`) barring one, given I've heard that in hot code `Files.exists()` is slower than `toFile().exists()` if in the default `FileSystem`, and that place seemed to be hot given it even used caches. That one is pending investigation to whether it is actually worth, though it'll likely just be kept that way given AFAIK minecraft worlds can only be interacted with in the default filesystem.

It also fixes some resource leaks, given `Stream`s don't `close()` when you call a terminal operation, therefore those created by `Files.list` and `Files.walk` were previously leaking open directories (`DirectoryStream`s are also one of the few resource handlers in Java without a cleanable for closing on gc). Luckily these functions weren't called commonly so we haven't heard about any problems caused by them.

Pending testing.