### PR TITLE
Allow scarpet function name to be different to annotated method name

### DIFF
--- a/src/main/java/carpet/script/annotation/AnnotationParser.java
+++ b/src/main/java/carpet/script/annotation/AnnotationParser.java
@@ -77,6 +77,7 @@ import carpet.script.value.Value;
 public final class AnnotationParser
 {
     static final int UNDEFINED_PARAMS = -2;
+    static final String USE_METHOD_NAME = "$METHOD_NAME_MARKER$";
     private static final List<ParsedFunction> functionList = new ArrayList<>();
 
     /**
@@ -172,7 +173,8 @@ public final class AnnotationParser
 
         private ParsedFunction(Method method, Class<?> originClass, Supplier<Object> instance)
         {
-            this.name = method.getName();
+            ScarpetFunction annotation = method.getAnnotation(ScarpetFunction.class);
+            this.name = annotation.functionName() == USE_METHOD_NAME ? method.getName() : annotation.functionName();
             this.isMethodVarArgs = method.isVarArgs();
             this.methodParamCount = method.getParameterCount();
 
@@ -199,7 +201,7 @@ public final class AnnotationParser
             int setMaxParams = this.minParams; // Unlimited == Integer.MAX_VALUE
             if (this.isEffectivelyVarArgs)
             {
-                setMaxParams = method.getAnnotation(ScarpetFunction.class).maxParams();
+                setMaxParams = annotation.maxParams();
                 if (setMaxParams == UNDEFINED_PARAMS)
                 {
                     throw new IllegalArgumentException("No maximum number of params specified for " + name + ", use ScarpetFunction.UNLIMITED_PARAMS for unlimited. "
@@ -237,7 +239,7 @@ public final class AnnotationParser
             }
 
             this.scarpetParamCount = this.isEffectivelyVarArgs ? -1 : this.minParams;
-            this.contextType = method.getAnnotation(ScarpetFunction.class).contextType();
+            this.contextType = annotation.contextType();
         }
 
         @Override

--- a/src/main/java/carpet/script/annotation/ScarpetFunction.java
+++ b/src/main/java/carpet/script/annotation/ScarpetFunction.java
@@ -76,6 +76,15 @@ public @interface ScarpetFunction
     int maxParams() default AnnotationParser.UNDEFINED_PARAMS;
 
     /**
+     * <p>The name of the function in Scarpet, that by default will be the method name.<p>
+     * 
+     * <p>The convention in Scarpet is to use names in snake case.</p>
+     * 
+     * @return The name for this function in Scarpet
+     */
+    String functionName() default AnnotationParser.USE_METHOD_NAME;
+
+    /**
      * <p>Defines the Context Type that will be used when evaluating arguments to annotated methods.</p>
      * 
      * <p>Note that this is not the same as the output from a {@link Context.Type} parameter, since that returns the Context Type the method was


### PR DESCRIPTION
Java methods look weird in snake case, this allows annotated methods for the annotation api to have the name of the scarpet function defined in the `@ScarpetFunction` annotation, so their Java name can be different to the one that will be exposed to Scarpet code.