### PR TITLE
Cleanup to the `/player` command

### DIFF
--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -131,10 +131,7 @@ public class PlayerCommand
                 .then(literal("mainhand").executes(manipulation(ap -> ap.drop(-1, dropAll))))
                 .then(literal("offhand").executes(manipulation(ap -> ap.drop(40, dropAll))))
                 .then(argument("slot", IntegerArgumentType.integer(0, 40)).
-                        executes(c -> manipulate(c, ap -> ap.drop(
-                                IntegerArgumentType.getInteger(c, "slot"),
-                                dropAll
-                        ))));
+                        executes(c -> manipulate(c, ap -> ap.drop(IntegerArgumentType.getInteger(c, "slot"), dropAll))));
     }
 
     private static Collection<String> getPlayerSuggestions(CommandSourceStack source)

--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -46,11 +46,10 @@ import static net.minecraft.commands.SharedSuggestionProvider.suggest;
 
 public class PlayerCommand
 {
-
     // TODO: allow any order like execute
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext commandBuildContext)
     {
-        LiteralArgumentBuilder<CommandSourceStack> literalargumentbuilder = literal("player")
+        LiteralArgumentBuilder<CommandSourceStack> command = literal("player")
                 .requires((player) -> CommandHelper.canUseCommand(player, CarpetSettings.commandPlayer))
                 .then(argument("player", StringArgumentType.word())
                         .suggests((c, b) -> suggest(getPlayerSuggestions(c.getSource()), b))
@@ -112,7 +111,7 @@ public class PlayerCommand
                                 ))
                         )
                 );
-        dispatcher.register(literalargumentbuilder);
+        dispatcher.register(command);
     }
 
     private static LiteralArgumentBuilder<CommandSourceStack> makeActionCommand(String actionName, ActionType type)

--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -80,7 +80,8 @@ public class PlayerCommand
                                 .then(literal("west").executes(manipulation(ap -> ap.look(Direction.WEST))))
                                 .then(literal("up").executes(manipulation(ap -> ap.look(Direction.UP))))
                                 .then(literal("down").executes(manipulation(ap -> ap.look(Direction.DOWN))))
-                                .then(literal("at").then(argument("position", Vec3Argument.vec3()).executes(PlayerCommand::lookAt)))
+                                .then(literal("at").then(argument("position", Vec3Argument.vec3())
+                                        .executes(c -> manipulate(c, ap -> ap.lookAt(Vec3Argument.getVec3(c, "position"))))))
                                 .then(argument("direction", RotationArgument.rotation())
                                         .executes(c -> manipulate(c, ap -> ap.look(RotationArgument.getRotation(c, "direction").getRotation(c.getSource())))))
                         ).then(literal("turn")
@@ -227,11 +228,6 @@ public class PlayerCommand
         return 1;
     }
 
-    private static int lookAt(CommandContext<CommandSourceStack> context)
-    {
-        return manipulate(context, ap -> ap.lookAt(Vec3Argument.getVec3(context, "position")));
-    }
-
     @FunctionalInterface
     interface SupplierWithCSE<T>
     {
@@ -288,7 +284,7 @@ public class PlayerCommand
             flying = false;
         }
         String playerName = StringArgumentType.getString(context, "player");
-        if (playerName.length() > maxPlayerLength(source.getServer()))
+        if (playerName.length() > maxNameLength(source.getServer()))
         {
             Messenger.m(source, "rb Player name: " + playerName + " is too long");
             return 0;
@@ -310,7 +306,7 @@ public class PlayerCommand
         return 1;
     }
 
-    private static int maxPlayerLength(MinecraftServer server)
+    private static int maxNameLength(MinecraftServer server)
     {
         return server.getPort() >= 0 ? 16 : 40;
     }

--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -116,11 +116,11 @@ public class PlayerCommand
     private static LiteralArgumentBuilder<CommandSourceStack> makeActionCommand(String actionName, EntityPlayerActionPack.ActionType type)
     {
         return literal(actionName)
-                .executes(c -> action(c, type, EntityPlayerActionPack.Action.once()))
-                .then(literal("once").executes(c -> action(c, type, EntityPlayerActionPack.Action.once())))
-                .then(literal("continuous").executes(c -> action(c, type, EntityPlayerActionPack.Action.continuous())))
+                .executes(manipulation(ap -> ap.start(type, EntityPlayerActionPack.Action.once())))
+                .then(literal("once").executes(manipulation(ap -> ap.start(type, EntityPlayerActionPack.Action.once()))))
+                .then(literal("continuous").executes(manipulation(ap -> ap.start(type, EntityPlayerActionPack.Action.continuous()))))
                 .then(literal("interval").then(argument("ticks", IntegerArgumentType.integer(1))
-                        .executes(c -> action(c, type, EntityPlayerActionPack.Action.interval(IntegerArgumentType.getInteger(c, "ticks"))))));
+                        .executes(c -> manipulate(c, ap -> ap.start(type, EntityPlayerActionPack.Action.interval(IntegerArgumentType.getInteger(c, "ticks")))))));
     }
 
     private static LiteralArgumentBuilder<CommandSourceStack> makeDropCommand(String actionName, boolean dropAll)
@@ -322,11 +322,6 @@ public class PlayerCommand
     private static Command<CommandSourceStack> manipulation(Consumer<EntityPlayerActionPack> action)
     {
         return c -> manipulate(c, action);
-    }
-
-    private static int action(CommandContext<CommandSourceStack> context, EntityPlayerActionPack.ActionType type, EntityPlayerActionPack.Action action)
-    {
-        return manipulate(context, ap -> ap.start(type, action));
     }
 
     private static int shadow(CommandContext<CommandSourceStack> context)

--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -288,13 +288,12 @@ public class PlayerCommand
             return 0;
         }
 
-        MinecraftServer server = source.getServer();
         if (!Level.isInSpawnableBounds(BlockPos.containing(pos.x, pos.y, pos.z)))
         {
             Messenger.m(source, "rb Player " + playerName + " cannot be placed outside of the world");
             return 0;
         }
-        Player player = EntityPlayerMPFake.createFake(playerName, server, pos.x, pos.y, pos.z, facing.y, facing.x, dimType, mode, flying);
+        Player player = EntityPlayerMPFake.createFake(playerName, source.getServer(), pos, facing.y, facing.x, dimType, mode, flying);
         if (player == null)
         {
             Messenger.m(source, "rb Player " + playerName + " doesn't exist and cannot spawn in online mode. " +

--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -1,6 +1,8 @@
 package carpet.commands;
 
 import carpet.helpers.EntityPlayerActionPack;
+import carpet.helpers.EntityPlayerActionPack.Action;
+import carpet.helpers.EntityPlayerActionPack.ActionType;
 import carpet.CarpetSettings;
 import carpet.fakes.ServerPlayerInterface;
 import carpet.patches.EntityPlayerMPFake;
@@ -53,14 +55,14 @@ public class PlayerCommand
                 .then(argument("player", StringArgumentType.word())
                         .suggests((c, b) -> suggest(getPlayerSuggestions(c.getSource()), b))
                         .then(literal("stop").executes(manipulation(EntityPlayerActionPack::stopAll)))
-                        .then(makeActionCommand("use", EntityPlayerActionPack.ActionType.USE))
-                        .then(makeActionCommand("jump", EntityPlayerActionPack.ActionType.JUMP))
-                        .then(makeActionCommand("attack", EntityPlayerActionPack.ActionType.ATTACK))
-                        .then(makeActionCommand("drop", EntityPlayerActionPack.ActionType.DROP_ITEM))
+                        .then(makeActionCommand("use", ActionType.USE))
+                        .then(makeActionCommand("jump", ActionType.JUMP))
+                        .then(makeActionCommand("attack", ActionType.ATTACK))
+                        .then(makeActionCommand("drop", ActionType.DROP_ITEM))
                         .then(makeDropCommand("drop", false))
-                        .then(makeActionCommand("dropStack", EntityPlayerActionPack.ActionType.DROP_STACK))
+                        .then(makeActionCommand("dropStack", ActionType.DROP_STACK))
                         .then(makeDropCommand("dropStack", true))
-                        .then(makeActionCommand("swapHands", EntityPlayerActionPack.ActionType.SWAP_HANDS))
+                        .then(makeActionCommand("swapHands", ActionType.SWAP_HANDS))
                         .then(literal("hotbar")
                                 .then(argument("slot", IntegerArgumentType.integer(1, 9))
                                         .executes(c -> manipulate(c, ap -> ap.setSlot(IntegerArgumentType.getInteger(c, "slot"))))))
@@ -113,14 +115,14 @@ public class PlayerCommand
         dispatcher.register(literalargumentbuilder);
     }
 
-    private static LiteralArgumentBuilder<CommandSourceStack> makeActionCommand(String actionName, EntityPlayerActionPack.ActionType type)
+    private static LiteralArgumentBuilder<CommandSourceStack> makeActionCommand(String actionName, ActionType type)
     {
         return literal(actionName)
-                .executes(manipulation(ap -> ap.start(type, EntityPlayerActionPack.Action.once())))
-                .then(literal("once").executes(manipulation(ap -> ap.start(type, EntityPlayerActionPack.Action.once()))))
-                .then(literal("continuous").executes(manipulation(ap -> ap.start(type, EntityPlayerActionPack.Action.continuous()))))
+                .executes(manipulation(ap -> ap.start(type, Action.once())))
+                .then(literal("once").executes(manipulation(ap -> ap.start(type, Action.once()))))
+                .then(literal("continuous").executes(manipulation(ap -> ap.start(type, Action.continuous()))))
                 .then(literal("interval").then(argument("ticks", IntegerArgumentType.integer(1))
-                        .executes(c -> manipulate(c, ap -> ap.start(type, EntityPlayerActionPack.Action.interval(IntegerArgumentType.getInteger(c, "ticks")))))));
+                        .executes(c -> manipulate(c, ap -> ap.start(type, Action.interval(IntegerArgumentType.getInteger(c, "ticks")))))));
     }
 
     private static LiteralArgumentBuilder<CommandSourceStack> makeDropCommand(String actionName, boolean dropAll)

--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -305,7 +305,7 @@ public class PlayerCommand
 
     private static int maxNameLength(MinecraftServer server)
     {
-        return server.getPort() >= 0 ? 16 : 40;
+        return server.getPort() >= 0 ? Player.MAX_NAME_LENGTH : 40;
     }
 
     private static int manipulate(CommandContext<CommandSourceStack> context, Consumer<EntityPlayerActionPack> action)

--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -288,7 +288,7 @@ public class PlayerCommand
             return 0;
         }
 
-        if (!Level.isInSpawnableBounds(BlockPos.containing(pos.x, pos.y, pos.z)))
+        if (!Level.isInSpawnableBounds(BlockPos.containing(pos)))
         {
             Messenger.m(source, "rb Player " + playerName + " cannot be placed outside of the world");
             return 0;

--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -253,13 +253,14 @@ public class PlayerCommand
     private static int spawn(CommandContext<CommandSourceStack> context) throws CommandSyntaxException
     {
         if (cantSpawn(context)) return 0;
+
         CommandSourceStack source = context.getSource();
         Vec3 pos = getArgOrDefault(
                 () -> Vec3Argument.getVec3(context, "position"),
                 source.getPosition()
         );
         Vec2 facing = getArgOrDefault(
-                () -> RotationArgument.getRotation(context, "direction").getRotation(context.getSource()),
+                () -> RotationArgument.getRotation(context, "direction").getRotation(source),
                 source.getRotation()
         );
         ResourceKey<Level> dimType = getArgOrDefault(
@@ -268,10 +269,10 @@ public class PlayerCommand
         );
         GameType mode = GameType.CREATIVE;
         boolean flying = false;
-        if (context.getSource().getEntity() instanceof ServerPlayer player)
+        if (source.getEntity() instanceof ServerPlayer sender)
         {
-            mode = player.gameMode.getGameModeForPlayer();
-            flying = player.getAbilities().flying;
+            mode = sender.gameMode.getGameModeForPlayer();
+            flying = sender.getAbilities().flying;
         }
         try {
             mode = GameModeArgument.getGameMode(context, "gamemode");
@@ -289,20 +290,20 @@ public class PlayerCommand
         String playerName = StringArgumentType.getString(context, "player");
         if (playerName.length() > maxPlayerLength(source.getServer()))
         {
-            Messenger.m(context.getSource(), "rb Player name: "+playerName+" is too long");
+            Messenger.m(source, "rb Player name: " + playerName + " is too long");
             return 0;
         }
 
         MinecraftServer server = source.getServer();
         if (!Level.isInSpawnableBounds(BlockPos.containing(pos.x, pos.y, pos.z)))
         {
-            Messenger.m(context.getSource(), "rb Player "+playerName+" cannot be placed outside of the world");
+            Messenger.m(source, "rb Player " + playerName + " cannot be placed outside of the world");
             return 0;
         }
         Player player = EntityPlayerMPFake.createFake(playerName, server, pos.x, pos.y, pos.z, facing.y, facing.x, dimType, mode, flying);
         if (player == null)
         {
-            Messenger.m(context.getSource(), "rb Player " + playerName + " doesn't exist and cannot spawn in online mode. " +
+            Messenger.m(source, "rb Player " + playerName + " doesn't exist and cannot spawn in online mode. " +
                     "Turn the server offline to spawn non-existing players");
             return 0;
         }

--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -26,6 +26,7 @@ import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.SkullBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
 import carpet.fakes.ServerPlayerInterface;
 import carpet.utils.Messenger;
 
@@ -37,7 +38,7 @@ public class EntityPlayerMPFake extends ServerPlayer
     public Runnable fixStartingPosition = () -> {};
     public boolean isAShadow;
 
-    public static EntityPlayerMPFake createFake(String username, MinecraftServer server, double d0, double d1, double d2, double yaw, double pitch, ResourceKey<Level> dimensionId, GameType gamemode, boolean flying)
+    public static EntityPlayerMPFake createFake(String username, MinecraftServer server, Vec3 pos, double yaw, double pitch, ResourceKey<Level> dimensionId, GameType gamemode, boolean flying)
     {
         //prolly half of that crap is not necessary, but it works
         ServerLevel worldIn = server.getLevel(dimensionId);
@@ -65,9 +66,9 @@ public class EntityPlayerMPFake extends ServerPlayer
             gameprofile = result.get();
         }
         EntityPlayerMPFake instance = new EntityPlayerMPFake(server, worldIn, gameprofile, false);
-        instance.fixStartingPosition = () -> instance.moveTo(d0, d1, d2, (float) yaw, (float) pitch);
+        instance.fixStartingPosition = () -> instance.moveTo(pos.x, pos.y, pos.z, (float) yaw, (float) pitch);
         server.getPlayerList().placeNewPlayer(new FakeClientConnection(PacketFlow.SERVERBOUND), instance);
-        instance.teleportTo(worldIn, d0, d1, d2, (float)yaw, (float)pitch);
+        instance.teleportTo(worldIn, pos.x, pos.y, pos.z, (float) yaw, (float) pitch);
         instance.setHealth(20.0F);
         instance.unsetRemoved();
         instance.setMaxUpStep(0.6F);


### PR DESCRIPTION
There should be no changes to users.

Changes:
- Use `GameModeArgument` instead of a String with suggestions
- Refactor unnecessary exceptional control flow
- Rename `SupplierWithCommandSyntaxException`
- Rename `tryGetArg` to `getArgOrDefault`
- Don't use supplier for default in `getOrDefault`
- Inline some methods that were the same as a general method just with a specific param
- Use lambda-creating `manipulate` function when possible
- Remove/move some unnecessary checks
- Minor renames to variables to make them clearer

Pending (about argument):
- [x] Testing that the gamemode argument syncs correctly with carpetless clients (quite sure it should)
- [x] ~Ensure network compatibility with older carpet versions~ Now that I remember, server controls command arguments