### PR TITLE
Fix fake players not accumulating fallDistance

### DIFF
--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -2,6 +2,7 @@ package carpet.patches;
 
 import carpet.CarpetSettings;
 import com.mojang.authlib.GameProfile;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.UUIDUtil;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.PacketFlow;
@@ -23,6 +24,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.SkullBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import carpet.fakes.ServerPlayerInterface;
 import carpet.utils.Messenger;
 
@@ -174,5 +176,10 @@ public class EntityPlayerMPFake extends ServerPlayer
     public String getIpAddress()
     {
         return "127.0.0.1";
+    }
+
+    @Override
+    protected void checkFallDamage(double y, boolean onGround, BlockState state, BlockPos pos) {
+        doCheckFallDamage(y, onGround);
     }
 }


### PR DESCRIPTION
Fix fake players not accumulating fallDistance or ever 'hitting the ground'
 * Fixes #1586 (Fake player does not take fall damage)
 * Should Fix #1478 (fake players cannot use critical hits)
 * Should Fix Unreported/Unconfirmed (fake players can not engage Elytras)

Tested in single player and multiplayer (with change applied to 1.19.3 branch), connected to server with a matching modified carpet and 1.19.3 release carpet on client, without any apparent issues.

I do get a crash on the client when I disconnect from a server, but that also happens on a build of 1.19.3 branch with nothing else applied, so I'm claiming it's unrelated ;) Doesn't happen with the current released 1.19.3 version on the client though :shrug: 