### PR TITLE
Fix null skyLightSources crash

### DIFF
--- a/src/main/java/carpet/mixins/LevelChunk_movableBEMixin.java
+++ b/src/main/java/carpet/mixins/LevelChunk_movableBEMixin.java
@@ -114,7 +114,8 @@ public abstract class LevelChunk_movableBEMixin extends ChunkAccess implements W
         if (LightEngine.hasDifferentLightProperties(oldBlockState, newBlockState)) {
             ProfilerFiller profiler = Profiler.get();
             profiler.push("updateSkyLightSources");
-            skyLightSources.update(this, x, chunkY, z);
+            if (skyLightSources != null)
+                skyLightSources.update(this, x, chunkY, z);
             profiler.popPush("queueCheckLight");
             level.getChunkSource().getLightEngine().checkBlock(blockPos_1);
             profiler.pop();


### PR DESCRIPTION
https://github.com/gnembon/fabric-carpet/issues/2098

Player created a flying machine that used movableTileEntities, it crashed the server, and then anytime those chunks were loaded, the server would also crash. I traced it down to here from the error, where skyLightSources was showing up as null (despite IntelliJ saying that isn't possible).  

After applying this fix, and putting it on the server, everything functioned normally. So there must be a case where that actually can be null. 