### PR TITLE
Add `quasiConnectivityRange` setting

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -347,6 +347,21 @@ public class CarpetSettings
     @Rule(desc = "Pistons, droppers and dispensers react if block above them is powered", category = CREATIVE)
     public static boolean quasiConnectivity = true;
 
+    private static class QuasiConnectivityRangeValidator extends Validator<Integer> {
+
+        @Override
+        public Integer validate(CommandSourceStack source, CarpetRule<Integer> changingRule, Integer newValue, String userInput) {
+            return newValue > 0 && newValue < 384 ? newValue : null;
+        }
+    }
+
+    @Rule(
+        desc = "The range at which pistons, droppers, and dispensers check for 'quasi power'",
+        category = CREATIVE,
+        validate = QuasiConnectivityRangeValidator.class
+    )
+    public static int quasiConnectivityRange = 1;
+
     @Rule(
             desc = "Players can flip and rotate blocks when holding cactus",
             extra = {

--- a/src/main/java/carpet/helpers/QuasiConnectivity.java
+++ b/src/main/java/carpet/helpers/QuasiConnectivity.java
@@ -1,0 +1,21 @@
+package carpet.helpers;
+
+import carpet.CarpetSettings;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+
+public class QuasiConnectivity {
+
+    public static boolean hasQuasiSignal(Level level, BlockPos pos) {
+        if (CarpetSettings.quasiConnectivity) {
+            for (int i = 1; i <= CarpetSettings.quasiConnectivityRange; i++) {
+                if (level.hasNeighborSignal(pos.above(i))) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/carpet/mixins/DispenserBlock_qcMixin.java
+++ b/src/main/java/carpet/mixins/DispenserBlock_qcMixin.java
@@ -1,25 +1,29 @@
 package carpet.mixins;
 
-import carpet.CarpetSettings;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.DispenserBlock;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import carpet.helpers.QuasiConnectivity;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.DispenserBlock;
+import net.minecraft.world.level.block.state.BlockState;
+
 @Mixin(DispenserBlock.class)
-public class DispenserBlock_qcMixin
-{
-    @Redirect(method = "neighborChanged", at = @At(
+public class DispenserBlock_qcMixin {
+
+    @Redirect(
+        method = "neighborChanged",
+        at = @At(
             value = "INVOKE",
-            target =  "Lnet/minecraft/world/level/Level;hasNeighborSignal(Lnet/minecraft/core/BlockPos;)Z",
-            ordinal = 1
-    ))
-    private boolean checkUpPower(Level world, BlockPos blockPos_1)
-    {
-        if (!CarpetSettings.quasiConnectivity)
-            return false;
-        return world.hasNeighborSignal(blockPos_1);
+            ordinal = 1,
+            target =  "Lnet/minecraft/world/level/Level;hasNeighborSignal(Lnet/minecraft/core/BlockPos;)Z"
+        )
+    )
+    private boolean carpet_hasQuasiSignal(Level _level, BlockPos above, BlockState state, Level level, BlockPos pos, Block neighborBlock, BlockPos neighborPos, boolean movedByPiston) {
+        return QuasiConnectivity.hasQuasiSignal(level, pos);
     }
 }

--- a/src/main/java/carpet/mixins/PistonBaseBlock_qcMixin.java
+++ b/src/main/java/carpet/mixins/PistonBaseBlock_qcMixin.java
@@ -1,29 +1,29 @@
 package carpet.mixins;
 
-import carpet.CarpetSettings;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.piston.PistonBaseBlock;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import carpet.helpers.QuasiConnectivity;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.piston.PistonBaseBlock;
+
 @Mixin(PistonBaseBlock.class)
-public class PistonBaseBlock_qcMixin
-{
-    @Inject(method = "getNeighborSignal", cancellable = true, at = @At(
+public class PistonBaseBlock_qcMixin {
+
+    @Inject(
+        method = "getNeighborSignal",
+        cancellable = true,
+        at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/core/BlockPos;above()Lnet/minecraft/core/BlockPos;"
-    ))
-    private void cancelUpCheck(Level world_1, BlockPos blockPos_1, Direction direction_1, CallbackInfoReturnable<Boolean> cir)
-    {
-        if (!CarpetSettings.quasiConnectivity)
-        {
-            cir.setReturnValue(false);
-            cir.cancel();
-        }
+        )
+    )
+    private void carpet_checkQuasiSignal(Level level, BlockPos pos, Direction facing, CallbackInfoReturnable<Boolean> cir) {
+        cir.setReturnValue(QuasiConnectivity.hasQuasiSignal(level, pos));
     }
-
 }


### PR DESCRIPTION
The `quasiConnectivity` setting could be made redundant, but I opted to keep it for the sake of backwards compatibility. The `quasiConnectivityRange` setting can be configured to a value between 1 and 383 (no point in going higher due to the world height limit).