### PR TITLE
fix-fake-player-xp-not-resetting-on-death

### DIFF
--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -187,6 +187,7 @@ public class EntityPlayerMPFake extends ServerPlayer
         shakeOff();
         super.die(cause);
         setHealth(20);
+        giveExperienceLevels(-(experienceLevel + 1));
         this.foodData = new FoodData();
         kill(this.getCombatTracker().getDeathMessage());
     }


### PR DESCRIPTION
* remove XP on bot death
* fixes #1797