### PR TITLE
Add option to configure listing fake players on the multiplayer screen

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -597,6 +597,9 @@ public class CarpetSettings
     @Rule(desc = "Spawn offline players in online mode if online-mode player with specified name does not exist", category = COMMAND)
     public static boolean allowSpawningOfflinePlayers = true;
 
+    @Rule(desc = "Allows listing fake players on the multiplayer screen", category = COMMAND)
+    public static boolean allowListingFakePlayers = true;
+
     @Rule(desc = "Allows to track mobs AI via /track command", category = COMMAND)
     public static String commandTrackAI = "ops";
 

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -598,7 +598,7 @@ public class CarpetSettings
     public static boolean allowSpawningOfflinePlayers = true;
 
     @Rule(desc = "Allows listing fake players on the multiplayer screen", category = COMMAND)
-    public static boolean allowListingFakePlayers = true;
+    public static boolean allowListingFakePlayers = false;
 
     @Rule(desc = "Allows to track mobs AI via /track command", category = COMMAND)
     public static String commandTrackAI = "ops";

--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -191,6 +191,11 @@ public class EntityPlayerMPFake extends ServerPlayer
     }
 
     @Override
+    public boolean allowsListing() {
+        return CarpetSettings.allowListingFakePlayers;
+    }
+
+    @Override
     protected void checkFallDamage(double y, boolean onGround, BlockState state, BlockPos pos) {
         doCheckFallDamage(0.0, y, 0.0, onGround);
     }


### PR DESCRIPTION
This adds a new Carpet option (`allowListingFakePlayers`) that configures whether fake/bot players are displayed on a player list on the multiplayer screen. When this option is disabled, all fake players will be listed as "Anonymous Player". This fixes #1749.

Previously, this option was always enabled, so fake players were also always displayed on the list. However, recently (I think in `1.20-pre1`), Minecraft changed the internal option to be `false` by default, so fake players are now listed as anonymous. With this PR, the behaviour can now be configured by users.

~~I set `true` as default because this was the old behaviour (until recently). However, I can change it to `false` by default if needed.~~ Now it's `false` by default.