### PR TITLE
Fixed a bug in the ai_tracker script which caused the golem detection range to be incorrect.

### DIFF
--- a/src/main/resources/assets/carpet/scripts/ai_tracker.sc
+++ b/src/main/resources/assets/carpet/scripts/ai_tracker.sc
@@ -40,7 +40,7 @@ global_functions = {
             );
             __create_box(abnoxious_visuals, e,
                   [-16-half_width,-16,-16-half_width],
-                  [16+half_width,16+height,16+half_width],
+                  [16+half_width,16+villager_height,16+half_width],
                   0xdddddd00, 'golem detection', false
             );
 


### PR DESCRIPTION
Changed height to villager_height in the ai_tracker.sc file which caused the golem detection range to be 2 blocks smaller towards the positive Z.

Consist of one line of code, but I believe this should resolve the issue.