### PR TITLE
fix: pink carpets again for various edge case Jockey Spawning; fix Aquatic Mob condtions on sea floor

### DIFF
--- a/src/main/java/carpet/utils/SpawnReporter.java
+++ b/src/main/java/carpet/utils/SpawnReporter.java
@@ -38,8 +38,6 @@ import net.minecraft.world.level.entity.EntityTypeTest;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.level.levelgen.structure.structures.NetherFortressStructure;
-import net.minecraft.world.level.material.FluidState;
-import net.minecraft.world.level.material.Fluids;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;


### PR DESCRIPTION
This is an adjustment to my previous PR to cover all cases of Jockey spawning via `killEntity()` due to changes with the Camel Husk and Warm Chickens.
Also; this fix adds an `pos.above()` offset for when placing pink carpets on the ocean floor not being able to return a spawn condition for Aquatic mobs.  It's simply a QOL fix for end users since they cannot place carpets in mid-water.