### PR TITLE
More Ender Dragon queries

### DIFF
--- a/src/main/java/carpet/mixins/DragonHoldingPatternPhase_scarpetMixin.java
+++ b/src/main/java/carpet/mixins/DragonHoldingPatternPhase_scarpetMixin.java
@@ -1,0 +1,12 @@
+package carpet.mixins;
+
+import net.minecraft.world.entity.boss.enderdragon.phases.DragonHoldingPatternPhase;
+import net.minecraft.world.level.pathfinder.Path;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(DragonHoldingPatternPhase.class)
+public interface DragonHoldingPatternPhase_scarpetMixin {
+    @Accessor
+    Path getCurrentPath();
+}

--- a/src/main/java/carpet/mixins/DragonLandingApproachPhase_scarpetMixin.java
+++ b/src/main/java/carpet/mixins/DragonLandingApproachPhase_scarpetMixin.java
@@ -1,0 +1,12 @@
+package carpet.mixins;
+
+import net.minecraft.world.entity.boss.enderdragon.phases.DragonLandingApproachPhase;
+import net.minecraft.world.level.pathfinder.Path;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(DragonLandingApproachPhase.class)
+public interface DragonLandingApproachPhase_scarpetMixin {
+    @Accessor
+    Path getCurrentPath();
+}

--- a/src/main/java/carpet/mixins/DragonStrafePlayerPhase_scarpetMixin.java
+++ b/src/main/java/carpet/mixins/DragonStrafePlayerPhase_scarpetMixin.java
@@ -1,0 +1,12 @@
+package carpet.mixins;
+
+import net.minecraft.world.entity.boss.enderdragon.phases.DragonStrafePlayerPhase;
+import net.minecraft.world.level.pathfinder.Path;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(DragonStrafePlayerPhase.class)
+public interface DragonStrafePlayerPhase_scarpetMixin {
+    @Accessor
+    Path getCurrentPath();
+}

--- a/src/main/java/carpet/mixins/DragonTakeoffPhase_scarpetMixin.java
+++ b/src/main/java/carpet/mixins/DragonTakeoffPhase_scarpetMixin.java
@@ -1,0 +1,12 @@
+package carpet.mixins;
+
+import net.minecraft.world.entity.boss.enderdragon.phases.DragonTakeoffPhase;
+import net.minecraft.world.level.pathfinder.Path;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(DragonTakeoffPhase.class)
+public interface DragonTakeoffPhase_scarpetMixin {
+    @Accessor
+    Path getCurrentPath();
+}

--- a/src/main/java/carpet/mixins/EnderDragon_scarpetMixin.java
+++ b/src/main/java/carpet/mixins/EnderDragon_scarpetMixin.java
@@ -1,0 +1,15 @@
+package carpet.mixins;
+
+import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
+import net.minecraft.world.level.pathfinder.Node;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(EnderDragon.class)
+public interface EnderDragon_scarpetMixin {
+    @Accessor
+    Node[] getNodes();
+
+    @Accessor
+    int[] getNodeAdjacency();
+}

--- a/src/main/java/carpet/script/value/ValueConversions.java
+++ b/src/main/java/carpet/script/value/ValueConversions.java
@@ -215,6 +215,20 @@ public class ValueConversions
         return ListValue.wrap(nodes);
     }
 
+    public static Value fromNodeArray(ServerLevel world,  Node[] nodes)
+    {
+        List<Value> nodesValue = new ArrayList<>();
+        for (Node node : nodes) {
+            nodesValue.add(ListValue.of(
+                    new BlockValue(null, world, node.asBlockPos()),
+                    new StringValue(node.type.name().toLowerCase(Locale.ROOT)),
+                    new NumericValue(node.costMalus),
+                    BooleanValue.of(node.closed)
+            ));
+        }
+        return ListValue.wrap(nodesValue);
+    }
+
     public static Value fromTimedMemory(Entity e, long expiry, Object v)
     {
         Value ret = fromEntityMemory(e, v);

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -94,6 +94,11 @@
     "ChunkGenerator_customMobSpawnsMixin",
     "ServerChunkCacheMixin",
     "NaturalSpawnerMixin",
+    "EnderDragon_scarpetMixin",
+    "DragonHoldingPatternPhase_scarpetMixin",
+    "DragonLandingApproachPhase_scarpetMixin",
+    "DragonStrafePlayerPhase_scarpetMixin",
+    "DragonTakeoffPhase_scarpetMixin",
 
     "DirectionMixin",
     "ServerPlayerGameMode_cactusMixin",


### PR DESCRIPTION
`query(e, 'dragon_nodes');`  returns Ender Dragon nodes 
`query(e, 'dragon_node_adjacency');` returns Ender Dragon node adjacency map 
`query(e, 'dragon_target');` returns Ender Dragon target pos 
`query(e, 'path');`  works with Ender Dragon too