### PR TITLE
fixed horse-feeding offhand fallback, solving #2219

### DIFF
--- a/src/main/java/carpet/helpers/EntityPlayerActionPack.java
+++ b/src/main/java/carpet/helpers/EntityPlayerActionPack.java
@@ -20,6 +20,7 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.animal.equine.AbstractHorse;
+import net.minecraft.world.entity.animal.equine.SkeletonHorse;
 import net.minecraft.world.entity.decoration.ItemFrame;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.vehicle.boat.Boat;
@@ -331,8 +332,14 @@ public class EntityPlayerActionPack
                             player.resetLastActionTime();
                             EntityHitResult entityHit = (EntityHitResult) hit;
                             Entity entity = entityHit.getEntity();
-                            boolean handWasEmpty = player.getItemInHand(hand).isEmpty();
+                            ItemStack handItem = player.getItemInHand(hand);
+                            boolean handWasEmpty = handItem.isEmpty();
                             boolean itemFrameEmpty = (entity instanceof ItemFrame) && ((ItemFrame) entity).getItem().isEmpty();
+                            // client always consumes action with food on a horse, unless it's a skeleton horse.
+                            boolean isFeedingHorse = entity instanceof AbstractHorse horse
+                                    && horse.isAlive()
+                                    && horse.isFood(handItem)
+                                    && !(horse instanceof SkeletonHorse);
                             Vec3 relativeHitPos = entityHit.getLocation().subtract(entity.getX(), entity.getY(), entity.getZ());
                             if (entity.interact(player,  hand, relativeHitPos).consumesAction())
                             {
@@ -340,7 +347,9 @@ public class EntityPlayerActionPack
                                 return true;
                             }
                             // fix for SS itemframe always returns CONSUME even if no action is performed
-                            if (player.interactOn(entity, hand, relativeHitPos).consumesAction() && !(handWasEmpty && itemFrameEmpty))
+                            InteractionResult interactionResult = player.interactOn(entity, hand, relativeHitPos);
+                            if ((interactionResult.consumesAction() && !(handWasEmpty && itemFrameEmpty))
+                                    || isFeedingHorse)
                             {
                                 ap.itemUseCooldown = 3;
                                 return true;


### PR DESCRIPTION
Updates Carpet bot hand iteration for equine-feeding interactions to match vanilla. When valid food is used on an `AbstractHorse`, vanilla consumes the interaction regardless of whether it alters horse state. Carpet previously continued to the offhand when the server interaction returned `PASS`. This could cause mounting of full-health full-temper horses for Carpet bots with food in their main hand and an empty offhand.

This change applies to all `AbstractHorse` subclasses _besides_ Skeleton Horses, as they use a different interaction path. Made with feedback from @altrisi - thanks! 

Fixes #2219. 