### PR TITLE
Fix golem spawning range box in ai-tracker

### DIFF
--- a/src/main/resources/assets/carpet/scripts/ai_tracker.sc
+++ b/src/main/resources/assets/carpet/scripts/ai_tracker.sc
@@ -35,7 +35,7 @@ global_functions = {
             villager_height = e~'height';
             __create_box(abnoxious_visuals, e,
                   [-8,-6,-8],
-                  [8,7,8],
+                  [9,7,9],
                   0x00dd0000, 'golem spawning', true
             );
             __create_box(abnoxious_visuals, e,


### PR DESCRIPTION
As per comments in #1760, box for iron golem spawning range is currently being drawn 1 short in +X and +Z.

Fixes #1760.
