### PR TITLE
Fixing `/player botname stop` with relation to fake player movement

### DIFF
--- a/src/main/java/carpet/helpers/EntityPlayerActionPack.java
+++ b/src/main/java/carpet/helpers/EntityPlayerActionPack.java
@@ -235,14 +235,9 @@ public class EntityPlayerActionPack
                 }
             }
         }
-        if (forward != 0.0F)
-        {
-            player.zza = forward*(sneaking?0.3F:1.0F);
-        }
-        if (strafing != 0.0F)
-        {
-            player.xxa = strafing*(sneaking?0.3F:1.0F);
-        }
+        float vel = sneaking?0.3F:1.0F;
+        player.zza = forward*vel;
+        player.xxa = strafing*vel;
     }
 
     static HitResult getTarget(ServerPlayer player)


### PR DESCRIPTION
Fixes #1072
This basically removed two if clauses that made no sense to me. If they were there for a reason, then I'll find another solution, but right now they are the cause of this bug.
Now `/player botname stop` will immediately stop the player's movement.
Todo proper testing.