### PR TITLE
Fixed NPE when events are triggered within events

### DIFF
--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -223,7 +223,7 @@ public class CarpetEventServer
         {
             if (callList.size() > 0 && CarpetServer.scriptServer != null)
             {
-                return CarpetServer.scriptServer.events.handleEvents.runIfEnabled( () -> {
+                Boolean isCancelled = CarpetServer.scriptServer.events.handleEvents.runIfEnabled( () -> {
                     CarpetProfiler.ProfilerToken currentSection = CarpetProfiler.start_section(null, "Scarpet events", CarpetProfiler.TYPE.GENERAL);
                     List<Value> argv = argumentSupplier.get(); // empty for onTickDone
                     CommandSourceStack source;
@@ -266,6 +266,7 @@ public class CarpetEventServer
                     CarpetProfiler.end_current_section(currentSection);
                     return cancelled;
                 });
+                return isCancelled != null && isCancelled;
             }
             return false;
         }


### PR DESCRIPTION
Fixes #1573

This would happen if an event is triggered inside an event (In the case of veinminer, by calling `harvest` inside `__on_player_breaks_block`, which would trigger the event again). This makes `runIfEnabled` return null, which errors when converting `Boolean` to the primitive