### PR TITLE
Fix shadowed player data not saved

### DIFF
--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -4,6 +4,7 @@ import carpet.CarpetSettings;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.UUIDUtil;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.DisconnectionDetails;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.contents.TranslatableContents;
@@ -35,6 +36,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.portal.TeleportTransition;
 import net.minecraft.world.level.storage.TagValueInput;
+import net.minecraft.world.level.storage.TagValueOutput;
 import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.phys.Vec3;
 import carpet.fakes.ServerPlayerInterface;
@@ -135,15 +137,47 @@ public class EntityPlayerMPFake extends ServerPlayer
         }
     }
 
+    /**
+     * Loads player data from a CompoundTag.
+     * Useful if persisted playerdata is not up-to-date.
+     * @author TeRacksito
+     */
+    private static void loadPlayerData(EntityPlayerMPFake player, CompoundTag nbt)
+    {
+        try (ProblemReporter.ScopedCollector scopedCollector = new ProblemReporter.ScopedCollector(player.problemPath(), CarpetSettings.LOG))
+        {
+            ValueInput input = TagValueInput.create(scopedCollector, player.registryAccess(), nbt);
+
+            player.load(input);
+            player.loadAndSpawnEnderPearls(input);
+            player.loadAndSpawnParentVehicle(input);
+        }
+    }
+
+    /**
+     * Saves the current in-memory player to a CompoundTag.
+     * Useful if this data won't be accesible in the near future. (e.g. for creating a shadow player)
+     * @author TeRacksito
+     */
+    private static CompoundTag savePlayerToNbt(ServerPlayer player) {
+        try (ProblemReporter.ScopedCollector scopedCollector = new ProblemReporter.ScopedCollector(player.problemPath(), carpet.CarpetSettings.LOG)) {
+            TagValueOutput output = TagValueOutput.createWithContext(scopedCollector, player.registryAccess());
+            player.saveWithoutId(output);
+            return output.buildResult();
+        }
+    }
+
     public static EntityPlayerMPFake createShadow(MinecraftServer server, ServerPlayer player)
     {
+        CompoundTag nbtData = savePlayerToNbt(player);
+
         player.connection.disconnect(Component.translatable("multiplayer.disconnect.duplicate_login"));
         ServerLevel worldIn = player.level();//.getWorld(player.dimension);
         GameProfile gameprofile = player.getGameProfile();
         EntityPlayerMPFake playerShadow = new EntityPlayerMPFake(server, worldIn, gameprofile, player.clientInformation(), true);
         playerShadow.setChatSession(player.getChatSession());
         server.getPlayerList().placeNewPlayer(new FakeClientConnection(PacketFlow.SERVERBOUND), playerShadow, new CommonListenerCookie(gameprofile, 0, player.clientInformation(), true));
-        loadPlayerData(playerShadow);
+        loadPlayerData(playerShadow, nbtData);
 
         playerShadow.setHealth(player.getHealth());
         playerShadow.connection.teleport(player.getX(), player.getY(), player.getZ(), player.getYRot(), player.getXRot());


### PR DESCRIPTION
This pr attempts to solve ["/player shadow" can be used to duplicate items or lose items issue](https://github.com/gnembon/fabric-carpet/issues/2166).

Apparently, this bug was introduced by [this commit](https://github.com/gnembon/fabric-carpet/commit/f2b7aaf28cfbfcd5c75c21b56c3b2cb96073cf06#diff-b7ee49570c62c9c8d735164413f5edfa283b5cf8af26ab0fc307f5a9ef59516aR141):
https://github.com/gnembon/fabric-carpet/blob/f2b7aaf28cfbfcd5c75c21b56c3b2cb96073cf06/src/main/java/carpet/patches/EntityPlayerMPFake.java#L140-L142

The problem is that `loadPlayerData` literally loads from persisted data.
https://github.com/gnembon/fabric-carpet/blob/6e332f9c0bf30454d1ac70a1faa36c6caaa48222/src/main/java/carpet/patches/EntityPlayerMPFake.java#L125-L136

But it seems that the `player.connection.disconnect` method doesn't save playerdata in time, so the shadowed player ends up with outdated data.

To solve this, I've implemented a method to save playerdata to a `CompoundTag`, then we load the player from this data (which is the most recent). 

Initially, I intended to solve this by just calling `playerShadow.restoreFrom(player, true);`, a Minecraft's native method. But this doesn't take into account ender pearls and parent vehicles, as Carpet's solution does. That is why I still trust this last approach.

Note that I intentionally overloaded `loadPlayerData` method to avoid the need of reviewing changes at, for example, `createFake` method.

Thanks to @SebaDelGitHub for spotting the bug in [TLS Unbound private server](https://tls-unbound.es), and for spotting some good initial thoughts.