### PR TITLE
Remove `lightEngineMaxBatchSize` rule

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -863,43 +863,6 @@ public class CarpetSettings
     )
     public static int spawnChunksSize = MinecraftServer.START_CHUNK_RADIUS;
 
-    public static class LightBatchValidator extends Validator<Integer> {
-        public static void applyLightBatchSizes(MinecraftServer server, int maxBatchSize)
-        {
-            for (ServerLevel world : server.getAllLevels())
-            {
-                //world.getChunkSource().getLightEngine().setTaskPerBatch(maxBatchSize);
-            }
-        }
-        @Override public Integer validate(CommandSourceStack source, CarpetRule<Integer> currentRule, Integer newValue, String string) {
-            if (source == null) return newValue;
-            if (newValue < 0)
-            {
-                Messenger.m(source, "r light batch size has to be at least 0");
-                return null;
-            }
-            if (currentRule.value().intValue() == newValue.intValue())
-            {
-                //must been some startup thing
-                return newValue;
-            }
-            
-            applyLightBatchSizes(source.getServer(), newValue); // Apply new settings
-            
-            return newValue;
-        }
-    }
-    
-    @Rule(
-            desc = "Changes maximum light tasks batch size",
-            extra = {"Allows for a higher light suppression tolerance", "setting it to 5 - Default limit defined by the game"},
-            category = {EXPERIMENTAL, OPTIMIZATION},
-            strict = false,
-            options = {"5", "50", "100", "200"},
-            validate = LightBatchValidator.class
-    )
-    public static int lightEngineMaxBatchSize = 5;
-
     public enum RenewableCoralMode {
         FALSE,
         EXPANDED,

--- a/src/main/java/carpet/mixins/MinecraftServer_coreMixin.java
+++ b/src/main/java/carpet/mixins/MinecraftServer_coreMixin.java
@@ -67,7 +67,5 @@ public abstract class MinecraftServer_coreMixin
     {
         if (CarpetSettings.spawnChunksSize != 11)
             SpawnChunks.changeSpawnSize(overworld(), CarpetSettings.spawnChunksSize);
-        
-        CarpetSettings.LightBatchValidator.applyLightBatchSizes((MinecraftServer) (Object) this, CarpetSettings.lightEngineMaxBatchSize);
     }
 }

--- a/src/main/resources/assets/carpet/lang/fr_fr.json
+++ b/src/main/resources/assets/carpet/lang/fr_fr.json
@@ -223,12 +223,6 @@
   // language
   "carpet.rule.language.desc": "Définit la langue pour Carpet",
   
-  // lightEngineMaxBatchSize
-  "carpet.rule.lightEngineMaxBatchSize.desc": "Modifie la taille maximale du lot de tâches d'éclairage",
-  
-  "carpet.rule.lightEngineMaxBatchSize.extra.0": "Permet une tolérance supérieure à l'extinction de la lumière",
-  "carpet.rule.lightEngineMaxBatchSize.extra.1": "en le réglant sur 5 - Limite par défaut définie par le jeu",
-  
   // lightningKillsDropsFix
   "carpet.rule.lightningKillsDropsFix.desc": "La foudre détruit les objets qui tombent lorsque la foudre tue une entité",
   

--- a/src/main/resources/assets/carpet/lang/pt_br.json
+++ b/src/main/resources/assets/carpet/lang/pt_br.json
@@ -229,12 +229,6 @@
 
   "carpet.rule.leadFix.extra.0": "Você ainda pode obter links de trela visivelmente quebrados no lado do cliente, mas no lado do servidor o link ainda está lá.",
 
-  // lightEngineMaxBatchSize
-  "carpet.rule.lightEngineMaxBatchSize.desc": "Altera o tamanho máximo do lote de tarefas leves",
-
-  "carpet.rule.lightEngineMaxBatchSize.extra.0": "Permite uma maior tolerância de supressão de luz",
-  "carpet.rule.lightEngineMaxBatchSize.extra.1": "configurando para 5 - Limite padrão definido pelo jogo",
-
   // lightningKillsDropsFix
   "carpet.rule.lightningKillsDropsFix.desc": "O relâmpago mata os itens que caem quando o relâmpago mata uma entidade",
 

--- a/src/main/resources/assets/carpet/lang/zh_tw.json
+++ b/src/main/resources/assets/carpet/lang/zh_tw.json
@@ -253,11 +253,6 @@
   "carpet.rule.renewableBlackstone.desc": "地獄玄武岩生成機，但在下方沒有靈魂沙",
   "carpet.rule.renewableBlackstone.extra.0": "..將會轉換成黑石",
 
-  "carpet.rule.lightEngineMaxBatchSize.name": "光照引擎最大批次大小",
-  "carpet.rule.lightEngineMaxBatchSize.desc": "更改光照引擎最大批次大小",
-  "carpet.rule.lightEngineMaxBatchSize.extra.0": "允許更高光照抑制容限",
-  "carpet.rule.lightEngineMaxBatchSize.extra.1": "設置成5-遊戲預設容限",
-
   "carpet.rule.cleanLogs.name": "清除數據追蹤器",
   "carpet.rule.cleanLogs.desc": "從數據追蹤器中刪除令人討厭的信息",
   "carpet.rule.cleanLogs.extra.0": "在'達到最大聲音對象池247'時將不再顯示",


### PR DESCRIPTION
Resolves #1711.

The rule has been soft-disabled (did nothing) since the new light engine, and the main reason this was added from what I can see is performance, that is better in the new engine.

Not only that, the new default batch size is `1000`, and the main values this rule used to be set were high values, making it seem more pointless.

This PR removes the rule. However, it wouldn't be difficult to make it usable with the new engine if still useful to someone.