### PR TITLE
Update mixin targets renamed by Mojang in 26.2-snap-5

### DIFF
--- a/src/main/java/carpet/mixins/ChunkAccess_warningsMixin.java
+++ b/src/main/java/carpet/mixins/ChunkAccess_warningsMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class ChunkAccess_warningsMixin
 {
     // failed to mixin into interface. need to mixin in two places that uses it
-    @Inject(method = "markPosForPostprocessing(Lnet/minecraft/core/BlockPos;)V",
+    @Inject(method = "markPosForPostProcessing(Lnet/minecraft/core/BlockPos;)V",
         at =@At("HEAD"), cancellable = true)
     private void squashWarnings(BlockPos blockPos_1, CallbackInfo ci)
     {

--- a/src/main/java/carpet/mixins/WorldGenRegion_scarpetPlopMixin.java
+++ b/src/main/java/carpet/mixins/WorldGenRegion_scarpetPlopMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(WorldGenRegion.class)
 public class WorldGenRegion_scarpetPlopMixin
 {
-    @Inject(method = "markPosForPostprocessing", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "markPosForPostProcessing", at = @At("HEAD"), cancellable = true)
     private void markOrNot(BlockPos blockPos, CallbackInfo ci)
     {
         if (CarpetSettings.skipGenerationChecks.get()) ci.cancel();


### PR DESCRIPTION
Fixes #2187
