### PR TITLE
Add arithmetic shift, use logic shift in current right shift

### DIFF
--- a/docs/scarpet/language/Operators.md
+++ b/docs/scarpet/language/Operators.md
@@ -310,6 +310,9 @@ only take integer values, so if the input has a decimal part, it will be discard
 	than 63 positions will result in a 0 (cos you shift out all the bits of the number)
  - `bitwise_shift_right(num, amount)` -> Shifts all the bits of the first number `amount` spots to the right. Like with the above,
 	shifting more than 63 bits results in a 0.
+ - `bitwise_arithmetic_shift_right(num, amount)` -> Shifts all the bits of the first number `amount` spots to the right arithmetically.
+    That is, if the most significant (sign) bit is a 1, it'll propagate the one to the `amount` most significant bits. Like with the above,
+	shifting more than 63 bits results in a 0.
  - `bitwise_roll_left(num, amount)` -> Rolls the bits of the first number `amount` bits to the left. This is basically where you
 	shift out the first `amount` bits and then add them on at the back, essentially 'rolling' the number. Note that unlike with
         shifting, you can roll more than 63 bits at a time, as it just makes the number roll over more times, which isn't an issue

--- a/docs/scarpet/language/Operators.md
+++ b/docs/scarpet/language/Operators.md
@@ -308,8 +308,8 @@ only take integer values, so if the input has a decimal part, it will be discard
 	tend to -1.
  - `bitwise_shift_left(num, amount)` -> Shifts all the bits of the first number `amount` spots to the left. Note that shifting more
 	than 63 positions will result in a 0 (cos you shift out all the bits of the number)
- - `bitwise_shift_right(num, amount)` -> Shifts all the bits of the first number `amount` spots to the right. Like with the above,
-	shifting more than 63 bits results in a 0.
+ - `bitwise_shift_right(num, amount)` -> Shifts all the bits of the first number `amount` spots to the right logically. That is, the 
+    `amount` most significant bits will always be set to 0. Like with the above, shifting more than 63 bits results in a 0.
  - `bitwise_arithmetic_shift_right(num, amount)` -> Shifts all the bits of the first number `amount` spots to the right arithmetically.
     That is, if the most significant (sign) bit is a 1, it'll propagate the one to the `amount` most significant bits. Like with the above,
 	shifting more than 63 bits results in a 0.

--- a/src/main/java/carpet/script/language/Operators.java
+++ b/src/main/java/carpet/script/language/Operators.java
@@ -314,7 +314,8 @@ public class Operators
         });
         expression.addFunctionalEquivalence("<=", "nondecreasing");
         expression.addMathematicalBinaryIntFunction("bitwise_shift_left", (num, amount) -> num << amount);
-        expression.addMathematicalBinaryIntFunction("bitwise_shift_right", (num, amount) -> num >> amount);
+        expression.addMathematicalBinaryIntFunction("bitwise_shift_right", (num, amount) -> num >>> amount);
+        expression.addMathematicalBinaryIntFunction("bitwise_arithmetic_shift_right", (num, amount) -> num >> amount);
         expression.addMathematicalBinaryIntFunction("bitwise_roll_left", (num, amount) -> Long.rotateLeft(num, (int)amount));
         expression.addMathematicalBinaryIntFunction("bitwise_roll_right", (num, amount) -> Long.rotateRight(num, (int)amount));
         expression.addMathematicalUnaryIntFunction("bitwise_not", d -> {


### PR DESCRIPTION
Partially resolves #1666.

This PR changes the current `bitwise_shift_right` to do a logic shift instead of arithmetic, and adds `bitwise_arithmetic_shift_right`.

RFC for whether it should be the other way around, logic being the new one added, but I personally think default should be logic.

Pending is either updating the docs to reflect that only the least significant bits of the amount is used (as specified by the JLS and therefore how the operator works), or if we should work around it and allow amounts greater than that by wrapping the operator (passing a number greater than those is useless as it'd just return 0, or 1 if arithmetic and with the MSB being 1).