### PR TITLE
Fix piercing weapon attacks for controlled players

### DIFF
--- a/src/main/java/carpet/helpers/EntityPlayerActionPack.java
+++ b/src/main/java/carpet/helpers/EntityPlayerActionPack.java
@@ -11,6 +11,7 @@ import carpet.script.utils.Tracer;
 import net.minecraft.commands.arguments.EntityAnchorArgument;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.protocol.game.ClientboundSetHeldSlotPacket;
 import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
 import net.minecraft.server.level.ServerLevel;
@@ -19,12 +20,14 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.animal.equine.AbstractHorse;
 import net.minecraft.world.entity.decoration.ItemFrame;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.vehicle.boat.Boat;
 import net.minecraft.world.entity.vehicle.minecart.Minecart;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.PiercingWeapon;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
@@ -369,6 +372,18 @@ public class EntityPlayerActionPack
         ATTACK(true) {
             @Override
             boolean execute(ServerPlayer player, Action action) {
+                ItemStack stack = player.getMainHandItem();
+                PiercingWeapon piercingWeapon = stack.get(DataComponents.PIERCING_WEAPON);
+                if (piercingWeapon != null)
+                {
+                    if (action.isContinuous) return true;
+                    if (!stack.isItemEnabled(player.level().enabledFeatures()) || player.cannotAttackWithItem(stack, 0)) return false;
+
+                    player.resetLastActionTime();
+                    piercingWeapon.attack(player, EquipmentSlot.MAINHAND);
+                    return true;
+                }
+
                 HitResult hit = getTarget(player);
                 switch (hit.getType()) {
                     case ENTITY: {


### PR DESCRIPTION
## Summary

- route Carpet-controlled attacks for `PIERCING_WEAPON` items through the
  vanilla `PiercingWeapon.attack()` behavior before the ordinary crosshair ray
  trace
- preserve the client-side feature and zero-latency attack-charge checks
- keep `attack continuous` from repeating Jab or falling through to block
  breaking

Fixes #2150.
Fixes #2163.

## Why

Vanilla checks for a piercing weapon before switching on the crosshair hit
result. The server then delegates STAB to `PiercingWeapon.attack()`, which owns
the collider-clipped ray, multiple targets, knockback, dismounting, durability,
sounds, and swing behavior.

Carpet currently resolves one target first and calls `player.attack(entity)`,
so only the nearest target is attacked and thin blocks can change the selected
target. Calling the vanilla component directly keeps those semantics in one
place and avoids the client-loaded acknowledgement required by a synthetic
packet on a fake connection.

This change only addresses spear Jab. Charge movement data remains separate
from this path and from #2176.

## Validation

- `./gradlew clean build` on the current master branch: passed
- equivalent Minecraft 1.21.11 / Carpet 1.4.194 dedicated-server smoke:
  - baseline Carpet, two aligned Creepers: `12.0 / 20.0` health
  - fixed piercing attack: `16.0 / 16.0`
  - pressure plate in the path: `16.0 / 16.0`
  - full stone collider in the path: `20.0 / 20.0`
  - `attack continuous`: `20.0 / 20.0`
  - Diamond Sword regression: `13.0 / 20.0`
  - Diamond Pickaxe continuous block breaking: passed
