### PR TITLE
Fix integer operation results being downcasted to floating point

### DIFF
--- a/src/main/java/carpet/script/language/Sys.java
+++ b/src/main/java/carpet/script/language/Sys.java
@@ -55,7 +55,7 @@ public class Sys
         {
             if (v instanceof final NumericValue num)
             {
-                return new NumericValue(num.isInteger() ? num.getLong() : num.getDouble());
+                return num.clone();
             }
             if (v instanceof ListValue || v instanceof MapValue)
             {

--- a/src/main/java/carpet/script/value/NumericValue.java
+++ b/src/main/java/carpet/script/value/NumericValue.java
@@ -131,7 +131,7 @@ public class NumericValue extends Value
     {  // TODO test if definintn add(NumericVlaue) woud solve the casting
         if (v instanceof final NumericValue nv)
         {
-            return new NumericValue(longValue != null && nv.longValue != null ? (longValue + nv.longValue) : (value + nv.value));
+            return longValue != null && nv.longValue != null ? new NumericValue(longValue + nv.longValue) : new NumericValue(value + nv.value);
         }
         return super.add(v);
     }
@@ -141,7 +141,7 @@ public class NumericValue extends Value
     {  // TODO test if definintn add(NumericVlaue) woud solve the casting
         if (v instanceof final NumericValue nv)
         {
-            return new NumericValue(longValue != null && nv.longValue != null ? (longValue - nv.longValue) : (value - nv.value));
+            return longValue != null && nv.longValue != null ? new NumericValue(longValue - nv.longValue) : new NumericValue(value - nv.value);
         }
         return super.subtract(v);
     }
@@ -151,7 +151,7 @@ public class NumericValue extends Value
     {
         if (v instanceof final NumericValue nv)
         {
-            return new NumericValue(longValue != null && nv.longValue != null ? (longValue * nv.longValue) : (value * nv.value));
+            return longValue != null && nv.longValue != null ? new NumericValue(longValue * nv.longValue) : new NumericValue(value * nv.value);
         }
         return v instanceof ListValue ? v.multiply(this) : new StringValue(StringUtils.repeat(v.getString(), (int) getLong()));
     }
@@ -303,13 +303,12 @@ public class NumericValue extends Value
         {
             return new JsonPrimitive(longValue);
         }
-        long lv = getLong();
-        return new JsonPrimitive(value == lv ? getLong() : value);
+        return isInteger() ? new JsonPrimitive(getLong()) : new JsonPrimitive(getDouble());
     }
 
     public NumericValue opposite()
     {
-        return new NumericValue(longValue != null ? -longValue : -value);
+        return longValue != null ? new NumericValue(-longValue) : new NumericValue(-value);
     }
 
     public boolean isInteger()


### PR DESCRIPTION
Fixes #1716.

This happens because when doing `NumericValue({thing})`, Java can only choose one constructor to call. Given `double` is "wider" than `long` (it covers both integers and decimals), and it has both of these as possible arguments and can implicitly convert `long`->`double`, Java will consider that a call to `NumericValue(double)` and will cast the `long` to a `double` in the ternary to match the call.

Worth backporting to 1.19.4 imo. Looking for whether there's more stuff we should backport.

Supersedes #1715. Found by @manyrandomthings there from a report on Discord.