### PR TITLE
Update to 1.21-pre2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,13 +3,13 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check https://fabricmc.net/develop/
-	minecraft_version=1.21-pre1
+	minecraft_version=1.21-pre2
 	loader_version=0.15.11
 	jsr305_version=3.0.2
 	fabric_version=0.99.2+1.21
 
 # Mod Properties
-	mod_version = 1.4.145
+	mod_version = 1.4.146
 	maven_group = carpet
 	archives_base_name = fabric-carpet
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check https://fabricmc.net/develop/
-	minecraft_version=1.21-pre2
+	minecraft_version=1.21-pre3
 	loader_version=0.15.11
 	jsr305_version=3.0.2
-	fabric_version=0.99.2+1.21
+	fabric_version=0.99.5+1.21
 
 # Mod Properties
 	mod_version = 1.4.146

--- a/src/main/java/carpet/mixins/LivingEntity_creativeFlyMixin.java
+++ b/src/main/java/carpet/mixins/LivingEntity_creativeFlyMixin.java
@@ -1,7 +1,6 @@
 package carpet.mixins;
 
 import carpet.CarpetSettings;
-import carpet.patches.EntityPlayerMPFake;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
@@ -49,8 +48,8 @@ public abstract class LivingEntity_creativeFlyMixin extends Entity
         }
     }
 
-    @Inject(method = "canChangeDimensions", at = @At("HEAD"), cancellable = true)
-    private void canChangeDimensions(CallbackInfoReturnable<Boolean> cir)
+    @Inject(method = "canUsePortal", at = @At("HEAD"), cancellable = true)
+    private void canUsePortal(CallbackInfoReturnable<Boolean> cir)
     {
         if (CarpetSettings.isCreativeFlying(this)) {
                 cir.setReturnValue(false);


### PR DESCRIPTION
Requires changing `LivingEntity_creativeFlyMixin#canChangeDimensions` target, as `canChangeDimensions()` is no longer overridden in `LivingEntity.class`. I have changed it to target `canUsePortal()` instead which has a different purpose to `canChangeDimensions()`, so please let me know if this is not a good fix.