### PR TITLE
Add `delete_folder` function

### DIFF
--- a/docs/scarpet/api/Auxiliary.md
+++ b/docs/scarpet/api/Auxiliary.md
@@ -344,13 +344,14 @@ Available output types:
 ### `delete_file(resource, type)`
 ### `write_file(resource, type, data, ...)`
 ### `list_files(resource, type)`
+### `delete_folder(resource, type, recursive?)`
 
 With the specified `resource` in the scripts folder, of a specific `type`, writes/appends `data` to it, reads its
  content, deletes the resource, or lists other files under this resource.
 
 Resource is identified by a path to the file.  
 A path can contain letters, numbers, characters `-`, `+`, or `_`, and a folder separator: `'/'`. Any other characters are stripped
-from the name. Empty descriptors are invalid, except for `list_files` where it means the root folder.
+from the name. Empty descriptors are invalid, except for `list_files` and `delete_folder` where it means the root folder.
  Do not add file extensions to the descriptor - extensions are inferred
 based on the `type` of the file. A path can have one `'.zip'` component indicating a zip folder allowing to read / write to and from
 zip files, although you cannot nest zip files in other zip files. 
@@ -376,7 +377,7 @@ Supported values for resource `type` are:
  * `json` - JSON file
  * `text` - text resource with automatic newlines added
  * `raw` - text resource without implied newlines
- * `folder` - for `list_files` only - indicating folder listing instead of files
+ * `folder` - for `list_files` and `delete_folder` - indicating folder listing instead of files or the type of folder to delete
  * `shared_nbt`, `shared_text`, `shared_raw`, `shared_folder`, `shared_json` - shared versions of the above
  
 NBT files have extension `.nbt`, store one NBT tag, and return a NBT type value. JSON files have `.json` extension, store 
@@ -392,6 +393,7 @@ Throws:
 - `nbt_read_error`: When failed to read NBT file.
 - `json_read_error`: When failed to read JSON file. The exception data will contain details about the problem.
 - `io_exception`: For all other errors when handling data on disk not related to encoding issues
+- `folder_not_empty`: When attempting to delete a non-empty folder without setting `recursive` to `true`
 
 All other errors resulting of improper use of input arguments should result in `null` returned from the function, rather than exception
 thrown.

--- a/docs/scarpet/language/FunctionsAndControlFlow.md
+++ b/docs/scarpet/language/FunctionsAndControlFlow.md
@@ -273,6 +273,7 @@ but like everywhere else, doing that sounds like a bad idea.
     - `nbt_error`: Incorrect input/output NBT file.
     - `json_error`: Incorrect input/output JSON data.
     - `b64_error`: Incorrect input/output b64 (base 64) string
+    - `folder_not_empty`: Folder is not empty when using `delete_folder` without `recursive` set to `true`.
   - `user_exception`: Exception thrown by default with `throw` function.
   
 Synopsis:

--- a/src/main/java/carpet/script/CarpetScriptHost.java
+++ b/src/main/java/carpet/script/CarpetScriptHost.java
@@ -1015,6 +1015,11 @@ public class CarpetScriptHost extends ScriptHost
         return (!isDefaultApp() || fdesc.isShared) && fdesc.dropExistingFile(main); //
     }
 
+    public boolean removeResourceFolder(FileArgument fdesc, boolean recursive)
+    {
+        return (!isDefaultApp() || fdesc.isShared) && fdesc.dropExistingFolder(main, recursive);
+    }
+
     public boolean appendLogFile(FileArgument fdesc, List<String> data)
     {
         return (!isDefaultApp() || fdesc.isShared) && fdesc.appendToTextFile(main, data); // if belongs to an app, cannot be default host.

--- a/src/main/java/carpet/script/api/Auxiliary.java
+++ b/src/main/java/carpet/script/api/Auxiliary.java
@@ -971,6 +971,17 @@ public class Auxiliary
         expression.addContextFunction("delete_file", 2, (c, t, lv) ->
                 BooleanValue.of(((CarpetScriptHost) c.host).removeResourceFile(FileArgument.from(c, lv, false, FileArgument.Reason.DELETE))));
 
+        expression.addContextFunction("delete_folder", -1, (c, t, lv) -> {
+                if (lv.size() != 2 && lv.size() != 3)
+                {
+                    throw new InternalExpressionException("'delete_folder' takes 2 or 3 arguments");
+                }
+                boolean recursive = lv.size() == 3 ? lv.get(2).getBoolean() : false;
+
+                FileArgument fdesc = FileArgument.from(c, lv, true, FileArgument.Reason.DELETE);
+                return BooleanValue.of(((CarpetScriptHost) c.host).removeResourceFolder(fdesc, recursive));
+        });
+
         expression.addContextFunction("write_file", -1, (c, t, lv) -> {
             if (lv.size() < 3)
             {

--- a/src/main/java/carpet/script/exception/Throwables.java
+++ b/src/main/java/carpet/script/exception/Throwables.java
@@ -31,6 +31,7 @@ public class Throwables
     public static final Throwables NBT_ERROR = register("nbt_error", IO_EXCEPTION);
     public static final Throwables JSON_ERROR = register("json_error", IO_EXCEPTION);
     public static final Throwables B64_ERROR = register("b64_error", IO_EXCEPTION);
+    public static final Throwables FOLDER_NOT_EMPTY = register("folder_not_empty", IO_EXCEPTION);
     public static final Throwables USER_DEFINED = register("user_exception", THROWN_EXCEPTION_TYPE);
 
     /**


### PR DESCRIPTION
### Description:
This PR introduces a new function `delete_folder(resource, type, recursive?)` that allows direct deletion of folders in Scarpet.

### Changes
 - Added the `delete_folder` function to directly delete folders at the specified resource path.
 - The function supports both app-specific and shared folders and can handle paths containing or ending with .zip, allowing the deletion of folders inside zip files or the entire zip files when appropriate.
 - The function includes an optional `recursive` flag that, when set to `true`, will delete the folder and its contents. If not present or set to `false`, the folder will only be deleted if it is empty, if it's not, it will throw a `folder_not_empty` exception.

### Behavior:
 - If the folder exists, it will be deleted. If `recursive` is true, all files and subfolders within the folder will be deleted first.
 - If the folder does not exist, the function will return `null`.
 - If the folder is not empty and `recursive` is not set to `true`, an `folder_not_empty` exception will be thrown.
 - If there is a filesystem error, an `io_exception` will be thrown.

### Why:
This feature significantly improves the Scarpet API by allowing scripts to directly delete folders and their contents when needed. The recursive flag adds an important layer of control, ensuring that scripts can avoid accidentally removing large amounts of data unless explicitly requested. 