### PR TITLE
fix-players-pushing-entities-in-tick-freeze

### DIFF
--- a/src/main/java/carpet/mixins/LivingEntity_tickSpeedMixin.java
+++ b/src/main/java/carpet/mixins/LivingEntity_tickSpeedMixin.java
@@ -1,0 +1,25 @@
+package carpet.mixins;
+
+import carpet.fakes.MinecraftServerInterface;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(LivingEntity.class)
+public class LivingEntity_tickSpeedMixin
+{
+	@Inject(method = "pushEntities", at = @At("HEAD"), cancellable = true)
+	private void onPushEntities(CallbackInfo ci)
+	{
+		if ((LivingEntity)(Object)this instanceof ServerPlayer) {
+			var server = (MinecraftServerInterface)((LivingEntity)(Object)this).level().getServer();
+			if(server.getTickRateManager().gameIsPaused()) {
+				ci.cancel();
+			}
+		}
+	}
+}
+

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -67,6 +67,7 @@
     "PistonStructureResolver_pushLimitMixin",
     "PoweredRailBlock_powerLimitMixin",
     "LivingEntity_maxCollisionsMixin",
+    "LivingEntity_tickSpeedMixin",
     "Level_getOtherEntitiesLimited",
     "CoralPlantBlock_renewableCoralMixin",
     "CoralFanBlock_renewableCoralMixin",


### PR DESCRIPTION
* cancel pushEntities() if game paused
* fixes #1779

Not so targeted an inject as would be nice, but there is far heavier stuff going on here anyway and I think a minor perf hit.
