### PR TITLE
Don't save player twice when shadowing

### DIFF
--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -136,7 +136,6 @@ public class EntityPlayerMPFake extends ServerPlayer
 
     public static EntityPlayerMPFake createShadow(MinecraftServer server, ServerPlayer player)
     {
-        player.level().getServer().getPlayerList().remove(player);
         player.connection.disconnect(Component.translatable("multiplayer.disconnect.duplicate_login"));
         ServerLevel worldIn = player.level();//.getWorld(player.dimension);
         GameProfile gameprofile = player.getGameProfile();


### PR DESCRIPTION
Resolves #2130.

`connection.disconnect()` calls `getPlayerList().remove()`, which saves the player.

Saving has side effects, such as removing enderpearls, which can make the second save store invalid data, or at the very least cause warnings.

Pending some further testing.