### PR TITLE
Add `make_folder` function

### DIFF
--- a/docs/scarpet/Full.md
+++ b/docs/scarpet/Full.md
@@ -5665,6 +5665,7 @@ Available output types:
 ### `delete_file(resource, type)`
 ### `write_file(resource, type, data, ...)`
 ### `list_files(resource, type)`
+### `make_folder(resource, type)`
 
 With the specified `resource` in the scripts folder, of a specific `type`, writes/appends `data` to it, reads its
  content, deletes the resource, or lists other files under this resource.
@@ -5688,8 +5689,8 @@ specific data directory is under `world/scripts/foo.data/...`, and shared data s
 
 The default no-name app, via `/script run` command can only save/load/read files from the shared space.
 
-Functions return `null` if no file is present (for read, list and delete operations). Returns `true`
-for success writes and deletes, and requested data, based on the file type, for read operations. It returns list of files 
+Functions return `null` if no file is present (for read, list, make and delete operations). Returns `true`
+for successful writes, folder creation, and deletes, and requested data, based on the file type, for read operations. It returns list of files 
 for folder listing.
  
 Supported values for resource `type` are:
@@ -5697,7 +5698,7 @@ Supported values for resource `type` are:
  * `json` - JSON file
  * `text` - text resource with automatic newlines added
  * `raw` - text resource without implied newlines
- * `folder` - for `list_files` only - indicating folder listing instead of files
+ * `folder` - for `list_files` and `make_folder` - indicating folder listing instead of files or the type of folder
  * `shared_nbt`, `shared_text`, `shared_raw`, `shared_folder`, `shared_json` - shared versions of the above
  
 NBT files have extension `.nbt`, store one NBT tag, and return a NBT type value. JSON files have `.json` extension, store 

--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -344,6 +344,7 @@ Available output types:
 ### `delete_file(resource, type)`
 ### `write_file(resource, type, data, ...)`
 ### `list_files(resource, type)`
+### `make_folder(resource, type)`
 
 With the specified `resource` in the scripts folder, of a specific `type`, writes/appends `data` to it, reads its
  content, deletes the resource, or lists other files under this resource.
@@ -367,8 +368,8 @@ specific data directory is under `world/scripts/foo.data/...`, and shared data s
 
 The default no-name app, via `/script run` command can only save/load/read files from the shared space.
 
-Functions return `null` if no file is present (for read, list and delete operations). Returns `true`
-for success writes and deletes, and requested data, based on the file type, for read operations. It returns list of files 
+Functions return `null` if no file is present (for read, list, make and delete operations). Returns `true`
+for successful writes, folder creation, and deletes, and requested data, based on the file type, for read operations. It returns list of files 
 for folder listing.
  
 Supported values for resource `type` are:
@@ -376,7 +377,7 @@ Supported values for resource `type` are:
  * `json` - JSON file
  * `text` - text resource with automatic newlines added
  * `raw` - text resource without implied newlines
- * `folder` - for `list_files` only - indicating folder listing instead of files
+ * `folder` - for `list_files` and `make_folder` - indicating folder listing instead of files or the type of folder
  * `shared_nbt`, `shared_text`, `shared_raw`, `shared_folder`, `shared_json` - shared versions of the above
  
 NBT files have extension `.nbt`, store one NBT tag, and return a NBT type value. JSON files have `.json` extension, store 

--- a/src/main/java/carpet/script/CarpetScriptHost.java
+++ b/src/main/java/carpet/script/CarpetScriptHost.java
@@ -1035,6 +1035,11 @@ public class CarpetScriptHost extends ScriptHost
         return isDefaultApp() && !fdesc.isShared ? null : fdesc.listFolder(main);
     }
 
+    public boolean makeFolder(FileArgument fdesc)
+    {
+        return isDefaultApp() && !fdesc.isShared ? false : fdesc.makeFolder(main);
+    }
+
     public boolean applyActionForResource(String path, boolean shared, Consumer<Path> action)
     {
         FileArgument fdesc = FileArgument.resourceFromPath(this, path, FileArgument.Reason.CREATE, shared);

--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -1022,6 +1022,9 @@ public class Auxiliary
             return BooleanValue.of(success);
         });
 
+        expression.addContextFunction("make_folder", 2, (c, t, lv) ->
+                BooleanValue.of(((CarpetScriptHost) c.host).makeFolder(FileArgument.from(c, lv, true, FileArgument.Reason.CREATE))));
+
         expression.addContextFunction("load_app_data", -1, (c, t, lv) ->
         {
             FileArgument fdesc = new FileArgument(null, FileArgument.Type.NBT, null, false, false, FileArgument.Reason.READ, c.host);

--- a/src/main/java/carpet/script/argument/FileArgument.java
+++ b/src/main/java/carpet/script/argument/FileArgument.java
@@ -143,6 +143,10 @@ public class FileArgument
         {
             throw new InternalExpressionException("Folder types are no supported for this IO function");
         }
+        if (isFolder && type != Type.FOLDER && reason == Reason.CREATE)
+        {
+            throw new InternalExpressionException("File types are no supported for this IO function");
+        }
         return new FileArgument(resource.getLeft(), type, resource.getRight(), isFolder, shared, reason, context.host);
 
     }
@@ -661,4 +665,23 @@ public class FileArgument
         }
     }
 
+    public boolean makeFolder(Module module) {
+        try {
+            synchronized (writeIOSync) {
+                Path dirPath = toPath(module);
+                if (dirPath == null) {
+                    return false;
+                }
+                if (!Files.exists(dirPath)) {
+                    Files.createDirectories(dirPath);
+                }
+                return true;
+            }
+        } catch (IOException e) {
+            CarpetScriptServer.LOG.warn("IOException when creating folder", e);
+            throw new ThrowStatement("Unable to create folder: " + getDisplayPath(), Throwables.IO_EXCEPTION);
+        } finally {
+            close();
+        }
+    }
 }


### PR DESCRIPTION
### Description:
This PR introduces a new function `make_folder(resource, type)` that allows direct folder creation in Scarpet.

### Changes:
 - Added the `make_folder` function to directly create folders and their parent directories at the specified resource path.
 - The function works with both app-specific and shared folders and supports paths ending with .zip, allowing the creation of folders inside zip files or empty zip files when appropriate.

### Behavior:
 - If the folder does not exist, it will be created, including necessary parent directories.
 - If the folder already exists, the function will return `null`.
 - If there is a filesystem error, an io_exception will be thrown.

### Why:
 - This feature provides a more intuitive and efficient way of handling folder creation, removing the need to use a workaround like making a temporary file and immediately delete it.
 - It enhances the Scarpet API by allowing users to manage folders directly in their scripts.