### PR TITLE
Add labels to TPS hud when warping and freezing

### DIFF
--- a/src/main/java/carpet/logging/HUDController.java
+++ b/src/main/java/carpet/logging/HUDController.java
@@ -118,13 +118,12 @@ public class HUDController
     {
         double MSPT = Mth.average(server.tickTimes) * 1.0E-6D;
         double TPS = 1000.0D / Math.max((TickSpeed.time_warp_start_time != 0)?0.0:TickSpeed.mspt, MSPT);
-        if (TickSpeed.isPaused()) {
-            TPS = 0;
-        }
-        String color = Messenger.heatmap_color(MSPT,TickSpeed.mspt);
+
+        TickSpeed.TickingState state = TickSpeed.getTickingState();
+        String color = Messenger.heatmap_color(MSPT, TickSpeed.mspt);
         return new Component[]{Messenger.c(
-                "g TPS: ", String.format(Locale.US, "%s %.1f",color, TPS),
-                "g  MSPT: ", String.format(Locale.US,"%s %.1f", color, MSPT))};
+                state.statePrefix(), state.tpsPrefix(), state.formatTPS(TPS, color),
+                "g MSPT: ", String.format(Locale.US,"%s %.1f", color, MSPT))};
     }
 
     private static Component [] send_counter_info(MinecraftServer server, String color)


### PR DESCRIPTION
This PR adds labels to frozen, deep frozen and warping states, as well as hides the TPS when the game is frozen.

See https://discord.com/channels/882822986795716608/894447061485899776/1060309643584340029
for screenshots.