### PR TITLE
Add back unnecessary int to CarpetPayload for backwards compatibility

### DIFF
--- a/src/main/java/carpet/mixins/ClientPacketListener_customPacketsMixin.java
+++ b/src/main/java/carpet/mixins/ClientPacketListener_customPacketsMixin.java
@@ -1,6 +1,8 @@
 package carpet.mixins;
 
+import carpet.CarpetSettings;
 import carpet.network.CarpetClient;
+import carpet.network.CarpetPayload;
 import carpet.network.ClientNetworkHandler;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientCommonPacketListenerImpl;
@@ -34,9 +36,13 @@ public abstract class ClientPacketListener_customPacketsMixin extends ClientComm
             ), cancellable = true)
     private void onOnCustomPayload(CustomPacketPayload packet, CallbackInfo ci)
     {
-        if (packet instanceof CarpetClient.CarpetPayload cpp)
+        if (packet instanceof CarpetPayload cpp)
         {
-            ClientNetworkHandler.onServerData(cpp.data(), minecraft.player);
+        	if (cpp.command() == CarpetPayload.DATA) {
+                ClientNetworkHandler.onServerData(cpp.data(), minecraft.player);
+            } else {
+                CarpetSettings.LOG.info("Invalid carpet-like packet received");
+            }
             ci.cancel();
         }
     }

--- a/src/main/java/carpet/mixins/ClientboundCustomPayloadPacket_customPacketMixin.java
+++ b/src/main/java/carpet/mixins/ClientboundCustomPayloadPacket_customPacketMixin.java
@@ -2,12 +2,10 @@ package carpet.mixins;
 
 
 import carpet.network.CarpetClient;
-import carpet.network.ClientNetworkHandler;
-import net.minecraft.client.Minecraft;
+import carpet.network.CarpetPayload;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
-import net.minecraft.network.protocol.common.custom.DiscardedPayload;
 import net.minecraft.resources.ResourceLocation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -25,7 +23,7 @@ public class ClientboundCustomPayloadPacket_customPacketMixin
     {
         if (resourceLocation.equals(CarpetClient.CARPET_CHANNEL))
         {
-            cir.setReturnValue(new CarpetClient.CarpetPayload(friendlyByteBuf));
+            cir.setReturnValue(new CarpetPayload(friendlyByteBuf));
         }
     }
 }

--- a/src/main/java/carpet/mixins/ServerCommonPacketListenerimpl_connectionMixin.java
+++ b/src/main/java/carpet/mixins/ServerCommonPacketListenerimpl_connectionMixin.java
@@ -1,6 +1,7 @@
 package carpet.mixins;
 
-import carpet.network.CarpetClient;
+import carpet.CarpetSettings;
+import carpet.network.CarpetPayload;
 import carpet.network.ServerNetworkHandler;
 import net.minecraft.network.protocol.PacketUtils;
 import net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket;
@@ -19,12 +20,16 @@ public class ServerCommonPacketListenerimpl_connectionMixin
     private void onCustomCarpetPayload(ServerboundCustomPayloadPacket serverboundCustomPayloadPacket, CallbackInfo ci)
     {
         Object thiss = this;
-        if (thiss instanceof ServerGamePacketListenerImpl impl && serverboundCustomPayloadPacket.payload() instanceof CarpetClient.CarpetPayload cpp) {
+        if (thiss instanceof ServerGamePacketListenerImpl impl && serverboundCustomPayloadPacket.payload() instanceof CarpetPayload cpp) {
             // We should force onto the main thread here
             // ServerNetworkHandler.handleData can possibly mutate data that isn't
             // thread safe, and also allows for client commands to be executed
             PacketUtils.ensureRunningOnSameThread(serverboundCustomPayloadPacket, (ServerGamePacketListener) this, impl.player.serverLevel());
-            ServerNetworkHandler.onClientData(impl.player, cpp.data());
+            if (cpp.command() == CarpetPayload.DATA) {
+                ServerNetworkHandler.onClientData(impl.player, cpp.data());
+            } else {
+                CarpetSettings.LOG.info("Invalid carpet-like packet received");
+            }
             ci.cancel();
         }
     }

--- a/src/main/java/carpet/mixins/ServerboundCustomPayloadPacket_mixin.java
+++ b/src/main/java/carpet/mixins/ServerboundCustomPayloadPacket_mixin.java
@@ -1,6 +1,7 @@
 package carpet.mixins;
 
 import carpet.network.CarpetClient;
+import carpet.network.CarpetPayload;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
@@ -21,7 +22,7 @@ public class ServerboundCustomPayloadPacket_mixin
     {
         if (CarpetClient.CARPET_CHANNEL.equals(resourceLocation))
         {
-            cir.setReturnValue(new CarpetClient.CarpetPayload(friendlyByteBuf));
+            cir.setReturnValue(new CarpetPayload(friendlyByteBuf));
         }
     }
 }

--- a/src/main/java/carpet/network/CarpetClient.java
+++ b/src/main/java/carpet/network/CarpetClient.java
@@ -7,33 +7,11 @@ import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
-import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 
 public class CarpetClient
 {
-    public record CarpetPayload(CompoundTag data) implements CustomPacketPayload
-    {
-        public CarpetPayload(FriendlyByteBuf input)
-        {
-            this(input.readNbt());
-        }
-
-        @Override
-        public void write(FriendlyByteBuf output)
-        {
-            output.writeNbt(data);
-        }
-
-        @Override
-        public ResourceLocation id()
-        {
-            return CARPET_CHANNEL;
-        }
-    }
-
     public static final String HI = "69";
     public static final String HELLO = "420";
 

--- a/src/main/java/carpet/network/CarpetPayload.java
+++ b/src/main/java/carpet/network/CarpetPayload.java
@@ -1,0 +1,34 @@
+package carpet.network;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+
+public record CarpetPayload(int command, CompoundTag data) implements CustomPacketPayload
+{
+    public static final int DATA = 1; // The only command, in the packet for backwards compat
+
+    public CarpetPayload(CompoundTag data)
+    {
+        this(DATA, data);
+    }
+
+    public CarpetPayload(FriendlyByteBuf input)
+    {
+        this(input.readInt(), input.readNbt());
+    }
+
+    @Override
+    public void write(FriendlyByteBuf output)
+    {
+        output.writeInt(command);
+        output.writeNbt(data);
+    }
+
+    @Override
+    public ResourceLocation id()
+    {
+        return CarpetClient.CARPET_CHANNEL;
+    }
+}

--- a/src/main/java/carpet/network/ClientNetworkHandler.java
+++ b/src/main/java/carpet/network/ClientNetworkHandler.java
@@ -110,7 +110,7 @@ public class ClientNetworkHandler
         CompoundTag data = new CompoundTag();
         data.putString(CarpetClient.HELLO, CarpetSettings.carpetVersion);
         CarpetClient.getPlayer().connection.send(new ServerboundCustomPayloadPacket(
-                new CarpetClient.CarpetPayload(data)
+                new CarpetPayload(data)
         ));
     }
 
@@ -144,7 +144,7 @@ public class ClientNetworkHandler
         CompoundTag outer = new CompoundTag();
         outer.put("clientCommand", tag);
         CarpetClient.getPlayer().connection.send(new ServerboundCustomPayloadPacket(
-                new CarpetClient.CarpetPayload(outer)
+                new CarpetPayload(CarpetPayload.DATA, outer)
         ));
     }
 }

--- a/src/main/java/carpet/network/ServerNetworkHandler.java
+++ b/src/main/java/carpet/network/ServerNetworkHandler.java
@@ -41,7 +41,7 @@ public class ServerNetworkHandler
         {
             CompoundTag data = new CompoundTag();
             data.putString(CarpetClient.HI, CarpetSettings.carpetVersion);
-            playerEntity.connection.send(new ClientboundCustomPayloadPacket(new CarpetClient.CarpetPayload(data)));
+            playerEntity.connection.send(new ClientboundCustomPayloadPacket(new CarpetPayload(data)));
         }
         else
         {
@@ -244,7 +244,7 @@ public class ServerNetworkHandler
 
         private ClientboundCustomPayloadPacket build()
         {
-            return new ClientboundCustomPayloadPacket(new CarpetClient.CarpetPayload(tag));
+            return new ClientboundCustomPayloadPacket(new CarpetPayload(tag));
         }
     }
 }


### PR DESCRIPTION
This adds back the unnecessary `command` `int` to `CarpetPayload`, to allow it to handle packets from servers running on older versions that are allowing newer clients with something like ViaVersion.

That `int` was removed in commit cd572695b6.

This also adds checks that `command` is always `DATA`, moves `CarpetPayload` to its own class and adds a constructor without `command` to it.

Completely untested at the moment.