### PR TITLE
Random cleanups to users of Level.OVERWORLD and reduce `minecraft_server` usage

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -812,7 +812,7 @@ public class CarpetSettings
     public static class ChangeSpawnChunksValidator extends Validator<Integer> {
         public static void changeSpawnSize(int size)
         {
-            ServerLevel overworld = CarpetServer.minecraft_server.getLevel(Level.OVERWORLD); // OW
+            ServerLevel overworld = CarpetServer.minecraft_server.overworld();
             if (overworld != null) {
                 ChunkPos centerChunk = new ChunkPos(new BlockPos(
                         overworld.getLevelData().getXSpawn(),
@@ -834,8 +834,7 @@ public class CarpetSettings
                 //must been some startup thing
                 return newValue;
             }
-            if (CarpetServer.minecraft_server == null) return newValue;
-            ServerLevel currentOverworld = CarpetServer.minecraft_server.getLevel(Level.OVERWORLD); // OW
+            ServerLevel currentOverworld = source.getServer().overworld();
             if (currentOverworld != null)
             {
                 changeSpawnSize(newValue);

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -32,7 +32,6 @@ import net.minecraft.world.level.border.WorldBorder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Iterator;
 import java.util.Optional;
 
 import static carpet.api.settings.RuleCategory.BUGFIX;
@@ -839,14 +838,11 @@ public class CarpetSettings
     public static int spawnChunksSize = MinecraftServer.START_CHUNK_RADIUS;
 
     public static class LightBatchValidator extends Validator<Integer> {
-        public static void applyLightBatchSizes(int maxBatchSize)
+        public static void applyLightBatchSizes(MinecraftServer server, int maxBatchSize)
         {
-            Iterator<ServerLevel> iterator = CarpetServer.minecraft_server.getAllLevels().iterator();
-            
-            while (iterator.hasNext()) 
+            for (ServerLevel world : server.getAllLevels())
             {
-                ServerLevel serverWorld = iterator.next();
-                serverWorld.getChunkSource().getLightEngine().setTaskPerBatch(maxBatchSize);
+                world.getChunkSource().getLightEngine().setTaskPerBatch(maxBatchSize);
             }
         }
         @Override public Integer validate(CommandSourceStack source, CarpetRule<Integer> currentRule, Integer newValue, String string) {
@@ -861,9 +857,8 @@ public class CarpetSettings
                 //must been some startup thing
                 return newValue;
             }
-            if (CarpetServer.minecraft_server == null) return newValue;
             
-            applyLightBatchSizes(newValue); // Apply new settings
+            applyLightBatchSizes(source.getServer(), newValue); // Apply new settings
             
             return newValue;
         }

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -12,7 +12,6 @@ import carpet.utils.Messenger;
 import carpet.utils.SpawnChunks;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
@@ -21,7 +20,6 @@ import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -810,18 +808,6 @@ public class CarpetSettings
     public static int simulationDistance = 0;
 
     public static class ChangeSpawnChunksValidator extends Validator<Integer> {
-        public static void changeSpawnSize(int size)
-        {
-            ServerLevel overworld = CarpetServer.minecraft_server.overworld();
-            if (overworld != null) {
-                ChunkPos centerChunk = new ChunkPos(new BlockPos(
-                        overworld.getLevelData().getXSpawn(),
-                        overworld.getLevelData().getYSpawn(),
-                        overworld.getLevelData().getZSpawn()
-                ));
-                SpawnChunks.changeSpawnChunks(overworld.getChunkSource(), centerChunk, size);
-            }
-        }
         @Override public Integer validate(CommandSourceStack source, CarpetRule<Integer> currentRule, Integer newValue, String string) {
             if (source == null) return newValue;
             if (newValue < 0 || newValue > 32)
@@ -837,7 +823,7 @@ public class CarpetSettings
             ServerLevel currentOverworld = source.getServer().overworld();
             if (currentOverworld != null)
             {
-                changeSpawnSize(newValue);
+                SpawnChunks.changeSpawnSize(currentOverworld, newValue);
             }
             return newValue;
         }

--- a/src/main/java/carpet/mixins/MinecraftServer_coreMixin.java
+++ b/src/main/java/carpet/mixins/MinecraftServer_coreMixin.java
@@ -3,9 +3,12 @@ package carpet.mixins;
 import carpet.CarpetServer;
 import carpet.CarpetSettings;
 import carpet.utils.CarpetProfiler;
+import carpet.utils.SpawnChunks;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.progress.ChunkProgressListener;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -56,11 +59,14 @@ public abstract class MinecraftServer_coreMixin
         CarpetServer.onServerDoneClosing((MinecraftServer) (Object) this);
     }
 
+    @Shadow
+    public abstract ServerLevel overworld();
+
     @Inject(method = "prepareLevels", at = @At("RETURN"))
     private void afterSpawnCreated(ChunkProgressListener worldGenerationProgressListener, CallbackInfo ci)
     {
         if (CarpetSettings.spawnChunksSize != 11)
-            CarpetSettings.ChangeSpawnChunksValidator.changeSpawnSize(CarpetSettings.spawnChunksSize);
+            SpawnChunks.changeSpawnSize(overworld(), CarpetSettings.spawnChunksSize);
         
         CarpetSettings.LightBatchValidator.applyLightBatchSizes(CarpetSettings.lightEngineMaxBatchSize);
     }

--- a/src/main/java/carpet/mixins/MinecraftServer_coreMixin.java
+++ b/src/main/java/carpet/mixins/MinecraftServer_coreMixin.java
@@ -68,6 +68,6 @@ public abstract class MinecraftServer_coreMixin
         if (CarpetSettings.spawnChunksSize != 11)
             SpawnChunks.changeSpawnSize(overworld(), CarpetSettings.spawnChunksSize);
         
-        CarpetSettings.LightBatchValidator.applyLightBatchSizes(CarpetSettings.lightEngineMaxBatchSize);
+        CarpetSettings.LightBatchValidator.applyLightBatchSizes((MinecraftServer) (Object) this, CarpetSettings.lightEngineMaxBatchSize);
     }
 }

--- a/src/main/java/carpet/mixins/ServerPlayer_scarpetEventMixin.java
+++ b/src/main/java/carpet/mixins/ServerPlayer_scarpetEventMixin.java
@@ -110,7 +110,7 @@ public abstract class ServerPlayer_scarpetEventMixin extends Player implements S
         {
             ServerPlayer player = (ServerPlayer) (Object)this;
             Vec3 to = null;
-            if (!wonGame || previousDimension != Level.END || destination.dimension() != Level.OVERWORLD) // end ow
+            if (!wonGame || previousDimension != Level.END || destination.dimension() != Level.OVERWORLD)
             {
                 to = position();
             }

--- a/src/main/java/carpet/script/CarpetEventServer.java
+++ b/src/main/java/carpet/script/CarpetEventServer.java
@@ -447,9 +447,7 @@ public class CarpetEventServer
             @Override
             public void onTick(MinecraftServer server)
             {
-                handler.call(Collections::emptyList, () ->
-                        server.createCommandSourceStack().withLevel(server.getLevel(Level.OVERWORLD))
-                );
+                handler.call(Collections::emptyList, server::createCommandSourceStack);
             }
         };
 
@@ -458,9 +456,7 @@ public class CarpetEventServer
             @Override
             public void onTick(MinecraftServer server)
             {
-                handler.call(Collections::emptyList, () ->
-                        server.createCommandSourceStack().withLevel(server.getLevel(Level.OVERWORLD))
-                );
+            handler.call(Collections::emptyList,server::createCommandSourceStack);
             }
         };
 
@@ -469,9 +465,7 @@ public class CarpetEventServer
             @Override
             public void onTick(MinecraftServer server)
             {
-                handler.call(Collections::emptyList, () ->
-                        server.createCommandSourceStack().withLevel(server.getLevel(Level.OVERWORLD))
-                );
+            handler.call(Collections::emptyList,server::createCommandSourceStack);
             }
         };
         public static final Event NETHER_TICK = new Event("tick_nether", 0, true)

--- a/src/main/java/carpet/utils/Messenger.java
+++ b/src/main/java/carpet/utils/Messenger.java
@@ -1,7 +1,6 @@
 package carpet.utils;
 
 import net.minecraft.ChatFormatting;
-import net.minecraft.Util;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
@@ -13,7 +12,6 @@ import net.minecraft.network.chat.TextColor;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -233,7 +231,7 @@ public class Messenger
     public static void m(CommandSourceStack source, Object ... fields)
     {
         if (source != null)
-            source.sendSuccess(Messenger.c(fields),source.getServer() != null && source.getServer().getLevel(Level.OVERWORLD) != null); //OW
+            source.sendSuccess(Messenger.c(fields), source.getServer() != null && source.getServer().overworld() != null); // OW
     }
     public static void m(Player player, Object ... fields)
     {

--- a/src/main/java/carpet/utils/Messenger.java
+++ b/src/main/java/carpet/utils/Messenger.java
@@ -160,7 +160,7 @@ public class Messenger
     }
     public static Component tp(String desc, int x, int y, int z)
     {
-        return getCoordsTextComponent(desc, (float)x, (float)y, (float)z, true);
+        return getCoordsTextComponent(desc, x, y, z, true);
     }
 
     /// to be continued
@@ -231,7 +231,7 @@ public class Messenger
     public static void m(CommandSourceStack source, Object ... fields)
     {
         if (source != null)
-            source.sendSuccess(Messenger.c(fields), source.getServer() != null && source.getServer().overworld() != null); // OW
+            source.sendSuccess(Messenger.c(fields), source.getServer() != null && source.getServer().overworld() != null);
     }
     public static void m(Player player, Object ... fields)
     {

--- a/src/main/java/carpet/utils/SpawnChunks.java
+++ b/src/main/java/carpet/utils/SpawnChunks.java
@@ -1,15 +1,23 @@
 package carpet.utils;
 
 import carpet.fakes.ChunkTicketManagerInterface;
+import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.DistanceManager;
-import net.minecraft.server.level.ServerChunkCache;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 
 public class SpawnChunks
 {
-    public static void changeSpawnChunks(ServerChunkCache chunkManager, ChunkPos pos, int size)
+    public static void changeSpawnSize(ServerLevel overworld, int size)
     {
-        DistanceManager ticketManager = chunkManager.chunkMap.getDistanceManager();
-        ((ChunkTicketManagerInterface)ticketManager).changeSpawnChunks(pos, size);
+        assert overworld != null : "Overworld must not be null";
+        assert overworld == overworld.getServer().overworld() : "Given world isn't overworld";
+        ChunkPos centerChunk = new ChunkPos(new BlockPos(
+                overworld.getLevelData().getXSpawn(),
+                overworld.getLevelData().getYSpawn(),
+                overworld.getLevelData().getZSpawn()
+        ));
+        DistanceManager ticketManager = overworld.getChunkSource().chunkMap.getDistanceManager();
+        ((ChunkTicketManagerInterface)ticketManager).changeSpawnChunks(centerChunk, size);
     }
 }

--- a/src/main/java/carpet/utils/SpawnChunks.java
+++ b/src/main/java/carpet/utils/SpawnChunks.java
@@ -10,8 +10,6 @@ public class SpawnChunks
 {
     public static void changeSpawnSize(ServerLevel overworld, int size)
     {
-        assert overworld != null : "Overworld must not be null";
-        assert overworld == overworld.getServer().overworld() : "Given world isn't overworld";
         ChunkPos centerChunk = new ChunkPos(new BlockPos(
                 overworld.getLevelData().getXSpawn(),
                 overworld.getLevelData().getYSpawn(),


### PR DESCRIPTION
- Use `overworld()` instead of `getLevel(Level.OVERWORLD)` when convenient
- Remove now unnecessary `// OW` comments, from when it had no mappings
- Make spawn chunk size and light batches not depend on global server instance
- Merge all spawn chunk size logic into SpawnChunks instead of methods in the validator
- Remove unneeded `withWorld(OVERWORLD)` with just-created server `CommandSource`s
- Use enhanced for in light batch application