### PR TITLE
Fix pingPlayerListLimit

### DIFF
--- a/src/main/java/carpet/mixins/MinecraftServer_pingPlayerSampleLimit.java
+++ b/src/main/java/carpet/mixins/MinecraftServer_pingPlayerSampleLimit.java
@@ -11,7 +11,7 @@ import net.minecraft.server.MinecraftServer;
 public abstract class MinecraftServer_pingPlayerSampleLimit
 {
 
-	@ModifyConstant(method = "tickServer", constant = @Constant(intValue = 12), require = 0, allow = 1)
+	@ModifyConstant(method = "buildPlayerStatus", constant = @Constant(intValue = 12), require = 0, allow = 1)
 	private int modifyPlayerSampleLimit(int value)
 	{
 		return CarpetSettings.pingPlayerListLimit;


### PR DESCRIPTION
This mixin crashed with

`-Dmixin.debug.countInjections=true`.

This happens because the injection point moved to a different method by now