### PR TITLE
Fix Race Condition Crash Exploit

### DIFF
--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -66,7 +66,7 @@ public class EntityPlayerMPFake extends ServerPlayer
             }
         }
         GameProfile finalGP = gameprofile;
-        fetchGameProfile(gameprofile.getName()).thenAccept(p -> {
+        fetchGameProfile(gameprofile.getName()).thenAcceptAsync(p -> {
             GameProfile current = finalGP;
             if (p.isPresent())
             {
@@ -85,7 +85,7 @@ public class EntityPlayerMPFake extends ServerPlayer
             //instance.world.getChunkManager(). updatePosition(instance);
             instance.entityData.set(DATA_PLAYER_MODE_CUSTOMISATION, (byte) 0x7f); // show all model layers (incl. capes)
             instance.getAbilities().flying = flying;
-        });
+        }, server);
         return true;
     }
 


### PR DESCRIPTION
I was getting some off-thread warnings in another mod I'm working on when spawning fake players. 
This lead me to try spamming `/player foobar spawn` in chat, which crashed the game.

I have just changed the `thenAccept` into a `thenAcceptAsync` on the main server thread. This now creates the player and spawns them on the main thread, so there are no more possible race conditions that can happen.