### PR TITLE
Remove `fillLimit` rule and its migration code

### DIFF
--- a/src/main/java/carpet/CarpetServer.java
+++ b/src/main/java/carpet/CarpetServer.java
@@ -25,8 +25,6 @@ import carpet.network.ServerNetworkHandler;
 import carpet.helpers.HopperCounter;
 import carpet.logging.LoggerRegistry;
 import carpet.script.CarpetScriptServer;
-import carpet.api.settings.CarpetRule;
-import carpet.api.settings.InvalidRuleValueException;
 import carpet.api.settings.SettingsManager;
 import carpet.logging.HUDController;
 import carpet.script.external.Carpet;
@@ -104,16 +102,6 @@ public class CarpetServer // static for now - easier to handle all around the co
         extensions.forEach(e -> e.onServerLoadedWorlds(minecraftServer));
         // initialize scarpet rules after all extensions are loaded
         forEachManager(SettingsManager::initializeScarpetRules);
-        // run fillLimit rule migration now that gamerules are available
-        @SuppressWarnings("unchecked")
-        CarpetRule<Integer> fillLimit = (CarpetRule<Integer>) settingsManager.getCarpetRule("fillLimit");
-        try
-        {
-            fillLimit.set(minecraftServer.createCommandSourceStack(), fillLimit.value());
-        } catch (InvalidRuleValueException e)
-        {
-            throw new AssertionError();
-        }
         scriptServer.initializeForWorld();
     }
 

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -653,43 +653,6 @@ public class CarpetSettings
     )
     public static int railPowerLimit = 9;
 
-    private static class FillLimitMigrator extends Validator<Integer>
-    {
-        @Override
-        public Integer validate(CommandSourceStack source, CarpetRule<Integer> changingRule, Integer newValue, String userInput)
-        {
-            if (source != null && source.getServer().overworld() != null)
-            {
-                GameRules.IntegerValue gamerule = source.getServer().getGameRules().getRule(GameRules.RULE_COMMAND_MODIFICATION_BLOCK_LIMIT);
-                if (gamerule.get() != newValue)
-                {
-                    if (newValue == 32768 && changingRule.value() == newValue) // migration call, gamerule is different, update rule
-                    {
-                        Messenger.m(source, "g Syncing fillLimit rule with gamerule");
-                        newValue = gamerule.get();
-                    } else if (newValue != 32768 && gamerule.get() == 32768)
-                    {
-                        Messenger.m(source, "g Migrated value of fillLimit carpet rule to commandModificationBlockLimit gamerule");
-                        gamerule.set(newValue, source.getServer());
-                    }
-                }
-            }
-            return newValue;
-        }
-        @Override
-        public String description() { return "The value of this rule will be migrated to the gamerule";}
-    }
-
-    @Rule(
-            desc = "[Deprecated] Customizable fill/fillbiome/clone volume limit",
-            extra = "Use vanilla gamerule instead. This setting will be removed in 1.20.0",
-            options = {"32768", "250000", "1000000"},
-            category = CREATIVE,
-            strict = false,
-            validate = FillLimitMigrator.class
-    )
-    public static int fillLimit = 32768;
-
     private static class ForceloadLimitValidator extends Validator<Integer>
     {
         @Override

--- a/src/main/java/carpet/script/external/Vanilla.java
+++ b/src/main/java/carpet/script/external/Vanilla.java
@@ -346,7 +346,7 @@ public class Vanilla
 
     public static int MinecraftServer_getFillLimit(MinecraftServer server)
     {
-        return Math.max(server.getGameRules().getInt(GameRules.RULE_COMMAND_MODIFICATION_BLOCK_LIMIT), CarpetSettings.fillLimit);
+        return server.getGameRules().getInt(GameRules.RULE_COMMAND_MODIFICATION_BLOCK_LIMIT);
     }
 
     public static int PoiRecord_getFreeTickets(PoiRecord record)


### PR DESCRIPTION
Maybe we should add some more generic code for carpet rule -> gamerule migration now that there's so many rules getting going this way.