### PR TITLE
Make Carpet's Network Handlers Run On Main Threads

### DIFF
--- a/src/main/java/carpet/mixins/ClientPacketListener_customPacketsMixin.java
+++ b/src/main/java/carpet/mixins/ClientPacketListener_customPacketsMixin.java
@@ -7,6 +7,7 @@ import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundCustomPayloadPacket;
 import net.minecraft.network.protocol.game.ClientboundLoginPacket;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -16,9 +17,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ClientPacketListener.class)
 public abstract class ClientPacketListener_customPacketsMixin
 {
-    @Shadow private Minecraft minecraft;
+    @Final @Shadow private Minecraft minecraft;
 
-    @Inject(method = "handleCustomPayload", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "handleCustomPayload", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/protocol/game/ClientboundCustomPayloadPacket;getIdentifier()Lnet/minecraft/resources/ResourceLocation;"), cancellable = true)
     private void onOnCustomPayload(ClientboundCustomPayloadPacket packet, CallbackInfo ci)
     {
         if (CarpetClient.CARPET_CHANNEL.equals(packet.getIdentifier()))
@@ -39,5 +40,4 @@ public abstract class ClientPacketListener_customPacketsMixin
     {
         CarpetClient.disconnect();
     }
-
 }

--- a/src/main/java/carpet/mixins/ServerGamePacketListenerImplMixin.java
+++ b/src/main/java/carpet/mixins/ServerGamePacketListenerImplMixin.java
@@ -3,6 +3,8 @@ package carpet.mixins;
 import carpet.network.CarpetClient;
 import carpet.network.ServerNetworkHandler;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.PacketUtils;
+import net.minecraft.network.protocol.game.ServerGamePacketListener;
 import net.minecraft.network.protocol.game.ServerboundCustomPayloadPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
@@ -24,6 +26,10 @@ public class ServerGamePacketListenerImplMixin
         ResourceLocation channel = packet.getIdentifier();
         if (CarpetClient.CARPET_CHANNEL.equals(channel))
         {
+            // We should force onto the main thread here
+            // ServerNetworkHandler.handleData can possibly mutate data that isn't
+            // thread safe, and also allows for client commands to be executed
+            PacketUtils.ensureRunningOnSameThread(packet, (ServerGamePacketListener) this, player.getLevel());
             ServerNetworkHandler.handleData(new FriendlyByteBuf(packet.getData().copy()), player);
             ci.cancel();
         }

--- a/src/main/java/carpet/mixins/ServerGamePacketListenerImplMixin.java
+++ b/src/main/java/carpet/mixins/ServerGamePacketListenerImplMixin.java
@@ -29,6 +29,7 @@ public class ServerGamePacketListenerImplMixin
             // We should force onto the main thread here
             // ServerNetworkHandler.handleData can possibly mutate data that isn't
             // thread safe, and also allows for client commands to be executed
+            // [TODO] need to investigate if that is actually an issue since carpet doesn't fiddle with its packets.
             PacketUtils.ensureRunningOnSameThread(packet, (ServerGamePacketListener) this, player.getLevel());
             ServerNetworkHandler.handleData(new FriendlyByteBuf(packet.getData().copy()), player);
             ci.cancel();

--- a/src/main/java/carpet/network/CarpetClient.java
+++ b/src/main/java/carpet/network/CarpetClient.java
@@ -12,7 +12,6 @@ import net.minecraft.resources.ResourceLocation;
 
 public class CarpetClient
 {
-    public static final Object sync = new Object();
     public static final int HI = 69;
     public static final int HELLO = 420;
     public static final int DATA = 1;
@@ -25,14 +24,7 @@ public class CarpetClient
 
     public static void gameJoined(LocalPlayer player)
     {
-        synchronized (sync)
-        {
-            clientPlayer = player;
-            // client didn't say hi back yet
-            if (isServerCarpet)
-                ClientNetworkHandler.respondHello();
-
-        }
+        clientPlayer = player;
     }
 
     public static void disconnect()

--- a/src/main/java/carpet/network/ClientNetworkHandler.java
+++ b/src/main/java/carpet/network/ClientNetworkHandler.java
@@ -87,6 +87,7 @@ public class ClientNetworkHandler
         });
     };
 
+    // Ran on the Main Minecraft Thread
     public static void handleData(FriendlyByteBuf data, LocalPlayer player)
     {
         if (data != null)
@@ -101,22 +102,19 @@ public class ClientNetworkHandler
 
     private static void onHi(FriendlyByteBuf data)
     {
-        synchronized (CarpetClient.sync)
+        CarpetClient.setCarpet();
+        CarpetClient.serverCarpetVersion = data.readUtf(64);
+        if (CarpetSettings.carpetVersion.equals(CarpetClient.serverCarpetVersion))
         {
-            CarpetClient.setCarpet();
-            CarpetClient.serverCarpetVersion = data.readUtf(64);
-            if (CarpetSettings.carpetVersion.equals(CarpetClient.serverCarpetVersion))
-            {
-                CarpetSettings.LOG.info("Joined carpet server with matching carpet version");
-            }
-            else
-            {
-                CarpetSettings.LOG.warn("Joined carpet server with another carpet version: "+CarpetClient.serverCarpetVersion);
-            }
-            if (CarpetClient.getPlayer() != null)
-                respondHello();
-
+            CarpetSettings.LOG.info("Joined carpet server with matching carpet version");
         }
+        else
+        {
+            CarpetSettings.LOG.warn("Joined carpet server with another carpet version: "+CarpetClient.serverCarpetVersion);
+        }
+        // We can ensure that this packet is
+        // processed AFTER the player has joined
+        respondHello();
     }
 
     public static void respondHello()


### PR DESCRIPTION
This PR ensures that Carpet's network handlers are being run on the main thread:

## Client
- The client network handler now mixins after the `handleCustomPayload` method has been pushed to the main thread.
- This wasn't direcly causing any concurrency issues but any Carpet Extensions with validators on the client side would be running off-thread and may lead to race conditions, this also would cause any other mods that mixin into Carpet's network handling to have the same issue.
- Since all the shape code is now running on the main thread the maps that store the shapes no longer needed to be synchronized.

## Server
- The server network handler now pushes the method to the main thread.
- This could have been the cause for a concurrency issue as `ServerNetworkHandler.remoteCarpetPlayers` gets updated on the Network thread. This also gets updated/iterated on the main thread. Also this caused Carpet's clientCommands to be executed off-thread (I didn't check but I suppose this could possibly cause issues).

I've tested outside of a dev environment on both the client and server in both on a dedicated and integrated server.