### PR TITLE
Move rule change event into a rule observer and outside the Java api

### DIFF
--- a/src/main/java/carpet/api/settings/CarpetRule.java
+++ b/src/main/java/carpet/api/settings/CarpetRule.java
@@ -100,15 +100,14 @@ public interface CarpetRule<T> {
     /**
      * <p>Sets this rule's value to the provided {@link String}, after first converting the {@link String} into a suitable type.</p>
      * 
-     * <p>This methods run any required validation on the value first, and throws {@link InvalidRuleValueException} if the value is not suitable
-     * for this rule, regardless of whether it was impossible to convert the value to the required type, the rule doesn't accept the
-     * value, or the rule is immutable.</p>
+     * <p>This methods run any required validation on the value first, and throws {@link InvalidRuleValueException} if the value is not suitable for
+     * this rule, regardless of whether it was impossible to convert the value to the required type, the rule doesn't accept the value, or the rule is
+     * immutable.</p>
      * 
      * <p>Implementations of this method must notify their {@link SettingsManager} by calling
-     * {@link SettingsManager#notifyRuleChanged(CommandSourceStack, CarpetRule, String)}, who is responsible for
-     * notifying the {@link ServerNetworkHandler} (if the rule isn't restricted from being synchronized with clients)
-     * and the {@link CarpetEventServer.Event#CARPET_RULE_CHANGES#onCarpetRuleChanges(CarpetRule, CommandSourceStack)} Scarpet event
-     * in case the value of the rule was changed because of the invocation.</p>
+     * {@link SettingsManager#notifyRuleChanged(CommandSourceStack, CarpetRule, String)}, who is responsible for notifying the
+     * {@link ServerNetworkHandler} (if the rule isn't restricted from being synchronized with clients) and other rule observers like the Scarpet
+     * event, in case the value of the rule was changed because of the invocation.</p>
      * 
      * <p>This method must not throw any exception other than the documented {@link InvalidRuleValueException}.</p>
      * 

--- a/src/main/java/carpet/api/settings/SettingsManager.java
+++ b/src/main/java/carpet/api/settings/SettingsManager.java
@@ -25,8 +25,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import carpet.script.CarpetEventServer;
-import carpet.script.value.StringValue;
 import com.google.common.collect.Sets;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
@@ -259,39 +257,12 @@ public class SettingsManager {
         rules.put(rule.name(), rule);
     }
 
-    public static final CarpetEventServer.Event CARPET_RULE_CHANGES = new CarpetEventServer.Event("carpet_rule_changes", 2, true)
-    {
-        @Override
-        public void handleAny(final Object ... args)
-        {
-            final CarpetRule<?> rule = (CarpetRule<?>) args[0];
-            final CommandSourceStack source = (CommandSourceStack) args[1];
-            final String id = rule.settingsManager().identifier();
-            final String namespace;
-            if (!id.equals("carpet"))
-            {
-                namespace = id + ":";
-            }
-            else
-            {
-                namespace = "";
-            }
-            handler.call(
-                    () -> Arrays.asList(
-                            new StringValue(namespace + rule.name()),
-                            new StringValue(RuleHelper.toRuleString(rule.value()))
-                    ), () -> source
-            );
-        }
-    };
-
     public void notifyRuleChanged(CommandSourceStack source, CarpetRule<?> rule, String userInput)
     {
         observers.forEach(observer -> observer.ruleChanged(source, rule, userInput));
         staticObservers.forEach(observer -> observer.ruleChanged(source, rule, userInput));
         ServerNetworkHandler.updateRuleWithConnectedClients(rule);
         switchScarpetRuleIfNeeded(source, rule); //TODO move into rule
-        if (CARPET_RULE_CHANGES.isNeeded()) CARPET_RULE_CHANGES.handleAny(rule, source);
     }
 
     /**

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -437,6 +437,11 @@ public class CarpetEventServer
             return events;
         }
 
+        static
+        {
+            Carpet.initCarpetEvents();
+        }
+
         public static final Event START = new Event("server_starts", 0, true)
         {
             @Override

--- a/src/main/java/carpet/script/external/Carpet.java
+++ b/src/main/java/carpet/script/external/Carpet.java
@@ -223,10 +223,10 @@ public class Carpet
             @Override
             public void handleAny(final Object... args)
             {
-                final CarpetRule<?> rule = (CarpetRule<?>) args[0];
-                final CommandSourceStack source = (CommandSourceStack) args[1];
-                final String id = rule.settingsManager().identifier();
-                final String namespace;
+                CarpetRule<?> rule = (CarpetRule<?>) args[0];
+                CommandSourceStack source = (CommandSourceStack) args[1];
+                String id = rule.settingsManager().identifier();
+                String namespace;
                 if (!id.equals("carpet"))
                 {
                     namespace = id + ":";
@@ -234,8 +234,10 @@ public class Carpet
                 {
                     namespace = "";
                 }
-                handler.call(() -> Arrays.asList(new StringValue(namespace + rule.name()), new StringValue(RuleHelper.toRuleString(rule.value()))),
-                        () -> source);
+                handler.call(() -> Arrays.asList(
+                                new StringValue(namespace + rule.name()),
+                                new StringValue(RuleHelper.toRuleString(rule.value()))
+                        ), () -> source);
             }
         };
         SettingsManager.registerGlobalRuleObserver((source, changedRule, userInput) -> carpetRuleChanges.handleAny(changedRule, source));

--- a/src/main/java/carpet/script/external/Carpet.java
+++ b/src/main/java/carpet/script/external/Carpet.java
@@ -216,7 +216,7 @@ public class Carpet
         throw new LoadException(String.format("%s requires a version of mod '%s' matching '%s', which is missing!", host.getName(), requiredModId, stringPredicate));
     }
 
-    // to be ran once during CarpetEventServer.Event init
+    // to be ran once during CarpetEventServer.Event static init
     public static void initCarpetEvents() {
         CarpetEventServer.Event carpetRuleChanges = new CarpetEventServer.Event("carpet_rule_changes", 2, true)
         {

--- a/src/main/java/carpet/script/external/Carpet.java
+++ b/src/main/java/carpet/script/external/Carpet.java
@@ -11,6 +11,7 @@ import carpet.helpers.TickSpeed;
 import carpet.logging.HUDController;
 import carpet.network.ServerNetworkHandler;
 import carpet.patches.EntityPlayerMPFake;
+import carpet.script.CarpetEventServer;
 import carpet.script.CarpetExpression;
 import carpet.script.CarpetScriptHost;
 import carpet.script.CarpetScriptServer;
@@ -40,6 +41,7 @@ import java.io.IOException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -212,6 +214,31 @@ public class Carpet
             }
         }
         throw new LoadException(String.format("%s requires a version of mod '%s' matching '%s', which is missing!", host.getName(), requiredModId, stringPredicate));
+    }
+
+    // to be ran once during CarpetEventServer.Event init
+    public static void initCarpetEvents() {
+        CarpetEventServer.Event carpetRuleChanges = new CarpetEventServer.Event("carpet_rule_changes", 2, true)
+        {
+            @Override
+            public void handleAny(final Object... args)
+            {
+                final CarpetRule<?> rule = (CarpetRule<?>) args[0];
+                final CommandSourceStack source = (CommandSourceStack) args[1];
+                final String id = rule.settingsManager().identifier();
+                final String namespace;
+                if (!id.equals("carpet"))
+                {
+                    namespace = id + ":";
+                } else
+                {
+                    namespace = "";
+                }
+                handler.call(() -> Arrays.asList(new StringValue(namespace + rule.name()), new StringValue(RuleHelper.toRuleString(rule.value()))),
+                        () -> source);
+            }
+        };
+        SettingsManager.registerGlobalRuleObserver((source, changedRule, userInput) -> carpetRuleChanges.handleAny(changedRule, source));
     }
 
     public static class ScarpetAppStoreValidator extends Validator<String>


### PR DESCRIPTION
Resolves #1671.

Makes the rule change event get triggered from a general rule observer, also moves it into `script.external.Carpet` given it's at least related and to ensure there's no load order issues by loading from SettingsManager, that extensions could access before we are in a late enough state, also removing it from being public.