### PR TITLE
fix: drowned spawns not spawning in Ocean biomes (fixes #2147)

### DIFF
--- a/src/main/java/carpet/mixins/NaturalSpawnerMixin.java
+++ b/src/main/java/carpet/mixins/NaturalSpawnerMixin.java
@@ -4,6 +4,8 @@ import carpet.CarpetSettings;
 import carpet.fakes.LevelInterface;
 import carpet.utils.SpawnReporter;
 import net.minecraft.world.entity.EntitySpawnReason;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import org.apache.commons.lang3.tuple.Pair;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -46,12 +48,12 @@ public class NaturalSpawnerMixin
 
     @Shadow @Final private static MobCategory[] SPAWNING_CATEGORIES;
 
-    @Redirect(method = "isValidSpawnPostitionForType",
-            at = @At(
+    @WrapOperation(method = "isValidSpawnPostitionForType",
+                   at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/server/level/ServerLevel;noCollision(Lnet/minecraft/world/phys/AABB;)Z"
     ))
-    private static boolean doesNotCollide(ServerLevel world, AABB bb)
+    private static boolean doesNotCollide(ServerLevel world, AABB bb, Operation<Boolean> original)
     {
         //.doesNotCollide is VERY expensive. On the other side - most worlds are not made of trapdoors in
         // various configurations, but solid and 'passable' blocks, like air, water grass, etc.
@@ -59,7 +61,7 @@ public class NaturalSpawnerMixin
         // in case something more complex happens - we default to full block collision check
         if (!CarpetSettings.lagFreeSpawning)
         {
-            return world.noCollision(bb);
+            return original.call(world, bb);
         }
         int minX = Mth.floor(bb.minX);
         int minY = Mth.floor(bb.minY);


### PR DESCRIPTION
fixes Issue #2147.

Replaced Mixin with `@WrapOperation`.  I recommend making much deeper usage of this type of Mixin, especially with the lag free spawning Mixin.  I also tested with and without `lagFreeSpawning` enabled.

`@WrapOperation` / `@WrapMethod`, etc can generally be used with `original.call()` as the default, to effectively replace any usage of `@Redirect`, basically; especially when using Redirect potentially causes problems.

Proof of functionality:

<img width="2314" height="1176" alt="2026-04-02_16 24 41" src="https://github.com/user-attachments/assets/e306bb59-b5ca-4f92-80c9-78a5e6364372" />

<img width="1184" height="1337" alt="Jockey-fix" src="https://github.com/user-attachments/assets/1bd585b4-6d76-4cd9-9b14-14d3831f7780" />
