### PR TITLE
fix built-in scarpet ai_tracker.sc failed if one player disconnect fr…

### DIFF
--- a/src/main/resources/assets/carpet/scripts/ai_tracker.sc
+++ b/src/main/resources/assets/carpet/scripts/ai_tracker.sc
@@ -526,11 +526,13 @@ __tick_tracker() ->
       return()
    );
    p = player();
-   in_dimension(p,
-      for (entity_area('valid', p, global_range, global_range, global_range),
-         __handle_entity(_)
-      )
-   );
+   if (p == null, (clear()), (
+      in_dimension(p,
+         for (entity_area('valid', p, global_range, global_range, global_range),
+            __handle_entity(_)
+         )
+      );
+   ));
    schedule(global_interval, '__tick_tracker');
 );
 


### PR DESCRIPTION
If any player disconnect from the server while his /ai_tracker function is on, then script will
throw an unhandled exception. And if the player re-connect the server again. He will not able to use /ai_tracker anymore (Because the script is failed then. You must unload and load the script again to make it work again.)

```
[19:32:54] [Server thread/INFO]: SakuraWald lost connection: Disconnected
[19:32:54] [Server thread/INFO]: SakuraWald left the game
[19:32:54] [Server thread/INFO]: [SakuraWald: Unhandled unknown_dimension exception: null in ai_tracker at line 529, pos 4]
[19:32:54] [Server thread/INFO]: [SakuraWald:    p = player();]
[19:32:54] [Server thread/INFO]: [SakuraWald:     HERE>> in_dimension(p,]
[19:32:54] [Server thread/INFO]: [SakuraWald:       for (entity_area('valid', p, global_range, global_range, global_range),]
[19:32:54] [Server thread/INFO]: [SakuraWald: Callback failed]
```


The original code is
```
__tick_tracker() ->
(
   if (!global_active_functions,
      global_tracker_running = false;
      return()
   );
   p = player();
   in_dimension(p,
      for (entity_area('valid', p, global_range, global_range, global_range),
         __handle_entity(_)
      )
   );
   schedule(global_interval, '__tick_tracker');
);
```

And the fixed code is 
```
__tick_tracker() ->
(
   if (!global_active_functions,
      global_tracker_running = false;
      return()
   );
   p = player();
   if (p == null, (clear()), (
      in_dimension(p,
         for (entity_area('valid', p, global_range, global_range, global_range),
            __handle_entity(_)
         )
      );
   ));
   schedule(global_interval, '__tick_tracker');
);
```