### PR TITLE
Allow rules to declare they only accept a set of options

### DIFF
--- a/src/main/java/carpet/api/settings/CarpetRule.java
+++ b/src/main/java/carpet/api/settings/CarpetRule.java
@@ -86,6 +86,18 @@ public interface CarpetRule<T> {
     T defaultValue();
     
     /**
+     * <p>Returns whether this rule is strict.</p>
+     * 
+     * <p>A rule being strict means that it will only accept the suggestions returned by {@link #suggestions()} as valid values.</p>
+     * 
+     * <p>Note that a rule implementation may return {@code false} in this method but still not accept options other than those
+     * returned in {@link #suggestions()}, only the opposite is guaranteed.</p>
+     */
+    default boolean strict() {
+        return false;
+    }
+    
+    /**
      * <p>Sets this rule's value to the provided {@link String}, after first converting the {@link String} into a suitable type.</p>
      * 
      * <p>This methods run any required validation on the value first, and throws {@link InvalidRuleValueException} if the value is not suitable

--- a/src/main/java/carpet/api/settings/SettingsManager.java
+++ b/src/main/java/carpet/api/settings/SettingsManager.java
@@ -533,7 +533,7 @@ public class SettingsManager {
             ps.println("* Type: `" + rule.type().getSimpleName() + "`  ");
             ps.println("* Default value: `" + RuleHelper.toRuleString(rule.defaultValue()) + "`  ");
             String options = rule.suggestions().stream().map(s -> "`" + s + "`").collect(Collectors.joining(", "));
-            if (!options.isEmpty()) ps.println((rule instanceof ParsedRule<?> pr && pr.isStrict?"* Required":"* Suggested")+" options: " + options + "  ");
+            if (!options.isEmpty()) ps.println((rule.strict() ? "* Required" : "* Suggested") + " options: " + options + "  ");
             ps.println("* Categories: " + rule.categories().stream().map(s -> "`" + s.toUpperCase(Locale.ROOT) + "`").collect(Collectors.joining(", ")) + "  ");
             if (rule instanceof ParsedRule<?>)
             {

--- a/src/main/java/carpet/settings/ParsedRule.java
+++ b/src/main/java/carpet/settings/ParsedRule.java
@@ -85,9 +85,9 @@ public final class ParsedRule<T> implements CarpetRule<T>, Comparable<ParsedRule
     @Deprecated(forRemoval = true) // to private (and rename?)
     public final List<String> options;
     /**
-     * @deprecated No replacement for this
+     * @deprecated Use {@link CarpetRule#strict()} instead
      */
-    @Deprecated(forRemoval = true) // to pckg private (for printRulesToLog, or get a different way)
+    @Deprecated(forRemoval = true) // to remove or fix
     public boolean isStrict;
     /**
      * @deprecated Use {@link CarpetRule#canBeToggledClientSide()} instead
@@ -389,6 +389,11 @@ public final class ParsedRule<T> implements CarpetRule<T>, Comparable<ParsedRule
     @Override
     public void set(CommandSourceStack source, T value) throws InvalidRuleValueException {
         set(source, value, RuleHelper.toRuleString(value));
+    }
+
+    @Override
+    public boolean strict() {
+        return !realValidators.isEmpty() && realValidators.get(0) instanceof Validator.StrictValidator;
     }
 
     private static <T> Map.Entry<Class<T>, FromStringConverter<T>> numericalConverter(Class<T> outputClass, Function<String, T> converter) {


### PR DESCRIPTION
This PR adds the `strict()` method to the `CarpetRule` interface.

If the method returns `true`, that means that the rule won't accept any value other than the ones returned in `CarpetRule#suggestions`. The opposite guarantees nothing.

The interface implements it as a default method (that returns `false`) to allow compatibility with current implementations.

`ParsedRule` implements it by checking that the rule has the `Strict` Validator, given that's how it's implemented now (the `isStrict` boolean just comes from the boolean in the annotation, that doesn't guarantee the rule will actually be strict).

Resolves #1541.