### PR TITLE
Fix fake players using wrong reach values

### DIFF
--- a/src/main/java/carpet/helpers/EntityPlayerActionPack.java
+++ b/src/main/java/carpet/helpers/EntityPlayerActionPack.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import carpet.logging.Logger;
 import carpet.patches.EntityPlayerMPFake;
 import carpet.script.utils.Tracer;
 import net.minecraft.commands.arguments.EntityAnchorArgument;
@@ -24,7 +25,9 @@ import net.minecraft.world.entity.decoration.ItemFrame;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.vehicle.Boat;
 import net.minecraft.world.entity.vehicle.Minecart;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
@@ -45,6 +48,7 @@ public class EntityPlayerActionPack
 
     private boolean sneaking;
     private boolean sprinting;
+    private boolean slowed;
     private float forward;
     private float strafing;
 
@@ -67,6 +71,7 @@ public class EntityPlayerActionPack
         sprinting = other.sprinting;
         forward = other.forward;
         strafing = other.strafing;
+        slowed = other.slowed;
 
         itemUseCooldown = other.itemUseCooldown;
     }
@@ -110,6 +115,13 @@ public class EntityPlayerActionPack
         strafing = value;
         return this;
     }
+
+    public EntityPlayerActionPack setSlowed(boolean value)
+    {
+        slowed = value;
+        return this;
+    }
+
     public EntityPlayerActionPack look(Direction direction)
     {
         return switch (direction)
@@ -238,7 +250,16 @@ public class EntityPlayerActionPack
                 }
             }
         }
-        float vel = sneaking?0.3F:1.0F;
+
+        if (player.isUsingItem())
+        {
+            ItemStack item = player.getUseItem();
+            ((ServerPlayerInterface) player).getActionPack().setSlowed(item.isEdible() || item.is(Items.SHIELD) || item.is(Items.BRUSH) || item.is(Items.BOW) || item.is(Items.CROSSBOW) || item.is(Items.TRIDENT) || item.is(Items.GOAT_HORN) || item.is(Items.SPYGLASS));
+        }
+        else {setSlowed(false);}
+
+        float vel = sneaking?0.30F:1.0F;
+        vel *= slowed?0.20F:1.0F;
         // The != 0.0F checks are needed given else real players can't control minecarts, however it works with fakes and else they don't stop immediately
         if (forward != 0.0F || player instanceof EntityPlayerMPFake) {
             player.zza = forward * vel;
@@ -250,8 +271,13 @@ public class EntityPlayerActionPack
 
     static HitResult getTarget(ServerPlayer player)
     {
-        double reach = player.gameMode.isCreative() ? 5 : 4.5f;
-        return Tracer.rayTrace(player, 1, reach, false);
+        double blockReach = player.gameMode.isCreative() ? 5 : 4.5f;
+        double entityReach = player.gameMode.isCreative() ? 5 : 3f;
+
+        HitResult hit = Tracer.rayTrace(player, 1, blockReach, false);
+
+        if (hit.getType() == HitResult.Type.BLOCK) return hit;
+        return Tracer.rayTrace(player, 1, entityReach, false);
     }
 
     private void dropItemFromSlot(int slot, boolean dropAll)
@@ -378,8 +404,6 @@ public class EntityPlayerActionPack
                             player.attack(entityHit.getEntity());
                             player.swing(InteractionHand.MAIN_HAND);
                         }
-                        player.resetAttackStrengthTicker();
-                        player.resetLastActionTime();
                         return true;
                     }
                     case BLOCK: {
@@ -443,11 +467,13 @@ public class EntityPlayerActionPack
                             player.level().destroyBlockProgress(-1, pos, (int) (ap.curBlockDamageMP * 10));
 
                         }
-                        player.resetLastActionTime();
                         player.swing(InteractionHand.MAIN_HAND);
                         return blockBroken;
                     }
                 }
+                if (!action.isContinuous) player.swing(InteractionHand.MAIN_HAND);
+                player.resetAttackStrengthTicker();
+                player.resetLastActionTime();
                 return false;
             }
 


### PR DESCRIPTION
The bots still have a 4.5 block range while interacting with blocks, but entity interaction range has been reduced to 3 blocks, fixing #1882

Player attacking is more realistic now. Using /player <player> attack once will swing even while not targeting an entity, and will properly reset attack cooldown

#1881 is also fixed, as players will properly lower their movement speed while using slow items