### PR TITLE
Don't make grindstones movable with `movableBlockEntities`

### DIFF
--- a/src/main/java/carpet/mixins/PistonBaseBlock_movableBEMixin.java
+++ b/src/main/java/carpet/mixins/PistonBaseBlock_movableBEMixin.java
@@ -20,7 +20,6 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.piston.PistonBaseBlock;
 import net.minecraft.world.level.block.piston.PistonStructureResolver;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.material.PushReaction;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -71,16 +70,6 @@ public abstract class PistonBaseBlock_movableBEMixin extends DirectionalBlock
         {
             return !(CarpetSettings.movableBlockEntities && isPushableBlockEntity(blockState.getBlock()));
         }
-    }
-
-    @Redirect(method = "isPushable", at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/state/BlockState;getPistonPushReaction()Lnet/minecraft/world/level/material/PushReaction;"
-    ))
-    private static PushReaction moveGrindstones(BlockState blockState)
-    {
-        if (CarpetSettings.movableBlockEntities && blockState.getBlock() == Blocks.GRINDSTONE) return PushReaction.NORMAL;
-        return blockState.getPistonPushReaction();
     }
 
     @Inject(method = "moveBlocks", at = @At(value = "INVOKE", shift = At.Shift.BEFORE,


### PR DESCRIPTION
Resolves #2085.

According to change history, this was done in 7dc1fa5f415fc31b880cdec0cfd9118a2dd2e5a8 because it's movable in bedrock, but it actually isn't (and the wiki doesn't mention it ever being).

As a PR wondering whether this is breaking and maybe we shouldn't do it at this point. To note, Carpet only changes pushing, pistons still cannot pull grindstone, which I don't know if it's a bug.