### PR TITLE
Don't compute tree size and depth with debugging disabled

### DIFF
--- a/src/main/java/carpet/script/Expression.java
+++ b/src/main/java/carpet/script/Expression.java
@@ -1116,26 +1116,34 @@ public class Expression
         if (CarpetSettings.scriptsDebugging)
             CarpetScriptServer.LOG.info("Input code size for "+getModuleName()+": " + treeSize(root) + " nodes, " + treeDepth(root) + " deep");
 
+        // Defined out here to not need to conditionally assign them with debugging disabled
+        int prevTreeSize = -1;
+        int prevTreeDepth = -1;
+
         boolean changed = true;
         while(changed) {
             changed = false;
             while (true) {
-                int tree_size = treeSize(root);
-                int tree_depth = treeDepth(root);
+                if (CarpetSettings.scriptsDebugging) {
+                    prevTreeSize = treeSize(root);
+                    prevTreeDepth = treeDepth(root);
+                }
                 boolean optimized = compactTree(root, Context.Type.NONE, 0);
                 if (!optimized) break;
                 changed = true;
                 if (CarpetSettings.scriptsDebugging)
-                    CarpetScriptServer.LOG.info("Compacted from " + tree_size + " nodes, " + tree_depth + " code depth to " + treeSize(root) + " nodes, " + treeDepth(root) + " code depth");
+                    CarpetScriptServer.LOG.info("Compacted from " + prevTreeSize + " nodes, " + prevTreeDepth + " code depth to " + treeSize(root) + " nodes, " + treeDepth(root) + " code depth");
             }
             while (true) {
-                int tree_size = treeSize(root);
-                int tree_depth = treeDepth(root);
+                if (CarpetSettings.scriptsDebugging) {
+                    prevTreeSize = treeSize(root);
+                    prevTreeDepth = treeDepth(root);
+                }
                 boolean optimized = optimizeTree(optimizeOnlyContext, root, Context.Type.NONE, 0);
                 if (!optimized) break;
                 changed = true;
                 if (CarpetSettings.scriptsDebugging)
-                    CarpetScriptServer.LOG.info("Optimized from " + tree_size + " nodes, " + tree_depth + " code depth to " + treeSize(root) + " nodes, " + treeDepth(root) + " code depth");
+                    CarpetScriptServer.LOG.info("Optimized from " + prevTreeSize + " nodes, " + prevTreeDepth + " code depth to " + treeSize(root) + " nodes, " + treeDepth(root) + " code depth");
             }
         }
         return extractOp(optimizeOnlyContext, root, Context.Type.NONE);


### PR DESCRIPTION
Those are relatively expensive to compute, more the bigger apps are.

They're especially expensive in terms of call stack size, given their use of heavily nested `Stream`s (each contributing multiple many to the call stack).

This not only improves compile times, but it also allows for much larger (deep) apps, including the depth that the unoptimized `;` adds.