### PR TITLE
Add easyBUD rule for quickly BUDing rail lines

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -1022,4 +1022,7 @@ public class CarpetSettings
             category = {SURVIVAL, FEATURE}
     )
     public static FungusGrowthMode thickFungusGrowth = FungusGrowthMode.FALSE;
+
+    @Rule( desc = "Allows you to BUD rail lines by right clicking them on the top with redstone dust.", category = CREATIVE )
+    public static boolean easyBUD = false;
 }

--- a/src/main/java/carpet/helpers/RailUtils.java
+++ b/src/main/java/carpet/helpers/RailUtils.java
@@ -1,0 +1,65 @@
+package carpet.helpers;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.PoweredRailBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.RailShape;
+
+public class RailUtils {
+    public static void powerRailLine(BlockPos pos, RailShape shape, boolean powerAdjacentLines, Level level) {
+        for (Direction dir : getStraightRailDirections(shape)) {
+            BlockPos checking = new BlockPos(pos);
+
+            while (true) {
+                BlockState state = level.getBlockState(checking);
+                if (!(state.getBlock() instanceof PoweredRailBlock)) {
+                    break;
+                }
+                if (state.getValue(PoweredRailBlock.POWERED) && !checking.equals(pos)) {
+                    break;
+                }
+
+                level.setBlock(checking, level.getBlockState(checking).setValue(PoweredRailBlock.POWERED, true), 2);
+                if (powerAdjacentLines) {
+                    for (BlockPos adjacentPos : adjacentRails(checking, shape, level)) {
+                        if (adjacentPos == null) continue;
+                        powerRailLine(adjacentPos,
+                                level.getBlockState(adjacentPos).getValue(PoweredRailBlock.SHAPE),
+                                true,
+                                level);
+                    }
+                }
+
+                checking = checking.relative(dir);
+            }
+        }
+    }
+
+    private static BlockPos[] adjacentRails(BlockPos pos, RailShape shape, Level level) {
+        Direction[] dirs = switch (shape) {
+            case NORTH_SOUTH -> new Direction[]{Direction.EAST, Direction.WEST};
+            case EAST_WEST -> new Direction[]{Direction.NORTH, Direction.SOUTH};
+            default -> throw new IllegalArgumentException("Invalid rail shape, rail shape must be straight");
+        };
+
+        BlockPos[] positions = new BlockPos[]{null, null};
+        for (int i = 0; i < 2; i++) {
+            BlockPos checking = pos.relative(dirs[i]);
+            if (level.getBlockState(checking).getBlock() instanceof PoweredRailBlock) {
+                positions[i] = checking;
+            }
+        }
+
+        return positions;
+    }
+
+    public static Direction[] getStraightRailDirections(RailShape shape) {
+        return switch (shape) {
+            case NORTH_SOUTH -> new Direction[]{Direction.NORTH, Direction.SOUTH};
+            case EAST_WEST -> new Direction[]{Direction.EAST, Direction.WEST};
+            default -> throw new IllegalArgumentException("Invalid rail shape, rail shape must be straight");
+        };
+    }
+}

--- a/src/main/java/carpet/mixins/BlockBehaviour_easyBUDMixin.java
+++ b/src/main/java/carpet/mixins/BlockBehaviour_easyBUDMixin.java
@@ -1,0 +1,44 @@
+package carpet.mixins;
+
+import carpet.CarpetSettings;
+import carpet.helpers.RailUtils;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.PoweredRailBlock;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(BlockBehaviour.class)
+public class BlockBehaviour_easyBUDMixin {
+    @Inject(at = @At("HEAD"), method = "useItemOn")
+    private void onUseItemOn(ItemStack itemStack,
+                             BlockState blockState,
+                             Level level,
+                             BlockPos blockPos,
+                             Player player,
+                             InteractionHand interactionHand,
+                             BlockHitResult blockHitResult,
+                             CallbackInfoReturnable<InteractionResult> cir)
+    {
+        if (CarpetSettings.easyBUD) {
+            if (blockState.getBlock() instanceof PoweredRailBlock &&
+                player.isHolding(Items.REDSTONE) &&
+                blockHitResult.getDirection().equals(Direction.UP) &&
+                player.isCreative())
+            {
+                RailUtils.powerRailLine(blockPos, blockState.getValue(PoweredRailBlock.SHAPE), true, level);
+            }
+        }
+    }
+}

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -181,7 +181,8 @@
     "DefaultRedstoneWireEvaluator_redstoneMixin",
 
     "CustomPacketPayload_networkStuffMixin",
-    "ServerGamePacketListenerimpl_connectionMixin"
+    "ServerGamePacketListenerimpl_connectionMixin",
+    "BlockBehaviour_easyBUDMixin"
 
   ],
   "client": [


### PR DESCRIPTION
This will add a carpet rule called `easyBUD` that will let creative mode players right click the top of powered rails to BUD them as well as any adjacent rail lines.

This could be useful if you need to work with BUDed rail lines a lot and resetting them manually would otherwise be tedious.