### PR TITLE
Optimize `ListValue::new(Collection)` slightly for best-case scenarios

### DIFF
--- a/src/main/java/carpet/script/value/ListValue.java
+++ b/src/main/java/carpet/script/value/ListValue.java
@@ -64,8 +64,7 @@ public class ListValue extends AbstractListValue implements ContainerValueInterf
 
     public ListValue(Collection<? extends Value> list)
     {
-        items = new ArrayList<>();
-        items.addAll(list);
+        items = new ArrayList<>(list);
     }
 
     protected ListValue(List<Value> list)


### PR DESCRIPTION
Calling `ArrayList::addAll` after constructing the `ArrayList` will always copy the array returned from `Collection::toArray` (that is always a copy by contract).

However, calling the constructor that takes a `Collection` will just use the array returned by `toArray` if it's trusted that the array is a copy, by checking if the collection was an `ArrayList`, the most likely case.

Therefore, in the common case of an `ArrayList` being passed, there will be a single copy of the array instead of two, and some empty list initialization code will be skipped.

And it also simplifies code a tiny bit.