### PR TITLE
Simplify and fix some issues in `/script` command registration

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -498,7 +498,7 @@ public class CarpetSettings
             extra = "An in-game scripting API for Scarpet programming language",
             category = {COMMAND, SCARPET}
     )
-    public static String commandScript = "true";
+    public static String commandScript = "ops";
 
     private static class ModulePermissionLevel extends Validator<String> {
         @Override public String validate(CommandSourceStack source, CarpetRule<String> currentRule, String newValue, String string) {


### PR DESCRIPTION
This PR refactors the `/script` command registration a bit, mostly to make it more clear when adding to brigadier and to fix some issues with it.

Summary of changes:
- `/script in <app>` will no longer silently use the default host when `app` isn't valid, but instead will fail
- Global `/script` actions such as `stop` or `resume` will no longer be repeated under each `/script in <app>`
- Suggestion initialization will no longer sort on insert but at the end, and will then use unmodifiable collections
- Hides `/script download` if app store is completely disabled
- Simplifies permissions: Now the whole `/script` is under the same rule
- No longer stores all individual subcommands in variables with meaningless names, but uses the typical fluent API of brigadier
- Removes unnecessary `Stream`->`List` conversions for some suggestions
- Makes all methods in multiline chains consistently have the dot at the start of the line instead of at the end of the previous one to prevent confusion with direct method calls

There may be more changes I've missed given most of this has been in a git stash for a while, though I think I got them all.