### PR TITLE
Use optimzedTNT explosionNoBlockDamage fast path for non optimizedTNT explosions

### DIFF
--- a/src/main/java/carpet/helpers/OptimizedExplosion.java
+++ b/src/main/java/carpet/helpers/OptimizedExplosion.java
@@ -35,7 +35,7 @@ public class OptimizedExplosion
 
         List<BlockPos> toBlow;
 
-        if (!CarpetSettings.explosionNoBlockDamage && eAccess.getDamageSource() != null) {
+        if (eAccess.getDamageSource() != null) {
             rayCalcDone = false;
             firstRay = true;
             getAffectedPositionsOnPlaneY(e,  0,  0, 15,  0, 15); // bottom

--- a/src/main/java/carpet/mixins/Explosion_optimizedTntMixin.java
+++ b/src/main/java/carpet/mixins/Explosion_optimizedTntMixin.java
@@ -29,6 +29,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -45,9 +46,18 @@ public abstract class Explosion_optimizedTntMixin
             cancellable = true)
     private void calculateExplodedPositionsCM(final CallbackInfoReturnable<List<BlockPos>> cir)
     {
-        if (CarpetSettings.optimizedTNT && !level.isClientSide() && !(getIndirectSourceEntity() instanceof Breeze))
+        if (!level.isClientSide())
         {
-            cir.setReturnValue(OptimizedExplosion.doExplosionA((Explosion) (Object) this, eLogger));
+            // Move explosionNoBlockDamage out so non carpet optimizedTNT code also takes the fast path when block damage is off.
+            if (CarpetSettings.explosionNoBlockDamage)
+            {
+                cir.setReturnValue(Collections.emptyList());
+            }
+
+            if (CarpetSettings.optimizedTNT && !(getIndirectSourceEntity() instanceof Breeze))
+            {
+                cir.setReturnValue(OptimizedExplosion.doExplosionA((Explosion) (Object) this, eLogger));
+            }
         }
     }
 


### PR DESCRIPTION
Use explosion no block damage fast path - return empty list - for non optimizedTNT code (e.g. vanilla / Lithium).
This noticeably reduces lag while testing.