### PR TITLE
Add food properties

### DIFF
--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -1,5 +1,6 @@
 package carpet.script.api;
 
+import carpet.CarpetServer;
 import carpet.script.external.Vanilla;
 import carpet.script.utils.FeatureGenerator;
 import carpet.script.argument.FileArgument;
@@ -1240,6 +1241,10 @@ public class Auxiliary
             cc.host.issueDeprecation("enable_hidden_dimensions in 1.18.2 and 1.19+");
             return Value.NULL;
         });
+
+        expression.addUnaryFunction("item_nutrition", v-> NumericValue.of(NBTSerializableValue.parseItem(v.getString(), CarpetServer.minecraft_server.registryAccess()).getItem().getFoodProperties().getNutrition()));
+        expression.addUnaryFunction("item_saturation", v-> NumericValue.of(NBTSerializableValue.parseItem(v.getString(), CarpetServer.minecraft_server.registryAccess()).getItem().getFoodProperties().getSaturationModifier()));
+
     }
 
     private static void zipValueToJson(Path path, Value output) throws IOException


### PR DESCRIPTION
Fixes #1701 
I have added what was requested in the issue, but I realised that there is currently also no way to look at a food item's food properties, so I decided to add a system_info() style thing where you can either query it for a single property, or query all of them.
This way it's simple, and with no unnecessary overload.