### PR TITLE
Allow fake players to be `/kick`ed

### DIFF
--- a/src/main/java/carpet/patches/NetHandlerPlayServerFake.java
+++ b/src/main/java/carpet/patches/NetHandlerPlayServerFake.java
@@ -2,7 +2,6 @@ package carpet.patches;
 
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
@@ -24,10 +23,7 @@ public class NetHandlerPlayServerFake extends ServerGamePacketListenerImpl
     @Override
     public void disconnect(Component message)
     {
-        if (message.getContents() instanceof TranslatableContents text && (text.getKey().equals("multiplayer.disconnect.idling") || text.getKey().equals("multiplayer.disconnect.duplicate_login")))
-        {
-            ((EntityPlayerMPFake) player).kill(message);
-        }
+        ((EntityPlayerMPFake) player).kill(message);
     }
 
     @Override
@@ -41,6 +37,3 @@ public class NetHandlerPlayServerFake extends ServerGamePacketListenerImpl
     }
 
 }
-
-
-


### PR DESCRIPTION
Fixes #1759.

This removes all conditions for a fake player's `connection` to accept a call to `disconnect`.

From some quick testing, I can see no issues, but I don't know in what ways could disconnect be called that would be problematic, and this has been like this since the initial fabric versions.