### PR TITLE
The rule `optimizedTnt` make player's wind charge break blocks

### DIFF
--- a/src/main/java/carpet/mixins/Explosion_optimizedTntMixin.java
+++ b/src/main/java/carpet/mixins/Explosion_optimizedTntMixin.java
@@ -9,6 +9,7 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.monster.breeze.Breeze;
+import net.minecraft.world.entity.projectile.windcharge.WindCharge;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -39,13 +40,14 @@ public abstract class Explosion_optimizedTntMixin
 
     @Shadow @Nullable public abstract LivingEntity getIndirectSourceEntity();
 
+    @Shadow @Final @Nullable private Entity source;
     private ExplosionLogHelper eLogger;
 
     @Inject(method = "explode", at = @At("HEAD"),
             cancellable = true)
     private void onExplosionA(CallbackInfo ci)
     {
-        if (CarpetSettings.optimizedTNT && !level.isClientSide && !(getIndirectSourceEntity() instanceof Breeze))
+        if (CarpetSettings.optimizedTNT && !level.isClientSide && !(getIndirectSourceEntity() instanceof Breeze) && !(this.source instanceof WindCharge))
         {
             OptimizedExplosion.doExplosionA((Explosion) (Object) this, eLogger);
             ci.cancel();
@@ -65,7 +67,7 @@ public abstract class Explosion_optimizedTntMixin
         {
             toBlow.clear();
         }
-        if (CarpetSettings.optimizedTNT && !level.isClientSide && !(getIndirectSourceEntity() instanceof Breeze))
+        if (CarpetSettings.optimizedTNT && !level.isClientSide && !(getIndirectSourceEntity() instanceof Breeze) && !(this.source instanceof WindCharge))
         {
             OptimizedExplosion.doExplosionB((Explosion) (Object) this, spawnParticles);
             ci.cancel();


### PR DESCRIPTION
the `Explosion_optimizedTntMixin` only Only the windcharge from the breeze is determined, not the windcharge from the player