### PR TITLE
Expose origin-less constructors and methods

### DIFF
--- a/src/main/java/carpet/script/CarpetContext.java
+++ b/src/main/java/carpet/script/CarpetContext.java
@@ -8,6 +8,11 @@ public class CarpetContext extends Context
 {
     public CommandSourceStack s;
     public final BlockPos origin;
+
+    public CarpetContext(ScriptHost host, CommandSourceStack source) {
+        this(host, source, BlockPos.ZERO);
+    }
+
     public CarpetContext(ScriptHost host, CommandSourceStack source, BlockPos origin)
     {
         super(host);

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -1221,7 +1221,7 @@ public class CarpetEventServer
         if (executingHost == null) return CallbackResult.FAIL;
         try
         {
-            executingHost.callUDF(BlockPos.ZERO, source.withPermission(CarpetSettings.runPermissionLevel), udf, argv);
+            executingHost.callUDF(source.withPermission(CarpetSettings.runPermissionLevel), udf, argv);
             return CallbackResult.SUCCESS;
         }
         catch (NullPointerException | InvalidCallbackException | IntegrityException error)

--- a/src/main/java/carpet/script/CarpetScriptHost.java
+++ b/src/main/java/carpet/script/CarpetScriptHost.java
@@ -764,7 +764,7 @@ public class CarpetScriptHost extends ScriptHost
         {
             // TODO: this is just for now - invoke would be able to invoke other hosts scripts
             assertAppIntegrity(function.getModule());
-            Context context = new CarpetContext(this, source, BlockPos.ZERO);
+            Context context = new CarpetContext(this, source);
             return scriptServer().events.handleEvents.getWhileDisabled(() -> function.getExpression().evalValue(
                     () -> function.lazyEval(context, Context.VOID, function.getExpression(), function.getToken(), argv),
                     context,
@@ -795,7 +795,7 @@ public class CarpetScriptHost extends ScriptHost
         try
         {
             assertAppIntegrity(function.getModule());
-            Context context = new CarpetContext(this, source, BlockPos.ZERO);
+            Context context = new CarpetContext(this, source);
             return function.getExpression().evalValue(
                     () -> function.execute(context, Context.VOID, function.getExpression(), function.getToken(), argv),
                     context,
@@ -808,7 +808,12 @@ public class CarpetScriptHost extends ScriptHost
         }
     }
 
-    public Value callUDF(BlockPos pos, CommandSourceStack source, FunctionValue fun, List<Value> argv) throws InvalidCallbackException, IntegrityException
+    public Value callUDF(CommandSourceStack source, FunctionValue fun, List<Value> argv) throws InvalidCallbackException, IntegrityException
+    {
+        return callUDF(BlockPos.ZERO, source, fun, argv);
+    }
+
+    public Value callUDF(BlockPos origin, CommandSourceStack source, FunctionValue fun, List<Value> argv) throws InvalidCallbackException, IntegrityException
     {
         if (CarpetServer.scriptServer.stopAll)
             return Value.NULL;
@@ -824,7 +829,7 @@ public class CarpetScriptHost extends ScriptHost
         try
         {
             assertAppIntegrity(fun.getModule());
-            Context context = new CarpetContext(this, source, pos);
+            Context context = new CarpetContext(this, source, origin);
             return fun.getExpression().evalValue(
                     () -> fun.execute(context, Context.VOID, fun.getExpression(), fun.getToken(), argv),
                     context,
@@ -844,7 +849,7 @@ public class CarpetScriptHost extends ScriptHost
         return scriptServer().events.handleEvents.getWhileDisabled(()->{
         try
         {
-            return callUDF(BlockPos.ZERO, source, fun, arguments);
+            return callUDF(source, fun, arguments);
         }
         catch (InvalidCallbackException ignored)
         {

--- a/src/main/java/carpet/script/value/ScreenValue.java
+++ b/src/main/java/carpet/script/value/ScreenValue.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
@@ -182,7 +181,7 @@ public class ScreenValue extends Value {
         CarpetScriptHost executingHost = appHost.retrieveForExecution(source,player);
         try
         {
-            Value cancelValue = executingHost.callUDF(BlockPos.ZERO, source.withPermission(CarpetSettings.runPermissionLevel), callback, args);
+            Value cancelValue = executingHost.callUDF(source.withPermission(CarpetSettings.runPermissionLevel), callback, args);
             return cancelValue.getString().equals("cancel");
         }
         catch (NullPointerException | InvalidCallbackException | IntegrityException error)


### PR DESCRIPTION
This PR creates an origin-less `CarpetContext` constructor and an origin-less `callUDF` method.

This is done given most callers use `BlockPos.ZERO` anyway, and this argument has led to confusion (and therefore a bug) at least once, plus these may get removed at some point IIRC, so having the definitive ones already is nice.

The PR also migrates usages of the old ones with `BlockPos.ZERO` to these.

The origin is still there so this doesn't break existing behaviour, just in a second place.