### PR TITLE
Fix a simple grammar mistake in a JavaDoc

### DIFF
--- a/src/main/java/carpet/CarpetExtension.java
+++ b/src/main/java/carpet/CarpetExtension.java
@@ -146,7 +146,7 @@ public interface CarpetExtension
      * rules.
      * 
      * @param lang A {@link String} being the language id selected by the user
-     * @return A {@link Map<String, String>} containing the string key with it's 
+     * @return A {@link Map<String, String>} containing the string key with its 
      *         respective translation {@link String} or an empty map if not available
      * 
      */


### PR DESCRIPTION
Fix a simple mistake in the Javadoc of the method `canHasTranslations`