### PR TITLE
Register Carpet payload with Fabric API when available

### DIFF
--- a/src/main/java/carpet/CarpetServer.java
+++ b/src/main/java/carpet/CarpetServer.java
@@ -18,6 +18,7 @@ import carpet.commands.ProfileCommand;
 import carpet.script.ScriptCommand;
 import carpet.commands.SpawnCommand;
 import carpet.commands.TestCommand;
+import carpet.network.CarpetClient;
 import carpet.network.ServerNetworkHandler;
 import carpet.helpers.HopperCounter;
 import carpet.logging.LoggerRegistry;
@@ -75,6 +76,7 @@ public class CarpetServer // static for now - easier to handle all around the co
     {
         settingsManager = new carpet.settings.SettingsManager(CarpetSettings.carpetVersion, "carpet", "Carpet Mod");
         settingsManager.parseSettingsClass(CarpetSettings.class);
+        CarpetClient.registerPayloads();
         extensions.forEach(CarpetExtension::onGameStarted);
         //FabricAPIHooks.initialize();
         CarpetScriptServer.parseFunctionClasses();
@@ -227,4 +229,3 @@ public class CarpetServer // static for now - easier to handle all around the co
         extensions.forEach(e -> e.onReload(server));
     }
 }
-

--- a/src/main/java/carpet/network/CarpetClient.java
+++ b/src/main/java/carpet/network/CarpetClient.java
@@ -3,6 +3,10 @@ package carpet.network;
 import carpet.CarpetServer;
 import carpet.CarpetSettings;
 import carpet.script.utils.ShapesRenderer;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -15,6 +19,64 @@ import net.minecraft.resources.Identifier;
 
 public class CarpetClient
 {
+    private static boolean fabricApiPayloadsRegistered = false;
+
+    public static void registerPayloads()
+    {
+        if (fabricApiPayloadsRegistered)
+        {
+            return;
+        }
+        try
+        {
+            // Fabric API checks its dynamic registry before vanilla's fallback codec.
+            Class<?> registryClass = Class.forName("net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry");
+            registerWithFabricApi(invokePayloadRegistryFactory(registryClass, "clientboundPlay", "playS2C"));
+            registerWithFabricApi(invokePayloadRegistryFactory(registryClass, "serverboundPlay", "playC2S"));
+            fabricApiPayloadsRegistered = true;
+        }
+        catch (ClassNotFoundException ignored)
+        {
+            fabricApiPayloadsRegistered = true;
+        }
+        catch (ReflectiveOperationException | LinkageError exception)
+        {
+            CarpetSettings.LOG.warn("Failed to register Carpet custom payload with Fabric API", exception);
+        }
+    }
+
+    private static Object invokePayloadRegistryFactory(Class<?> registryClass, String... methodNames) throws ReflectiveOperationException
+    {
+        for (String methodName : methodNames)
+        {
+            try
+            {
+                return registryClass.getMethod(methodName).invoke(null);
+            }
+            catch (NoSuchMethodException ignored)
+            {
+            }
+        }
+        throw new NoSuchMethodException(String.join("/", methodNames));
+    }
+
+    private static void registerWithFabricApi(Object registry) throws ReflectiveOperationException
+    {
+        Method registerMethod = registry.getClass().getMethod("register", CustomPacketPayload.Type.class, StreamCodec.class);
+        try
+        {
+            registerMethod.invoke(registry, CarpetPayload.TYPE, CarpetPayload.STREAM_CODEC);
+        }
+        catch (InvocationTargetException exception)
+        {
+            if (exception.getCause() instanceof IllegalArgumentException cause && cause.getMessage() != null && cause.getMessage().contains("already registered"))
+            {
+                return;
+            }
+            throw exception;
+        }
+    }
+
     public record CarpetPayload(CompoundTag data) implements CustomPacketPayload
     {
         public static final StreamCodec<FriendlyByteBuf, CarpetPayload> STREAM_CODEC = CustomPacketPayload.codec(CarpetPayload::write, CarpetPayload::new);


### PR DESCRIPTION
## Summary
- register the `carpet:hello` payload with Fabric API's play payload registries when Fabric API is present
- keep Fabric API optional by using reflection and retaining the existing vanilla codec-list injection fallback
- support both current `clientboundPlay`/`serverboundPlay` and older `playS2C`/`playC2S` registry method names

Fixes #2016.

## Testing
- `git diff --check`
- `./gradlew build` could not run locally: no Java runtime is installed on this machine