### PR TITLE
Fixed AnnotationParser not detecting USE_METHOD_NAME

### DIFF
--- a/src/main/java/carpet/script/annotation/AnnotationParser.java
+++ b/src/main/java/carpet/script/annotation/AnnotationParser.java
@@ -174,7 +174,7 @@ public final class AnnotationParser
         private ParsedFunction(Method method, Class<?> originClass, Supplier<Object> instance)
         {
             ScarpetFunction annotation = method.getAnnotation(ScarpetFunction.class);
-            this.name = annotation.functionName() == USE_METHOD_NAME ? method.getName() : annotation.functionName();
+            this.name = USE_METHOD_NAME.equals(annotation.functionName()) ? method.getName() : annotation.functionName();
             this.isMethodVarArgs = method.isVarArgs();
             this.methodParamCount = method.getParameterCount();
 


### PR DESCRIPTION
(This was introduced in cc24f79d47ef260be12a4ca583186ea12907cfdc)

When specifying no function name in the Annotation, the equality check here seems to fail, making the function name actually become `$METHOD_NAME_MARKER$`, breaking extensions that use that Annotation.

https://github.com/gnembon/fabric-carpet/blob/cc24f79d47ef260be12a4ca583186ea12907cfdc/src/main/java/carpet/script/annotation/AnnotationParser.java#L177

I'm not exactly sure why that fails, since it should be the exact same string literal, but i did check with `System.identityHashCode()`, and they returned different numbers.

This simply replaces that with `USE_METHOD_NAME.equals(annotation.functionName())`