### PR TITLE
Fixed `e~'invulnerable'` for players

### DIFF
--- a/src/main/java/carpet/script/value/EntityValue.java
+++ b/src/main/java/carpet/script/value/EntityValue.java
@@ -501,7 +501,7 @@ public class EntityValue extends Value
         put("immune_to_fire", (e, a) -> BooleanValue.of(e.fireImmune()));
         put("immune_to_frost", (e, a) -> BooleanValue.of(!e.canFreeze()));
 
-        put("invulnerable", (e, a) -> BooleanValue.of(e.isInvulnerable()));
+        put("invulnerable", (e, a) -> BooleanValue.of(e instanceof Player player ? player.getAbilities().invulnerable : e.isInvulnerable()));
         put("dimension", (e, a) -> nameFromRegistryId(e.level().dimension().location())); // getDimId
         put("height", (e, a) -> new NumericValue(e.getDimensions(Pose.STANDING).height()));
         put("width", (e, a) -> new NumericValue(e.getDimensions(Pose.STANDING).width()));


### PR DESCRIPTION
Setting a player to invulnerable with `modify(player, 'invulnerable', true)` sets the invulnerable ability if the entity value is a player:
https://github.com/gnembon/fabric-carpet/blob/c2f66b12e3e36141d7a6be9ca6de3aa4ea88b8ae/src/main/java/carpet/script/value/EntityValue.java#L1588-L1599
However, querying `player~'invulnerable'` always uses `Entity.isInvulnerable` which won't be true when set via the abilities:
https://github.com/gnembon/fabric-carpet/blob/74e8a8d2eca9e28a67321d6def21cb5a49457471/src/main/java/carpet/script/value/EntityValue.java#L504

That means that this script would return false.
```js
modify(player(), 'invulnerable', true);
query(player(), 'invulnerable'); // => false
```

This PR changes this to return the invulnerable ability for players.

See this thread from the carpet discord: https://discord.com/channels/882822986795716608/1369599475928006773/1369599475928006773