### PR TITLE
Fixes #1958

### DIFF
--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -190,6 +190,11 @@ public class PlayerCommand
         MinecraftServer server = context.getSource().getServer();
         PlayerList manager = server.getPlayerList();
 
+        if (EntityPlayerMPFake.isSpawningPlayer(playerName))
+        {
+            Messenger.m(context.getSource(), "r Player ", "rb " + playerName, "r  is currently logging on");
+            return true;
+        }
         if (manager.getPlayerByName(playerName) != null)
         {
             Messenger.m(context.getSource(), "r Player ", "rb " + playerName, "r  is already logged on");

--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -36,12 +36,16 @@ import net.minecraft.world.phys.Vec3;
 import carpet.fakes.ServerPlayerInterface;
 import carpet.utils.Messenger;
 
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 @SuppressWarnings("EntityConstructor")
 public class EntityPlayerMPFake extends ServerPlayer
 {
+    private static final Set<String> spawning = new HashSet<>();
+
     public Runnable fixStartingPosition = () -> {};
     public boolean isAShadow;
 
@@ -68,7 +72,21 @@ public class EntityPlayerMPFake extends ServerPlayer
             }
         }
         GameProfile finalGP = gameprofile;
-        fetchGameProfile(gameprofile.getName()).thenAcceptAsync(p -> {
+
+        // We need to mark this player as spawning so that we do not
+        // try to spawn another player with the name while the profile
+        // is being fetched - preventing multiple players spawning
+        String name = gameprofile.getName();
+        spawning.add(name);
+
+        fetchGameProfile(name).whenCompleteAsync((p, t) -> {
+            // Always remove the name, even if exception occurs
+            spawning.remove(name);
+            if (t != null)
+            {
+                return;
+            }
+
             GameProfile current = finalGP;
             if (p.isPresent())
             {
@@ -124,6 +142,11 @@ public class EntityPlayerMPFake extends ServerPlayer
     public static EntityPlayerMPFake respawnFake(MinecraftServer server, ServerLevel level, GameProfile profile, ClientInformation cli)
     {
         return new EntityPlayerMPFake(server, level, profile, cli, false);
+    }
+
+    public static boolean isSpawningPlayer(String username)
+    {
+        return spawning.contains(username);
     }
 
     private EntityPlayerMPFake(MinecraftServer server, ServerLevel worldIn, GameProfile profile, ClientInformation cli, boolean shadow)


### PR DESCRIPTION
Fixes an issue where repeatedly calling the `createFake` method in quick succession will spawn multiple of the same player which can cause lots of issues. This is because fetching the profile takes some time and the player is not online thus bypasses the logged in check. I've added an extra check for players that are currently being spawned in to prevent further requests to spawn that player in while their profile is being fetched.