### PR TITLE
Add modrinth link to Discord release message

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -144,6 +144,7 @@ jobs:
            ${{ github.event.release.body }}
            ​
            Get it on Github Releases: <${{ github.event.release.html_url }}>
+           On Modrinth: <https://modrinth.com/mod/carpet/version/${{ github.event.release.tag_name }}>
            Or on CurseForge
   Merge-Scarpet-Docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since the [tag names](https://github.com/gnembon/fabric-carpet/tags) for carpet match the exact URL part needed to create a modrinth version URL I thought this may be useful for those of us preferring to download from there.