### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/docs/scarpet/Full.md
+++ b/docs/scarpet/Full.md
@@ -5227,7 +5227,7 @@ Reads the `property` of the `team` if no `value` is specified. If a `value` is a
     
 * `color`
   * Type: String
-  * Options: See [team command](https://minecraft.gamepedia.com/Commands/team#Arguments) (same strings as `'teamcolor'` [command argument](https://github.com/gnembon/fabric-carpet/blob/master/docs/scarpet/Full.md#command-argument-types) options)
+  * Options: See [team command](https://minecraft.wiki/w/Commands/team#Arguments) (same strings as `'teamcolor'` [command argument](https://github.com/gnembon/fabric-carpet/blob/master/docs/scarpet/Full.md#command-argument-types) options)
 
 * `displayName`
   * Type: String or FormattedText, when querying returns FormattedText

--- a/docs/scarpet/api/Scoreboard.md
+++ b/docs/scarpet/api/Scoreboard.md
@@ -80,7 +80,7 @@ Reads the `property` of the `team` if no `value` is specified. If a `value` is a
     
 * `color`
   * Type: String
-  * Options: See [team command](https://minecraft.gamepedia.com/Commands/team#Arguments) (same strings as `'teamcolor'` [command argument](https://github.com/gnembon/fabric-carpet/blob/master/docs/scarpet/Full.md#command-argument-types) options)
+  * Options: See [team command](https://minecraft.wiki/w/Commands/team#Arguments) (same strings as `'teamcolor'` [command argument](https://github.com/gnembon/fabric-carpet/blob/master/docs/scarpet/Full.md#command-argument-types) options)
 
 * `displayName`
   * Type: String or FormattedText, when querying returns FormattedText

--- a/src/main/java/carpet/script/command/CommandArgument.java
+++ b/src/main/java/carpet/script/command/CommandArgument.java
@@ -122,7 +122,7 @@ public abstract class CommandArgument
     private static final List<? extends CommandArgument> baseTypes = Lists.newArrayList(
             // default
             new StringArgument(),
-            // vanilla arguments as per https://minecraft.gamepedia.com/Argument_types
+            // vanilla arguments as per https://minecraft.wiki/w/Argument_types
             new VanillaUnconfigurableArgument("bool", BoolArgumentType::bool,
                     (c, p) -> BooleanValue.of(BoolArgumentType.getBool(c, p)), false
             ),


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.