### PR TITLE
endPortalItemVelocityRotationFix

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -971,6 +971,13 @@ public class CarpetSettings
     public static boolean lightningKillsDropsFix = false;
 
     @Rule(
+            desc = "Makes the velocity of items going through end portals preserved.",
+            extra = "As of 1.21, the item entity velocity is rotated based on the yaw, which is random.",
+            category = {BUGFIX, FEATURE}
+    )
+    public static boolean endPortalItemVelocityRotationFix = false;
+
+    @Rule(
             desc = "Placing an activator rail on top of a barrier block will fill the neighbor updater stack when the rail turns off.",
             extra = {"The integer entered is the amount of updates that should be left in the stack", "-1 turns it off"},
             category = CREATIVE,

--- a/src/main/java/carpet/mixins/EndPortalBlockMixin_itemRotation.java
+++ b/src/main/java/carpet/mixins/EndPortalBlockMixin_itemRotation.java
@@ -1,0 +1,55 @@
+package carpet.mixins;
+
+import carpet.CarpetSettings;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.Relative;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.level.block.EndPortalBlock;
+import net.minecraft.world.level.portal.TeleportTransition;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+@Mixin(EndPortalBlock.class)
+public class EndPortalBlockMixin_itemRotation {
+
+
+    @Inject(
+            method = "getPortalDestination(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/portal/TeleportTransition;",
+            at = @At("RETURN"),
+            cancellable = true
+    )
+    private void carpetDebug$fixItemRotateDelta(ServerLevel world, Entity entity, BlockPos pos, CallbackInfoReturnable<TeleportTransition> cir) {
+        System.out.println("Hello; ");
+        System.out.println(entity);
+
+        if (CarpetSettings.endPortalItemVelocityRotationFix && entity instanceof ItemEntity) {
+            TeleportTransition original = cir.getReturnValue();
+            if (original != null) {
+                // Make a mutable set (immutable -> mutable); EnumSet is ideal for enum flags.
+                Set<Relative> flags = original.relatives();
+                Set<Relative> mutable = flags.isEmpty() ? EnumSet.noneOf(Relative.class) : EnumSet.copyOf(flags);
+
+                // Remove the flag safely
+                mutable.remove(Relative.ROTATE_DELTA);
+
+                TeleportTransition patched = new TeleportTransition(
+                        original.newLevel(),
+                        original.position(),
+                        original.deltaMovement(),
+                        original.yRot(),
+                        original.xRot(),
+                        mutable,
+                        original.postTeleportTransition()
+                );
+                cir.setReturnValue(patched);
+            }
+        }
+    }
+}

--- a/src/main/resources/assets/carpet/lang/en_us.json
+++ b/src/main/resources/assets/carpet/lang/en_us.json
@@ -32,5 +32,4 @@
   "carpet.settings.command.default_set": "Rule %s will now default to %s",
   "carpet.settings.command.default_removed": "Rule %s will no longer be set on restart",
   "carpet.settings.command.current_value": "current value"
-
 }

--- a/src/main/resources/carpet.mixins.json
+++ b/src/main/resources/carpet.mixins.json
@@ -181,7 +181,9 @@
     "DefaultRedstoneWireEvaluator_redstoneMixin",
 
     "CustomPacketPayload_networkStuffMixin",
-    "ServerGamePacketListenerimpl_connectionMixin"
+    "ServerGamePacketListenerimpl_connectionMixin",
+
+    "EndPortalBlockMixin_itemRotation"
 
   ],
   "client": [


### PR DESCRIPTION
This is feature for fixing the rotation of the velocity of items thrown though an end portal.
In MC versions  < 1.21, items thrown through an end portal preserved their momentum. This changes in 1.21.

In the SMP I am hosting, we are relying on precise throws though the portal for sorting. I couldn't find any other fixes for this, so I implemented a fix on my own.

The fix I wrote for 1.21.4 is mostly the same, except some of the names has changed.