### PR TITLE
Fixes bugged `run(expr)` (#2023) by adding `run_cb(expr, callback)` and `run_wait(expr)`

### DIFF
--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -706,6 +706,106 @@ public class Auxiliary
             }
         });
 
+        expression.addContextFunction("run_async", 1, (c, t, lv) ->
+        {
+            CommandSourceStack source = ((CarpetContext) c).source();
+            FunctionArgument callback = FunctionArgument.findIn(c, expression.module, lv, 1, true, false);
+            String command = lv.get(0).getString();
+            if(callback.function == null)
+            {
+                try
+                {
+                    Component[] errorOutput = {null};
+                    List<Component> output = new ArrayList<>();
+                    OptionalLong[] returnValue = {OptionalLong.empty()};
+                    source.getServer().getCommands().performPrefixedCommand(
+                            new SnoopyCommandSource(source, errorOutput, output, returnValue),
+                            command
+                    );
+                }
+                catch (Exception ignored)
+                {
+                }
+                return Value.NULL;
+            }
+            else if (callback.function.getArguments().size() < 1)
+            {
+                throw new InternalExpressionException("callback requires 1 argument for command output");
+            }
+            boolean[] isCallbackConsumed = {false};
+            try
+            {
+                boolean[] hasCommandError = {false};
+                Integer[] commandExitCode = {null};
+                Component[] errorOutput = {null};
+                List<Component> output = new ArrayList<>();
+                OptionalLong[] ignoredReturnedValue = {OptionalLong.empty()};
+
+                SnoopyCommandSource snoopyCommandSource = (SnoopyCommandSource) new SnoopyCommandSource(source, errorOutput, output, ignoredReturnedValue)
+                        .withCallback((success, exitCode) -> {
+                            if(isCallbackConsumed[0])
+                            {
+                                return;
+                            }
+                            isCallbackConsumed[0] = true;
+                            // The CommandSourceStack.sendFailure are sent after the resultConsumer, so the error output is always empty in
+                            // this resultConsumer. This workaround is using the resultConsumer in tandem with an errorCallback.
+                            if(!success)
+                            {
+                                hasCommandError[0] = true;
+                                commandExitCode[0] = exitCode;
+                                return;
+                            }
+                            List<Value> args = List.of(ListValue.of(
+                                    NumericValue.of(exitCode),
+                                    ListValue.wrap(output.stream().map(FormattedTextValue::new)),
+                                    FormattedTextValue.of(errorOutput[0])
+                            ));
+                            callback.function.callInContext(c, t, args);
+                        });
+                // To catch errors that don't call the resultConsumer and make sure the error output is set for those that do.
+                snoopyCommandSource.setErrorCallback((ignored) -> {
+                    if(isCallbackConsumed[0])
+                    {
+                        if(!hasCommandError[0])
+                        {
+                            return;
+                        }
+                        List<Value> args = List.of(ListValue.of(
+                                NumericValue.of(commandExitCode[0]),
+                                ListValue.wrap(output.stream().map(FormattedTextValue::new)),
+                                FormattedTextValue.of(errorOutput[0])
+                        ));
+                        callback.function.callInContext(c, t, args);
+                        return;
+                    }
+                    isCallbackConsumed[0] = true;
+                    List<Value> args = List.of(ListValue.of(
+                            Value.NULL,
+                            ListValue.of(),
+                            FormattedTextValue.of(errorOutput[0])
+                    ));
+                    callback.function.callInContext(c, t, args);
+                });
+
+                source.getServer().getCommands().performPrefixedCommand(snoopyCommandSource, command);
+            }
+            catch (Exception exc)
+            {
+                if(!isCallbackConsumed[0])
+                {
+                    isCallbackConsumed[0] = true;
+                    List<Value> args = List.of(ListValue.of(
+                            Value.NULL,
+                            ListValue.of(),
+                            new FormattedTextValue(Component.literal(exc.getMessage()))
+                    ));
+                    callback.function.callInContext(c, t, args);
+                }
+            }
+            return Value.NULL;
+        });
+
         expression.addContextFunction("save", 0, (c, t, lv) ->
         {
             CommandSourceStack s = ((CarpetContext) c).source();

--- a/src/main/java/carpet/script/utils/SnoopyCommandSource.java
+++ b/src/main/java/carpet/script/utils/SnoopyCommandSource.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.OptionalLong;
 import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public class SnoopyCommandSource extends CommandSourceStack
@@ -43,6 +44,9 @@ public class SnoopyCommandSource extends CommandSourceStack
     private final CommandSigningContext signingContext;
 
     private final TaskChainer taskChainer;
+
+    // sendFailure() callback
+    @Nullable private Consumer<Component> errorCallback = null;
 
     public SnoopyCommandSource(CommandSourceStack original, Component[] error, List<Component> chatOutput, OptionalLong[] returnValue)
     {
@@ -197,6 +201,10 @@ public class SnoopyCommandSource extends CommandSourceStack
     public void sendFailure(Component message)
     {
         error[0] = message;
+        if(this.errorCallback != null)
+        {
+            this.errorCallback.accept(message);
+        }
     }
 
     @Override
@@ -204,4 +212,15 @@ public class SnoopyCommandSource extends CommandSourceStack
     {
         chatOutput.add(message.get());
     }
+
+    /**
+     * Added for the new queue system for commands, since some early errors don't trigger the resultConsumer and all sendFailures calls
+     * are executed after the call resultConsumer when they do.
+     * @param errorCallback A consumer that will be called upon sendFailure
+     */
+    public void setErrorCallback(Consumer<Component> errorCallback)
+    {
+        this.errorCallback = errorCallback;
+    }
+
 }


### PR DESCRIPTION
This PR fixes #2023 by adding `run_cb(expr, callback)` and `run_wait(expr)` functions that cover the previous return value use cases for `run(expr)`
More details and information in the committed Auxiliary.md

This also adds an error callback along with a setter `setErrorCallback` in SnoopyCommandSource to work with errors from the CommandSourceStack sendFailure being called after the resultConsumer from `withCallback` or being called too early with resultConsumer not being triggered

I've tried to follow the code practices and indentation of the project but I'm still new to contributing to open source so apologies if it doesn't match perfectly