### PR TITLE
Fix `in` (`~`) operator producing broken values

### DIFF
--- a/src/main/java/carpet/script/value/Value.java
+++ b/src/main/java/carpet/script/value/Value.java
@@ -153,11 +153,11 @@ public abstract class Value implements Comparable<Value>, Cloneable
         if (!m.find()) return Value.NULL;
         int gc = m.groupCount();
         if (gc == 0) return new StringValue(m.group());
-        if (gc == 1) return new StringValue(m.group(1));
+        if (gc == 1) return StringValue.of(m.group(1));
         List<Value> groups = new ArrayList<>(gc);
         for (int i = 1; i <= gc; i++)
         {
-            groups.add(new StringValue(m.group(i)));
+            groups.add(StringValue.of(m.group(i)));
         }
         return ListValue.wrap(groups);
     }


### PR DESCRIPTION
Fixes #1542.

From the `Matcher.group(int)` javadoc:
>  If the match was successful but the group specified failed to match any part of the input sequence, then null is returned.

We were taking these nulls to the null-safe `StringValue` constructor, therefore creating broken values. This makes those cases return a scarpet `null`.

I don't know a lot about regex (and its "contracts" in scarpet) so I'm not sure if `null` is the proper return for this kind of cases.