### PR TITLE
Make `/fillbiome` limit customisable with `fillLimit`

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -630,7 +630,7 @@ public class CarpetSettings
         public String description() { return "You must choose a value from 1 to 20M";}
     }
     @Rule(
-            desc = "Customizable fill/clone volume limit",
+            desc = "Customizable fill/fillbiome/clone volume limit",
             options = {"32768", "250000", "1000000"},
             category = CREATIVE,
             strict = false,

--- a/src/main/java/carpet/mixins/FillBiomeCommandMixin.java
+++ b/src/main/java/carpet/mixins/FillBiomeCommandMixin.java
@@ -1,0 +1,17 @@
+package carpet.mixins;
+
+import carpet.CarpetSettings;
+import net.minecraft.server.commands.FillBiomeCommand;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(FillBiomeCommand.class)
+public class FillBiomeCommandMixin
+{
+	@ModifyConstant(method = "fill", constant = @Constant(intValue = 32768))
+	private static int fillLimit(int original)
+	{
+		return CarpetSettings.fillLimit;
+	}
+}

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -11,6 +11,7 @@
 
     "PerfCommand_permissionMixin",
     "FillCommandMixin",
+    "FillBiomeCommandMixin",
     "CloneCommands_fillUpdatesMixin",
     "SetBlockCommand_fillUpdatesMixin",
     "ForceLoadCommand_forceLoadLimitMixin",


### PR DESCRIPTION
Simply just uses carpet's `fillLimit` as the limit for the `/fillbiome` command.