### PR TITLE
Do not issue deprecation warning when correctly using `scoreboard_add` but an objective already exists

### DIFF
--- a/src/main/java/carpet/script/api/Scoreboards.java
+++ b/src/main/java/carpet/script/api/Scoreboards.java
@@ -132,18 +132,15 @@ public class Scoreboards {
             else
             {
                 String critetionName = lv.get(1).getString();
-                criterion = ObjectiveCriteria.byName(critetionName).orElse(null);
-                if (criterion==null)
-                {
-                    throw new ThrowStatement(critetionName, Throwables.UNKNOWN_CRITERION);
-                }
+                criterion = ObjectiveCriteria.byName(critetionName)
+                        .orElseThrow(() -> new ThrowStatement(critetionName, Throwables.UNKNOWN_CRITERION));
             }
 
-            Objective objective = scoreboard.getOrCreateObjective(objectiveName);
+            Objective objective = scoreboard.getObjective(objectiveName);
             if (objective != null) {
+                if (objective.getCriteria().equals(criterion)) return Value.NULL;
                 c.host.issueDeprecation("reading or modifying an objective's criterion with scoreboard_add");
                 if(lv.size() == 1) return StringValue.of(objective.getCriteria().getName());
-                if(objective.getCriteria().equals(criterion) || lv.size() == 1) return Value.NULL;
                 ((Scoreboard_scarpetMixin)scoreboard).getObjectivesByCriterion().get(objective.getCriteria()).remove(objective);
                 ((Objective_scarpetMixin) objective).setCriterion(criterion);
                 (((Scoreboard_scarpetMixin)scoreboard).getObjectivesByCriterion().computeIfAbsent(criterion, (criterion1) -> Lists.newArrayList())).add(objective);


### PR DESCRIPTION
According to the docs, it is supported to call `scoreboard_add` when a scoreboard with that name already exists as long as that didn't change anything.

https://github.com/gnembon/fabric-carpet/blob/6adccfd46ace8e9d0e103fdd453cdf1480167e29/docs/scarpet/api/Scoreboard.md?plain=1#L14

However, that was causing a deprecation warning to be issued as that was made instantly once it was found that an objective with that name exists. This PR delays the warning to after checking the criterion doesn't match.

This introduces a compatibility risk though (with the old deprecated behaviour): People querying a criterion with a single argument will get `null` if it's `dummy`, as it's the default.

I wonder if it'd be a good idea to deprecate the default argument and requiring the criterion to always be passed as a parameter. Would allow preserving the old behaviour in that case, and also fixing the amount of parameters of the function (after deprecation removal). What do you think?

CC @replaceitem 