### PR TITLE
fix-bots-for-new-networky-bits

### DIFF
--- a/src/main/java/carpet/patches/FakeClientConnection.java
+++ b/src/main/java/carpet/patches/FakeClientConnection.java
@@ -3,6 +3,7 @@ package carpet.patches;
 import carpet.fakes.ClientConnectionInterface;
 import io.netty.channel.embedded.EmbeddedChannel;
 import net.minecraft.network.Connection;
+import net.minecraft.network.PacketListener;
 import net.minecraft.network.protocol.PacketFlow;
 
 public class FakeClientConnection extends Connection
@@ -22,6 +23,11 @@ public class FakeClientConnection extends Connection
 
     @Override
     public void handleDisconnection()
+    {
+    }
+
+    @Override
+    public void setListener(PacketListener packetListener)
     {
     }
 }


### PR DESCRIPTION
* override and no-op setListener() in FakeClientConnection
* fixes error spawning bots.