### PR TITLE
Register Carpet payload with Fabric API

### DIFF
--- a/src/main/java/carpet/CarpetServer.java
+++ b/src/main/java/carpet/CarpetServer.java
@@ -18,6 +18,7 @@ import carpet.commands.ProfileCommand;
 import carpet.script.ScriptCommand;
 import carpet.commands.SpawnCommand;
 import carpet.commands.TestCommand;
+import carpet.network.CarpetClient;
 import carpet.network.ServerNetworkHandler;
 import carpet.helpers.HopperCounter;
 import carpet.logging.LoggerRegistry;
@@ -73,6 +74,7 @@ public class CarpetServer // static for now - easier to handle all around the co
     // to register before this call in a ModInitializer (declared in fabric.mod.json)
     public static void onGameStarted()
     {
+        CarpetClient.registerPayloadType();
         settingsManager = new carpet.settings.SettingsManager(CarpetSettings.carpetVersion, "carpet", "Carpet Mod");
         settingsManager.parseSettingsClass(CarpetSettings.class);
         extensions.forEach(CarpetExtension::onGameStarted);

--- a/src/main/java/carpet/mixins/CustomPacketPayload_networkStuffMixin.java
+++ b/src/main/java/carpet/mixins/CustomPacketPayload_networkStuffMixin.java
@@ -21,7 +21,7 @@ public interface CustomPacketPayload_networkStuffMixin
         // this is stupid hack to make sure carpet payloads are always registered
         // that might collide with other mods that do the same thing
         // so we may need to adjust this in the future
-        if (!(list instanceof CarpetTaintedList))
+        if (!(list instanceof CarpetTaintedList) && list.stream().noneMatch(typeAndCodec -> typeAndCodec.type().equals(CarpetClient.CarpetPayload.TYPE)))
         {
             List<CustomPacketPayload.TypeAndCodec<? super B, ?>> extendedList = new CarpetTaintedList<>(list);
             extendedList.add(new CustomPacketPayload.TypeAndCodec<>(CarpetClient.CarpetPayload.TYPE, CarpetClient.CarpetPayload.STREAM_CODEC));

--- a/src/main/java/carpet/network/CarpetClient.java
+++ b/src/main/java/carpet/network/CarpetClient.java
@@ -13,6 +13,9 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 public class CarpetClient
 {
     public record CarpetPayload(CompoundTag data) implements CustomPacketPayload
@@ -44,8 +47,45 @@ public class CarpetClient
 
     private static LocalPlayer clientPlayer = null;
     private static boolean isServerCarpet = false;
+    private static boolean payloadRegistered = false;
     public static String serverCarpetVersion;
     public static final ResourceLocation CARPET_CHANNEL = ResourceLocation.fromNamespaceAndPath("carpet", "hello");
+
+    public static void registerPayloadType()
+    {
+        if (payloadRegistered) return;
+        try
+        {
+            Class<?> payloadTypeRegistry = Class.forName("net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry");
+            registerPayloadType(payloadTypeRegistry, "playS2C");
+            registerPayloadType(payloadTypeRegistry, "playC2S");
+            payloadRegistered = true;
+        }
+        catch (ClassNotFoundException ignored)
+        {
+            // Fabric API is optional. The CustomPacketPayload mixin still handles vanilla registration.
+        }
+        catch (ReflectiveOperationException | RuntimeException e)
+        {
+            CarpetSettings.LOG.warn("Failed to register Carpet custom payload type with Fabric API", e);
+        }
+    }
+
+    private static void registerPayloadType(Class<?> payloadTypeRegistry, String registryGetter) throws ReflectiveOperationException
+    {
+        Object registry = payloadTypeRegistry.getMethod(registryGetter).invoke(null);
+        Method register = payloadTypeRegistry.getMethod("register", CustomPacketPayload.Type.class, StreamCodec.class);
+        try
+        {
+            register.invoke(registry, CarpetPayload.TYPE, CarpetPayload.STREAM_CODEC);
+        }
+        catch (InvocationTargetException e)
+        {
+            Throwable cause = e.getCause();
+            if (cause instanceof IllegalArgumentException && cause.getMessage() != null && cause.getMessage().contains("already registered")) return;
+            throw e;
+        }
+    }
 
     public static void gameJoined(LocalPlayer player)
     {


### PR DESCRIPTION
Fixes #2016
Related: #2005, #1922

## Summary
- register Carpet's `carpet:hello` custom payload with Fabric API's play S2C and C2S payload registries when Fabric API is present
- keep the existing vanilla `CustomPacketPayload` mixin fallback for installs without Fabric API
- avoid adding a duplicate `carpet:hello` codec in the mixin when the payload type is already present in the codec list

## Verification
- `git diff --check`
- `JAVA_HOME="C:\Program Files\Microsoft\jdk-21.0.9.10-hotspot" ./gradlew.bat build`

## Bounty payout
PayPal: https://paypal.me/Jeremytsangchina
USDT TRC20 fallback: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`