### PR TITLE
Fix unchecked removal of commands by app name

### DIFF
--- a/src/main/java/carpet/script/CarpetScriptHost.java
+++ b/src/main/java/carpet/script/CarpetScriptHost.java
@@ -83,6 +83,7 @@ public class CarpetScriptHost extends ScriptHost
     Predicate<CommandSourceStack> commandValidator;
     boolean isRuleApp;
     public AppStoreManager.StoreNode storeSource;
+    boolean hasCommand;
 
     private CarpetScriptHost(CarpetScriptServer server, Module code, boolean perUser, ScriptHost parent, Map<Value, Value> config, Map<String, CommandArgument> argTypes, Predicate<CommandSourceStack> commandValidator, boolean isRuleApp)
     {
@@ -358,6 +359,12 @@ public class CarpetScriptHost extends ScriptHost
         }
     }
 
+    // Used to ensure app gets marked as holding command from a central place
+    private void registerCommand(LiteralArgumentBuilder<CommandSourceStack> command) {
+        scriptServer().server.getCommands().getDispatcher().register(command);
+        hasCommand = true;
+    }
+
     public void readCustomArgumentTypes() throws CommandSyntaxException
     {
         // read custom arguments
@@ -401,7 +408,7 @@ public class CarpetScriptHost extends ScriptHost
                 LiteralArgumentBuilder<CommandSourceStack> command = readCommands(commandValidator);
                 if (command != null)
                 {
-                    scriptServer().server.getCommands().getDispatcher().register(command);
+                	registerCommand(command);
                     return true;
                 }
                 else {
@@ -523,7 +530,7 @@ public class CarpetScriptHost extends ScriptHost
                                         })));
             }
         }
-        scriptServer().server.getCommands().getDispatcher().register(command);
+        registerCommand(command);
         return true;
     }
 

--- a/src/main/java/carpet/script/CarpetScriptHost.java
+++ b/src/main/java/carpet/script/CarpetScriptHost.java
@@ -408,7 +408,7 @@ public class CarpetScriptHost extends ScriptHost
                 LiteralArgumentBuilder<CommandSourceStack> command = readCommands(commandValidator);
                 if (command != null)
                 {
-                	registerCommand(command);
+                    registerCommand(command);
                     return true;
                 }
                 else {

--- a/src/main/java/carpet/script/CarpetScriptServer.java
+++ b/src/main/java/carpet/script/CarpetScriptServer.java
@@ -341,10 +341,11 @@ public class CarpetScriptServer extends ScriptServer
             return false;
         }
         // stop all events associated with name
-        events.removeAllHostEvents(modules.get(name));
-        modules.get(name).onClose();
-        modules.remove(name);
-        ((CommandDispatcherInterface)server.getCommands().getDispatcher()).carpet$unregister(name);
+        CarpetScriptHost host = modules.remove(name);
+        events.removeAllHostEvents(host);
+        host.onClose();
+        if (host.hasCommand)
+            ((CommandDispatcherInterface)server.getCommands().getDispatcher()).carpet$unregister(name);
         if (!isRuleApp) unloadableModules.remove(name);
         CommandHelper.notifyPlayersCommandsChanged(server);
         if (notifySource) Messenger.m(source, "gi Removed "+name+" app");


### PR DESCRIPTION
Fixes #1634.

Should this make it into a 1.19.3 release? This isn't directly on top of 1.19.3, but it doesn't include any 23w03a commits, so it could be merged into 1.19.3 without many issues by just changing the target branch. Update: Actually it's sitting on top of a commit with an NPE.

The bug is present in all 1.19.3 versions, and on the latest 1.19.2 version. Older versions are unaffected.